### PR TITLE
homekit: airquality sensor updates

### DIFF
--- a/plugins/homekit/src/types/sensor.ts
+++ b/plugins/homekit/src/types/sensor.ts
@@ -104,10 +104,15 @@ addSupportedType({
             const service = accessory.addService(Service.AirQualitySensor, device.name);
             bindCharacteristic(device, ScryptedInterface.AirQualitySensor, service, Characteristic.AirQuality,
                 () => airQualityToHomekit(device.airQuality));
-            bindCharacteristic(device, ScryptedInterface.PM25Sensor, service, Characteristic.PM2_5Density,
-                () => device.pm25Density || 0);
-            bindCharacteristic(device, ScryptedInterface.VOCSensor, service, Characteristic.VOCDensity,
-                () => device.vocDensity || 0);
+            
+            if (device.interfaces.includes(ScryptedInterface.PM25Sensor)) {
+                bindCharacteristic(device, ScryptedInterface.PM25Sensor, service, Characteristic.PM2_5Density,
+                    () => device.pm25Density || 0);
+            }
+            if (device.interfaces.includes(ScryptedInterface.VOCSensor)) {
+                bindCharacteristic(device, ScryptedInterface.VOCSensor, service, Characteristic.VOCDensity,
+                    () => device.vocDensity || 0);
+            }
         }
 
         // todo: more sensors.


### PR DESCRIPTION
bugfix: airquality sub-sensor displayed when it shouldn't be

support air quality sensor as part of thermostat type