### PR TITLE
homekit: map EntrySensor to homekit ContactSensor

### DIFF
--- a/plugins/homekit/src/types/sensor.ts
+++ b/plugins/homekit/src/types/sensor.ts
@@ -1,4 +1,4 @@
-import { AmbientLightSensor, AudioSensor, BinarySensor, FloodSensor, HumiditySensor, MotionSensor, OccupancySensor, PM25Sensor, AirQualitySensor, ScryptedDevice, ScryptedDeviceType, ScryptedInterface, Thermometer, VOCSensor, AirQuality } from '@scrypted/sdk';
+import { AmbientLightSensor, AudioSensor, BinarySensor, FloodSensor, HumiditySensor, MotionSensor, OccupancySensor, PM25Sensor, AirQualitySensor, ScryptedDevice, ScryptedDeviceType, ScryptedInterface, Thermometer, VOCSensor, AirQuality, EntrySensor } from '@scrypted/sdk';
 import { addSupportedType, bindCharacteristic, DummyDevice, HomeKitSession } from '../common';
 import { Characteristic, Service } from '../hap';
 import { makeAccessory } from './common';
@@ -32,6 +32,7 @@ const supportedSensors: string[] = [
     ScryptedInterface.AirQualitySensor,
     ScryptedInterface.PM25Sensor,
     ScryptedInterface.VOCSensor,
+    ScryptedInterface.EntrySensor,
 ];
 
 addSupportedType({
@@ -43,13 +44,19 @@ addSupportedType({
         }
         return false;
     },
-    getAccessory: async (device: ScryptedDevice & OccupancySensor & AmbientLightSensor & AmbientLightSensor & AudioSensor & BinarySensor & MotionSensor & Thermometer & HumiditySensor & FloodSensor & AirQualitySensor & PM25Sensor & VOCSensor, homekitSession: HomeKitSession) => {
+    getAccessory: async (device: ScryptedDevice & OccupancySensor & AmbientLightSensor & AmbientLightSensor & AudioSensor & BinarySensor & MotionSensor & Thermometer & HumiditySensor & FloodSensor & AirQualitySensor & PM25Sensor & VOCSensor & EntrySensor, homekitSession: HomeKitSession) => {
         const accessory = makeAccessory(device, homekitSession);
 
         if (device.interfaces.includes(ScryptedInterface.BinarySensor)) {
             const service = accessory.addService(Service.ContactSensor, device.name);
             bindCharacteristic(device, ScryptedInterface.BinarySensor, service, Characteristic.ContactSensorState,
                 () => !!device.binaryState);
+        }
+
+        if (device.interfaces.includes(ScryptedInterface.EntrySensor)) {
+            const service = accessory.addService(Service.ContactSensor, device.name);
+            bindCharacteristic(device, ScryptedInterface.EntrySensor, service, Characteristic.ContactSensorState,
+                () => !! device.entryOpen);
         }
 
         if (device.interfaces.includes(ScryptedInterface.OccupancySensor)) {

--- a/plugins/homekit/src/types/sensor.ts
+++ b/plugins/homekit/src/types/sensor.ts
@@ -54,7 +54,7 @@ addSupportedType({
         }
 
         if (device.interfaces.includes(ScryptedInterface.EntrySensor)) {
-            const service = accessory.addService(Service.ContactSensor, device.name);
+            const service = accessory.addService(Service.ContactSensor, device.name + ' Entry Sensor', 'EntrySensor');
             bindCharacteristic(device, ScryptedInterface.EntrySensor, service, Characteristic.ContactSensorState,
                 () => !! device.entryOpen);
         }

--- a/plugins/homekit/src/types/sensor.ts
+++ b/plugins/homekit/src/types/sensor.ts
@@ -51,12 +51,10 @@ addSupportedType({
             const service = accessory.addService(Service.ContactSensor, device.name);
             bindCharacteristic(device, ScryptedInterface.BinarySensor, service, Characteristic.ContactSensorState,
                 () => !!device.binaryState);
-        }
-
-        if (device.interfaces.includes(ScryptedInterface.EntrySensor)) {
-            const service = accessory.addService(Service.ContactSensor, device.name + ' Entry Sensor', 'EntrySensor');
+        } else if (device.interfaces.includes(ScryptedInterface.EntrySensor)) {
+            const service = accessory.addService(Service.ContactSensor, device.name);
             bindCharacteristic(device, ScryptedInterface.EntrySensor, service, Characteristic.ContactSensorState,
-                () => !! device.entryOpen);
+                () => !!device.entryOpen);
         }
 
         if (device.interfaces.includes(ScryptedInterface.OccupancySensor)) {


### PR DESCRIPTION
Door/open close sensor in ZWave is a ScryptedInterface.EntrySensor which was not supported by homekit