### PR TITLE
prefer EntrySensor over BinarySensor if device has both

### DIFF
--- a/plugins/homekit/src/types/sensor.ts
+++ b/plugins/homekit/src/types/sensor.ts
@@ -49,14 +49,15 @@ addSupportedType({
     getAccessory: async (device: ScryptedDevice & OccupancySensor & AmbientLightSensor & AmbientLightSensor & AudioSensor & BinarySensor & MotionSensor & Thermometer & HumiditySensor & FloodSensor & AirQualitySensor & PM25Sensor & VOCSensor & EntrySensor & TamperSensor & CO2Sensor, homekitPlugin: HomeKitPlugin) => {
         const accessory = makeAccessory(device, homekitPlugin);
 
-        if (device.interfaces.includes(ScryptedInterface.BinarySensor)) {
-            const service = accessory.addService(Service.ContactSensor, device.name);
-            bindCharacteristic(device, ScryptedInterface.BinarySensor, service, Characteristic.ContactSensorState,
-                () => !!device.binaryState);
-        } else if (device.interfaces.includes(ScryptedInterface.EntrySensor)) {
+        if (device.interfaces.includes(ScryptedInterface.EntrySensor)) {
             const service = accessory.addService(Service.ContactSensor, device.name);
             bindCharacteristic(device, ScryptedInterface.EntrySensor, service, Characteristic.ContactSensorState,
                 () => !!device.entryOpen);
+        }
+        else if (device.interfaces.includes(ScryptedInterface.BinarySensor)) {
+            const service = accessory.addService(Service.ContactSensor, device.name);
+            bindCharacteristic(device, ScryptedInterface.BinarySensor, service, Characteristic.ContactSensorState,
+                () => !!device.binaryState);
         }
 
         if (device.interfaces.includes(ScryptedInterface.OccupancySensor)) {


### PR DESCRIPTION
Devices like Aeotec Door / Window Sensor 7 Pro support both BinarySensor and EntrySensor - but the EntrySensor attribute actually reflects the sensor state