### PR TITLE
github action: publish to ghcr and dockerhub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,17 +22,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         
-      - name: Log in to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
-#       - name: Extract metadata (tags, labels) for Docker
-#         id: meta
-#         uses: docker/metadata-action@v3
-#         with:
-#           images: koush/scrypted
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
@@ -41,6 +42,6 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64,linux/armhf
           push: true
-          tags: koush/scrypted:latest
-          # tags: ${{ steps.meta.outputs.tags }}
-          # labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            koush/scrypted:latest
+            ghcr.io/koush/scrypted:latest


### PR DESCRIPTION
This change causes the Github docker workflow to publish the image to both Dockerhub and [Github Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).

Why? Dockerhub rate limits downloads unless you pay them and authenticate with Dockerhub.  This can be problematic for people with larger setups that don't want to pay up to Dockerhub, like myself.

I suspect this will "just work".  I don't recall having to setup any permissions magic on my repositories that I've done this with.  I believe you get a `secrets.GITHUB_TOKEN` secret for free that has scoped access to this repo.

