### PR TITLE
Fix incorrect assumption that LIBX264_ENCODER_TITLE is always set

### DIFF
--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -1484,7 +1484,7 @@ export class RebroadcastPlugin extends AutoenableMixinProvider implements MixinP
       title: 'H264 Encoder Arguments',
       description: 'FFmpeg arguments used to encode h264 video. This is not camera specific and is used to setup the hardware accelerated encoder on your Scrypted server. This setting will only be used when transcoding is enabled on a camera.',
       choices: Object.keys(getH264EncoderArgs()),
-      defaultValue: getH264EncoderArgs()[LIBX264_ENCODER_TITLE].join(' '),
+      defaultValue: getH264EncoderArgs()[LIBX264_ENCODER_TITLE]?.join(' '),
       combobox: true,
       mapPut: (oldValue, newValue) => getH264EncoderArgs()[newValue]?.join(' ') || newValue || getH264EncoderArgs()[LIBX264_ENCODER_TITLE]?.join(' '),
     }


### PR DESCRIPTION
LIBX264_ENCODER_TITLE is not set under any condition where the is platform is unrecognised.

FreeBSD is not mapped in `common/src/ffmpeg-hardware-acceleration.ts` and as a result the rebroadcast plugin is unable to start due to `getH264EncoderArgs()[LIBX264_ENCODER_TITLE]` being undefined when `join` is called
