### PR TITLE
Add ZWave Security Keys and Barrier Operator Device Support

### DIFF
--- a/plugins/zwave/package.json
+++ b/plugins/zwave/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/zwave",
-   "version": "0.0.30",
+   "version": "0.0.31",
    "description": "Z-Wave USB Controller for Scrypted",
    "author": "Scrypted",
    "license": "Apache",

--- a/plugins/zwave/src/CommandClasses/EntrySensorToBarrierOperator.ts
+++ b/plugins/zwave/src/CommandClasses/EntrySensorToBarrierOperator.ts
@@ -1,0 +1,27 @@
+import { EntrySensor } from "@scrypted/sdk";
+import { ValueID } from "@zwave-js/core";
+import { BarrierState } from "zwave-js";
+import { ZwaveDeviceBase } from "./ZwaveDeviceBase";
+
+export class EntrySensorToBarriorOperator extends ZwaveDeviceBase implements EntrySensor {
+    static updateState(zwaveDevice: ZwaveDeviceBase, valueId: ValueID) {
+        let currentValue: BarrierState
+        currentValue = zwaveDevice.getValue(valueId);
+
+        switch (currentValue) {
+            case BarrierState.Closed:
+                zwaveDevice.entryOpen = false;
+                break;
+            case BarrierState.Closing:
+            case BarrierState.Opening:
+            case BarrierState.Open:
+            case BarrierState.Stopped:
+                zwaveDevice.entryOpen = true;
+                break;
+            default:
+                zwaveDevice.entryOpen = false;
+        }
+    }
+}
+
+export default EntrySensorToBarriorOperator;

--- a/plugins/zwave/src/CommandClasses/index.ts
+++ b/plugins/zwave/src/CommandClasses/index.ts
@@ -10,6 +10,7 @@ import LuminanceSensorToSensorMultilevel from './LuminanceSensorToSensorMultilev
 import UltravioletSensorMultilevel from './UltravioletSensorToSensorMultilevel';
 import SettingsToConfiguration from './SettingsToConfiguration';
 import EntryToBarrierOperator from './EntryToBarrierOperator';
+import EntrySensorToBarriorOperator from './EntrySensorToBarrierOperator';
 import ColorSettingRgbToColor from './ColorSettingRgbToColor';
 import { NotificationType } from './Notification';
 import { EntrySensorToAccessControl } from './EntrySensorToAccessControl';
@@ -86,6 +87,9 @@ addCommandClassIndex(CommandClasses['Notification'], 'Access Control', EntrySens
 addCommandClassIndex(CommandClasses['Notification'], 'Water Alarm', FloodSensorToWaterAlarm, 'FloodSensor');
 addCommandClassIndex(CommandClasses['Notification'], 'Home Security', IntrusionSensorToHomeSecurity, 'IntrusionSensor');
 addCommandClassIndex(CommandClasses['Notification'], 'Power Management', PowerSensorToPowerManagement, 'PowerSensor');
+
+addCommandClassIndex(CommandClasses['Barrier Operator'], 'currentState', EntryToBarrierOperator, 'Entry');
+addCommandClassIndex(CommandClasses['Barrier Operator'], 'position', EntrySensorToBarriorOperator, 'EntrySensor');
 
 addCommandClass(CommandClasses['Configuration'], SettingsToConfiguration, 'Settings');
 addCommandClass(CommandClasses['User Code'], PasswordStoreToUserCode, 'PasswordStore');

--- a/plugins/zwave/src/main.ts
+++ b/plugins/zwave/src/main.ts
@@ -49,52 +49,32 @@ export class ZwaveControllerProvider extends ScryptedDeviceBase implements Devic
     }
 
     startDriver() {
-        let networkKey: Buffer | undefined;
-        let s2AccessControlKey: Buffer | undefined;
-        let s2AuthenticatedKey: Buffer | undefined;
-        let s2UnauthenticatedKey: Buffer | undefined;
-        let b64NetworkKey = this.storage.getItem('networkKey');
-        let b64s2AccessControlKey = this.storage.getItem('s2AccessControlKey');
-        let b64s2AuthenticatedKey = this.storage.getItem('s2AuthenticatedKey');
-        let b64s2UnauthenticatedKey = this.storage.getItem('s2UnauthenticatedKey');
+        let networkKey = this.storage.getItem('networkKey');
+        let s2AccessControlKey = this.storage.getItem('s2AccessControlKey');
+        let s2AuthenticatedKey = this.storage.getItem('s2AuthenticatedKey');
+        let s2UnauthenticatedKey = this.storage.getItem('s2UnauthenticatedKey');
         
-        if (b64NetworkKey) {
-            networkKey = Buffer.from(b64NetworkKey, 'base64');
-        }
-        else {
-            networkKey = randomBytes(16);
-            b64NetworkKey = networkKey.toString('base64');
-            this.storage.setItem('networKey', b64NetworkKey);
+        if (!networkKey) {
+            networkKey = randomBytes(16).toString('hex').toUpperCase();
+            this.storage.setItem('networkKey', networkKey);
             this.log.a('No Network Key was present, so a random one was generated. You can change the Network Key in Settings.')
         }
 
-        if (b64s2AccessControlKey) {
-            s2AccessControlKey = Buffer.from(b64s2AccessControlKey, 'base64');
-        }
-        else {
-            s2AccessControlKey = randomBytes(16);
-            b64s2AccessControlKey = s2AccessControlKey.toString('base64');
-            this.storage.setItem('s2AccessControlKey', b64s2AccessControlKey);
+        if (!s2AccessControlKey) {
+            s2AccessControlKey = randomBytes(16).toString('hex').toUpperCase();
+            this.storage.setItem('s2AccessControlKey', s2AccessControlKey);
             this.log.a('No S2 Access Control Key was present, so a random one was generated. You can change the S2 Access Control Key in Settings.');
         }
 
-        if (b64s2AuthenticatedKey) {
-            s2AuthenticatedKey = Buffer.from(b64s2AuthenticatedKey, 'base64');
-        }
-        else {
-            s2AuthenticatedKey = randomBytes(16);
-            b64s2AuthenticatedKey = s2AuthenticatedKey.toString('base64');
-            this.storage.setItem('s2AuthenticatedKey', b64s2AuthenticatedKey);
-            this.log.a('No S2 Authenticated Key was present, so a random one was generated. You can change the S2 Authenticated Key in Settings.')
+        if (!s2AuthenticatedKey) {
+            s2AuthenticatedKey = randomBytes(16).toString('hex').toUpperCase();
+            this.storage.setItem('s2AuthenticatedKey', s2AuthenticatedKey);
+            this.log.a('No S2 Authenticated Key was present, so a random one was generated. You can change the S2 Access Control Key in Settings.');            
         }
 
-        if (b64s2UnauthenticatedKey) {
-            s2UnauthenticatedKey = Buffer.from(b64s2UnauthenticatedKey, 'base64');
-        }
-        else {
-            s2UnauthenticatedKey = randomBytes(16);
-            b64s2UnauthenticatedKey = s2UnauthenticatedKey.toString('base64');
-            this.storage.setItem('s2UnauthenticatedKey', b64s2UnauthenticatedKey);
+        if (!s2UnauthenticatedKey) {
+            s2UnauthenticatedKey = randomBytes(16).toString('hex').toUpperCase();
+            this.storage.setItem('s2UnauthenticatedKey', s2UnauthenticatedKey);
             this.log.a('No S2 Unauthenticated Key was present, so a random one was generated. You can change the S2 Unauthenticated Key in Settings.')
         }
         
@@ -102,10 +82,10 @@ export class ZwaveControllerProvider extends ScryptedDeviceBase implements Devic
         this.console.log(process.cwd());
         const driver = new Driver(this.storage.getItem('serialPort'), {
             securityKeys: {
-                S2_Unauthenticated: s2UnauthenticatedKey,
-                S2_Authenticated: s2AuthenticatedKey,
-                S2_AccessControl: s2AccessControlKey,
-                S0_Legacy: networkKey
+                S2_Unauthenticated: Buffer.from(s2UnauthenticatedKey, 'hex'),
+                S2_Authenticated: Buffer.from(s2AuthenticatedKey, 'hex'),
+                S2_AccessControl: Buffer.from(s2AccessControlKey, 'hex'),
+                S0_Legacy: Buffer.from(networkKey, 'hex')
             },
             storage: {
                 cacheDir,

--- a/plugins/zwave/src/main.ts
+++ b/plugins/zwave/src/main.ts
@@ -50,21 +50,63 @@ export class ZwaveControllerProvider extends ScryptedDeviceBase implements Devic
 
     startDriver() {
         let networkKey: Buffer | undefined;
-        let b64Key = this.storage.getItem('networkKey');
-        if (b64Key) {
-            networkKey = Buffer.from(b64Key, 'base64');
+        let s2AccessControlKey: Buffer | undefined;
+        let s2AuthenticatedKey: Buffer | undefined;
+        let s2UnauthenticatedKey: Buffer | undefined;
+        let b64NetworkKey = this.storage.getItem('networkKey');
+        let b64s2AccessControlKey = this.storage.getItem('s2AccessControlKey');
+        let b64s2AuthenticatedKey = this.storage.getItem('s2AuthenticatedKey');
+        let b64s2UnauthenticatedKey = this.storage.getItem('s2UnauthenticatedKey');
+        
+        if (b64NetworkKey) {
+            networkKey = Buffer.from(b64NetworkKey, 'base64');
         }
         else {
             networkKey = randomBytes(16);
-            b64Key = networkKey.toString('base64');
-            this.storage.setItem('networKey', b64Key);
+            b64NetworkKey = networkKey.toString('base64');
+            this.storage.setItem('networKey', b64NetworkKey);
             this.log.a('No Network Key was present, so a random one was generated. You can change the Network Key in Settings.')
+        }
+
+        if (b64s2AccessControlKey) {
+            s2AccessControlKey = Buffer.from(b64s2AccessControlKey, 'base64');
+        }
+        else {
+            s2AccessControlKey = randomBytes(16);
+            b64s2AccessControlKey = s2AccessControlKey.toString('base64');
+            this.storage.setItem('s2AccessControlKey', b64s2AccessControlKey);
+            this.log.a('No S2 Access Control Key was present, so a random one was generated. You can change the S2 Access Control Key in Settings.');
+        }
+
+        if (b64s2AuthenticatedKey) {
+            s2AuthenticatedKey = Buffer.from(b64s2AuthenticatedKey, 'base64');
+        }
+        else {
+            s2AuthenticatedKey = randomBytes(16);
+            b64s2AuthenticatedKey = s2AuthenticatedKey.toString('base64');
+            this.storage.setItem('s2AuthenticatedKey', b64s2AuthenticatedKey);
+            this.log.a('No S2 Authenticated Key was present, so a random one was generated. You can change the S2 Authenticated Key in Settings.')
+        }
+
+        if (b64s2UnauthenticatedKey) {
+            s2UnauthenticatedKey = Buffer.from(b64s2UnauthenticatedKey, 'base64');
+        }
+        else {
+            s2UnauthenticatedKey = randomBytes(16);
+            b64s2UnauthenticatedKey = s2UnauthenticatedKey.toString('base64');
+            this.storage.setItem('s2UnauthenticatedKey', b64s2UnauthenticatedKey);
+            this.log.a('No S2 Unauthenticated Key was present, so a random one was generated. You can change the S2 Unauthenticated Key in Settings.')
         }
         
         const cacheDir = path.join(process.env['SCRYPTED_PLUGIN_VOLUME'], 'cache');
         this.console.log(process.cwd());
         const driver = new Driver(this.storage.getItem('serialPort'), {
-            networkKey,
+            securityKeys: {
+                S2_Unauthenticated: s2UnauthenticatedKey,
+                S2_Authenticated: s2AuthenticatedKey,
+                S2_AccessControl: s2AccessControlKey,
+                S0_Legacy: networkKey
+            },
             storage: {
                 cacheDir,
             }
@@ -131,16 +173,34 @@ export class ZwaveControllerProvider extends ScryptedDeviceBase implements Devic
     async getSettings(): Promise<Setting[]> {
         return [
             {
+                title: 'Serial Port',
+                key: 'serialPort',
+                value: this.storage.getItem('serialPort'),
+                description: 'Serial Port path or COM Port name',
+            },
+            {
                 title: 'Network Key',
                 key: 'networkKey',
                 value: this.storage.getItem('networkKey'),
                 description: 'The 16 byte Base64 encoded Network Security Key',
             },
             {
-                title: 'Serial Port',
-                key: 'serialPort',
-                value: this.storage.getItem('serialPort'),
-                description: 'Serial Port path or COM Port name',
+                title: 'S2 Access Control Key',
+                key: 's2AccessControlKey',
+                value: this.storage.getItem('s2AccessControlKey'),
+                description: 'The 16 byte Base64 encoded S2 Access Control Key',
+            },
+            {
+                title: 'S2 Authenticated Key',
+                key: 's2AuthenticatedKey',
+                value: this.storage.getItem('s2AuthenticatedKey'),
+                description: 'The 16 byte Base64 encoded S2 Authenticated Key',
+            },
+            {
+                title: 'S2 Unauthenticated Key',
+                key: 's2UnauthenticatedKey',
+                value: this.storage.getItem('s2UnauthenticatedKey'),
+                description: 'The 16 byte Base64 encoded S2 Unauthenticated Key',
             }
         ]
     }


### PR DESCRIPTION
- Added support to specify security keys according to here: [Security S2](https://zwave-js.github.io/node-zwave-js/#/getting-started/security-s2)
- Added support for Barrier Operator devices such as garage doors

Main issue is that the ZWave plugin will fail to load during the first run if you have the ZWave plugin installed as it will be attempting to convert the existing base64 storage value as hex. I was able to get my ZWave up and running after deleting the plugin, closing my browser, and then going through the setup again. Would be nice to have a way to convert an existing setup to a hex string value, but I'm not sure what the best way to do this would be. I suppose you can test if the existing value ends in "==" and go from there?

I've confirmed my garage door is added as a new device and I can open/close it with the appropriate state being reported. Super excited!
