### PR TITLE
Adding support for Dahua doorbells

### DIFF
--- a/plugins/amcrest/src/amcrest-api.ts
+++ b/plugins/amcrest/src/amcrest-api.ts
@@ -14,6 +14,9 @@ export enum AmcrestEvent {
     AlarmIPCStop = "Code=AlarmIPC;action=Stop",
     PhoneCallDetectStart = "Code=PhoneCallDetect;action=Start",
     PhoneCallDetectStop = "Code=PhoneCallDetect;action=Stop",
+    DahuaTalkInvite = "Code=CallNoAnswered;action=Start",
+    DahuaTalkHangup = "Code=PassiveHungup;action=Start",
+    DahuaTalkPulse = "Code=_CallNoAnswer_;action=Pulse",
 }
 
 export const amcrestHttpsAgent = new https.Agent({

--- a/plugins/amcrest/src/main.ts
+++ b/plugins/amcrest/src/main.ts
@@ -106,6 +106,13 @@ class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration,
                 description: "Enable if this device is an Amcrest Doorbell.",
                 key: "amcrestDoorbell",
                 value: (!!this.providedInterfaces?.includes(ScryptedInterface.BinarySensor)).toString(),
+            },
+	    {
+	        title: 'Dahua Doorbell',
+	        type: 'boolean',
+	        description: "Enable if this device is an Dahua Doorbell.",
+	        key: "dahuaDoorbell",
+	        value: this.storage.getItem('dahuaDoorbell'),
             }
         ];
     }

--- a/plugins/amcrest/src/main.ts
+++ b/plugins/amcrest/src/main.ts
@@ -87,12 +87,12 @@ class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration,
                         || event === AmcrestEvent.AlarmIPCStop || event === AmcrestEvent.DahuaTalkHangup) {
                         this.binaryState = false;
                     }
-                    else if (event === AmcrestEvent.TalkPulse && dahuaDoorbell == false) {
+                    else if (event === AmcrestEvent.TalkPulse && dahuaDoorbell !== 'true') {
                         clearTimeout(pulseTimeout);
                         pulseTimeout = setTimeout(() => this.binaryState = false, 30000);
                         this.binaryState = true;
                     }
-		    else if (event === AmcrestEvent.DahuaTalkPulse && dahuaDoorbell == true) {
+		    else if (event === AmcrestEvent.DahuaTalkPulse && dahuaDoorbell === 'true') {
                         clearTimeout(pulseTimeout);
                         pulseTimeout = setTimeout(() => this.binaryState = false, 3000);
                         this.binaryState = true;
@@ -201,7 +201,7 @@ class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration,
             const url = `http://${this.getHttpAddress()}/cgi-bin/audio.cgi?action=postAudio&httptype=singlepart&channel=${channel}`;
             this.console.log('posting audio data to', url);
 		
-            if (dahuaDoorbell == true) {
+            if (dahuaDoorbell === 'true') {
 		    const passthrough = new PassThrough();
 		    this.getClient().digestAuth.request({
 			method: 'POST',

--- a/plugins/amcrest/src/main.ts
+++ b/plugins/amcrest/src/main.ts
@@ -7,6 +7,7 @@ import child_process, { ChildProcess } from 'child_process';
 import { ffmpegLogInitialOutput } from '../../../common/src/media-helpers';
 import net from 'net';
 import { listenZero } from "../../../common/src/listen-cluster";
+import { readLength } from "../../../common/src/read-length";
 
 const { mediaManager } = sdk;
 


### PR DESCRIPTION
There are two areas where Dahua doorbells (at least the model that I have tested, VTO2202F-P-S2) behave differently:

1. Event codes are used differently. More specifically, AmcrestEvent.TalkPulse should be ignored for Dahua doorbells. Also, other 3 new events were added.
2. Intercom also works slightly differently, we need to accumulate and send segments when they are over 1KB in size. 

I have added a setting for Dahua Doorbells to activate this different behaviour, however, I need your help figuring out how to better manage and present that setting. Right now if a user enables the Dahua Doorbell setting but disables the Amcrest Doorbell setting, it will disable the binary sensor which is obviously not what we want. 

