### PR TITLE
Register as a service via launchd on macOS

### DIFF
--- a/docker/install-scrypted-dependencies-mac.sh
+++ b/docker/install-scrypted-dependencies-mac.sh
@@ -69,17 +69,14 @@ RUN cat << EOF | tee ~/Library/LaunchAgents/com.scrypted.server.plist
 EOF
 
 RUN launchctl load ~/Library/LaunchAgents/com.scrypted.server.plist
-RUN launchctl start ~/Library/LaunchAgents/com.scrypted.server.plist
 
 set +x
 echo
 echo
 echo
 echo
-echo "Launch Scrypted with the following:"
-echo "  npx -y scrypted serve"
-echo
-echo "Follow these instructions to create a service that runs on boot:"
-echo "  https://github.com/koush/scrypted/wiki/Local-Installation#mac"
+echo "Scrypted Service has been installed (and started). You can start and stop Scrypted with:"
+echo "  launchctl unload ~/Library/LaunchAgents/com.scrypted.server.plist"
+echo "  launchctl load ~/Library/LaunchAgents/com.scrypted.server.plist"
 echo
 echo

--- a/docker/install-scrypted-dependencies-mac.sh
+++ b/docker/install-scrypted-dependencies-mac.sh
@@ -30,6 +30,47 @@ RUN pip3 install aiofiles debugpy typing_extensions typing opencv-python
 echo "Installing Scrypted..."
 RUN npx -y scrypted install-server
 
+RUN mkdir -p ~/Library/LaunchAgents
+RUN cat << EOF | tee -a ~/Library/LaunchAgents/com.scrypted.server.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>RunAtLoad</key>
+        <true/>
+    <key>KeepAlive</key>
+        <true/>
+    <key>Label</key>
+        <string>com.scrypted.server</string>
+    <key>ProgramArguments</key>
+        <array>
+             <string>$(brew --prefix)/bin/npx</string>
+             <string>-y</string>
+             <string>scrypted</string>
+             <string>serve</string>
+        </array>
+    <key>WorkingDirectory</key>
+         <string>/Users/$(whoami)/.scrypted</string>
+    <key>StandardOutPath</key>
+        <string>/Users/$(whoami)/.scrypted/scrypted.log</string>
+    <key>StandardErrorPath</key>
+        <string>/Users/$(whoami)/.scrypted/scrypted.log</string>
+    <key>UserName</key>
+        <string>$(whoami)</string>
+    <key>EnvironmentVariables</key>
+        <dict>
+            <key>PATH</key>
+                <string>$(brew --prefix)/bin:$(brew --prefix)/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+            <key>HOME</key>
+                <string>/Users/$(whoami)</string>
+        </dict>
+</dict>
+</plist>
+EOF
+
+RUN launchctl load ~/Library/LaunchAgents/com.scrypted.server.plist
+RUN launchctl start ~/Library/LaunchAgents/com.scrypted.server.plist
+
 set +x
 echo
 echo

--- a/docker/install-scrypted-dependencies-mac.sh
+++ b/docker/install-scrypted-dependencies-mac.sh
@@ -31,7 +31,7 @@ echo "Installing Scrypted..."
 RUN npx -y scrypted install-server
 
 RUN mkdir -p ~/Library/LaunchAgents
-RUN cat << EOF | tee -a ~/Library/LaunchAgents/com.scrypted.server.plist
+RUN cat << EOF | tee ~/Library/LaunchAgents/com.scrypted.server.plist
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/docker/install-scrypted-dependencies-mac.sh
+++ b/docker/install-scrypted-dependencies-mac.sh
@@ -68,6 +68,7 @@ RUN cat << EOF | tee ~/Library/LaunchAgents/com.scrypted.server.plist
 </plist>
 EOF
 
+RUN launchctl unload ~/Library/LaunchAgents/com.scrypted.server.plist || echo ""
 RUN launchctl load ~/Library/LaunchAgents/com.scrypted.server.plist
 
 set +x


### PR DESCRIPTION
This sets up scrypted to run under launchd as the currently logged in user. It will run at load, and keep alive in case it crashes.

It also will automatically detect the correct bin folder from brew, so it can run on Intel and Apple Silicon.