### PR TITLE
arlo 0.2.3

### DIFF
--- a/plugins/arlo/package-lock.json
+++ b/plugins/arlo/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/arlo",
-   "version": "0.2.0",
+   "version": "0.2.3",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/arlo",
-         "version": "0.2.0",
+         "version": "0.2.3",
          "devDependencies": {
             "@scrypted/sdk": "file:../../sdk"
          }

--- a/plugins/arlo/package.json
+++ b/plugins/arlo/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/arlo",
-   "version": "0.2.0",
+   "version": "0.2.3",
    "description": "Arlo Plugin for Scrypted",
    "keywords": [
       "scrypted",

--- a/plugins/arlo/src/arlo_plugin/arlo/arlo_async.py
+++ b/plugins/arlo/src/arlo_plugin/arlo/arlo_async.py
@@ -1502,6 +1502,9 @@ class Arlo(object):
         It can be streamed with: ffmpeg -re -i 'rtsps://<url>' -acodec copy -vcodec copy test.mp4
         The request to /users/devices/startStream returns: { url:rtsp://<url>:443/vzmodulelive?egressToken=b<xx>&userAgent=iOS&cameraId=<camid>}
         """
+        stream_url_dict = self.request.post(f'https://{self.BASE_URL}/hmsweb/users/devices/startStream', {"to":camera.get('parentId'),"from":self.user_id+"_web","resource":"cameras/"+camera.get('deviceId'),"action":"set","responseUrl":"", "publishResponse":True,"transId":self.genTransId(),"properties":{"activityState":"startUserStream","cameraId":camera.get('deviceId')}}, headers={"xcloudId":camera.get('xCloudId')})
+        return stream_url_dict['url'].replace("rtsp://", "rtsps://")
+
         resource = f"cameras/{camera.get('deviceId')}"
 
         # nonlocal variable hack for Python 2.x.
@@ -1510,6 +1513,7 @@ class Arlo(object):
 
         def trigger(self):
             nl.stream_url_dict = self.request.post(f'https://{self.BASE_URL}/hmsweb/users/devices/startStream', {"to":camera.get('parentId'),"from":self.user_id+"_web","resource":"cameras/"+camera.get('deviceId'),"action":"set","responseUrl":"", "publishResponse":True,"transId":self.genTransId(),"properties":{"activityState":"startUserStream","cameraId":camera.get('deviceId')}}, headers={"xcloudId":camera.get('xCloudId')})
+            logger.debug(f"startStream returned {nl.stream_url_dict}")
 
         def callback(self, event):
             properties = event.get("properties", {})

--- a/plugins/arlo/src/arlo_plugin/camera.py
+++ b/plugins/arlo/src/arlo_plugin/camera.py
@@ -49,7 +49,7 @@ class ArloCamera(ScryptedDeviceBase, Camera, VideoCamera, MotionSensor, Battery,
             self.logger.info("Getting snapshot from prebuffer")
             return await real_device.getVideoStream({"refresh": False})
 
-        pic_url = await asyncio.wait_for(self.provider.arlo.TriggerFullFrameSnapshot(self.arlo_basestation, self.arlo_device), timeout=10)
+        pic_url = await asyncio.wait_for(self.provider.arlo.TriggerFullFrameSnapshot(self.arlo_basestation, self.arlo_device), timeout=30)
         self.logger.debug(f"Got snapshot URL for at {pic_url}")
 
         if pic_url is None:
@@ -78,7 +78,7 @@ class ArloCamera(ScryptedDeviceBase, Camera, VideoCamera, MotionSensor, Battery,
     async def getVideoStream(self, options=None):
         self.logger.info("Requesting stream")
 
-        rtsp_url = await asyncio.wait_for(self.provider.arlo.StartStream(self.arlo_basestation, self.arlo_device), timeout=10)
+        rtsp_url = await asyncio.wait_for(self.provider.arlo.StartStream(self.arlo_basestation, self.arlo_device), timeout=30)
         self.logger.debug(f"Got stream URL at {rtsp_url}")
 
         return await scrypted_sdk.mediaManager.createMediaObject(str.encode(rtsp_url), ScryptedMimeTypes.Url.value)


### PR DESCRIPTION
Changes:
 - Return rtsp url immediately once we get it
 - Extended plugin-level timeouts (used to clear up blocked stale coroutines) to 30s
 - Restart auth if the headers don't work on plugin load
 - Return arloq and doorbell device types as cameras