### PR TITLE
Improve macOS launchd install safety

### DIFF
--- a/docker/install-scrypted-dependencies-mac.sh
+++ b/docker/install-scrypted-dependencies-mac.sh
@@ -30,6 +30,7 @@ RUN pip3 install aiofiles debugpy typing_extensions typing opencv-python
 echo "Installing Scrypted..."
 RUN npx -y scrypted install-server
 
+RUN test $(which npx)
 RUN mkdir -p ~/Library/LaunchAgents
 RUN cat << EOF | tee ~/Library/LaunchAgents/com.scrypted.server.plist
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docker/install-scrypted-dependencies-mac.sh
+++ b/docker/install-scrypted-dependencies-mac.sh
@@ -44,7 +44,7 @@ RUN cat << EOF | tee ~/Library/LaunchAgents/com.scrypted.server.plist
         <string>com.scrypted.server</string>
     <key>ProgramArguments</key>
         <array>
-             <string>$(brew --prefix)/bin/npx</string>
+             <string>$(which npx)</string>
              <string>-y</string>
              <string>scrypted</string>
              <string>serve</string>
@@ -60,7 +60,7 @@ RUN cat << EOF | tee ~/Library/LaunchAgents/com.scrypted.server.plist
     <key>EnvironmentVariables</key>
         <dict>
             <key>PATH</key>
-                <string>$(brew --prefix)/bin:$(brew --prefix)/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+                <string>$(dirname $(which npx)):$(brew --prefix)/bin:$(brew --prefix)/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
             <key>HOME</key>
                 <string>/Users/$(whoami)</string>
         </dict>


### PR DESCRIPTION
This will more reliably detect the location of `npx` and ensure it exists. Also adds the specific location to the `PATH` in the launchd plist.