### PR TITLE
synology-ss: add motion detected webhook

### DIFF
--- a/plugins/synology-ss/package-lock.json
+++ b/plugins/synology-ss/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/synology-ss",
-   "version": "0.0.2",
+   "version": "0.0.3",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/synology-ss",
-         "version": "0.0.2",
+         "version": "0.0.3",
          "license": "Apache",
          "dependencies": {
             "axios": "^0.24.0"
@@ -17,8 +17,7 @@
          }
       },
       "../../sdk": {
-         "name": "@scrypted/sdk",
-         "version": "0.0.93",
+         "version": "0.0.121",
          "dev": true,
          "license": "ISC",
          "dependencies": {
@@ -38,7 +37,10 @@
             "ncp": "^2.0.0",
             "raw-loader": "^4.0.2",
             "rimraf": "^3.0.2",
+            "stringify-object": "^3.3.0",
+            "tmp": "^0.2.1",
             "ts-loader": "^9.2.6",
+            "typedoc": "^0.22.8",
             "typescript-json-schema": "^0.50.1",
             "webpack": "^5.59.0"
          },
@@ -49,6 +51,10 @@
             "scrypted-package-json": "bin/scrypted-package-json.js",
             "scrypted-readme": "bin/scrypted-readme.js",
             "scrypted-webpack": "bin/scrypted-webpack.js"
+         },
+         "devDependencies": {
+            "@types/stringify-object": "^4.0.0",
+            "ts-node": "^10.4.0"
          }
       },
       "node_modules/@scrypted/sdk": {
@@ -56,9 +62,9 @@
          "link": true
       },
       "node_modules/@types/node": {
-         "version": "16.11.6",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-         "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
+         "version": "16.11.7",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
+         "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
          "dev": true
       },
       "node_modules/axios": {
@@ -101,6 +107,7 @@
             "@babel/plugin-transform-typescript": "^7.15.8",
             "@babel/preset-typescript": "^7.15.0",
             "@types/node": "^16.11.1",
+            "@types/stringify-object": "^4.0.0",
             "adm-zip": "^0.4.13",
             "axios": "^0.21.4",
             "babel-loader": "^8.2.3",
@@ -109,15 +116,19 @@
             "ncp": "^2.0.0",
             "raw-loader": "^4.0.2",
             "rimraf": "^3.0.2",
+            "stringify-object": "^3.3.0",
+            "tmp": "^0.2.1",
             "ts-loader": "^9.2.6",
+            "ts-node": "^10.4.0",
+            "typedoc": "^0.22.8",
             "typescript-json-schema": "^0.50.1",
             "webpack": "^5.59.0"
          }
       },
       "@types/node": {
-         "version": "16.11.6",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-         "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
+         "version": "16.11.7",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
+         "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
          "dev": true
       },
       "axios": {

--- a/plugins/synology-ss/package.json
+++ b/plugins/synology-ss/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/synology-ss",
-   "version": "0.0.2",
+   "version": "0.0.3",
    "description": "A Synology Surveillance Station plugin for Scrypted",
    "author": "Scrypted",
    "license": "Apache",


### PR DESCRIPTION
Eventually plan to automatically set up alerts in Surveillance Station using their API, but in the meantime this makes it possible by manually setting up alerts. Been testing it myself over the past week and works pretty well. Figuring out how three separate motion timeouts (Scrypted, Surveillance Station and on camera) interact is a bit hair-pulling though -- still unsure how best to coordinate them, or if it even matters.