### PR TITLE
feat: allow Arlo basestations that identify as sirens (e.g. VMB4000)

### DIFF
--- a/plugins/arlo/src/arlo_plugin/arlo/arlo_async.py
+++ b/plugins/arlo/src/arlo_plugin/arlo/arlo_async.py
@@ -228,7 +228,7 @@ class Arlo(object):
             # for now, keep doorbells in the list so they get pings
             proper_basestations = {}
             for basestation in basestations.values():
-                if basestation['deviceId'] == basestation.get('parentId') and basestation['deviceType'] != 'doorbell':
+                if basestation['deviceId'] == basestation.get('parentId') and basestation['deviceType'] not in ['doorbell', 'siren']:
                     continue
                 proper_basestations[basestation['deviceId']] = basestation
 

--- a/plugins/arlo/src/arlo_plugin/arlo/arlo_async.py
+++ b/plugins/arlo/src/arlo_plugin/arlo/arlo_async.py
@@ -225,7 +225,7 @@ class Arlo(object):
                 cameras[camera['deviceId']] = camera
 
             # filter out cameras without basestation, where they are their own basestations
-            # for now, keep doorbells in the list so they get pings
+            # for now, keep doorbells and sirens in the list so they get pings
             proper_basestations = {}
             for basestation in basestations.values():
                 if basestation['deviceId'] == basestation.get('parentId') and basestation['deviceType'] not in ['doorbell', 'siren']:

--- a/plugins/arlo/src/arlo_plugin/provider.py
+++ b/plugins/arlo/src/arlo_plugin/provider.py
@@ -225,7 +225,7 @@ class ArloProvider(ScryptedDeviceBase, Settings, DeviceProvider, DeviceDiscovery
         self.arlo_basestations = {}
         self.scrypted_devices = {}
 
-        basestations = self.arlo.GetDevices('basestation')
+        basestations = self.arlo.GetDevices(['basestation', 'siren'])
         for basestation in basestations:
             self.arlo_basestations[basestation["deviceId"]] = basestation
         self.logger.info(f"Discovered {len(basestations)} basestations")


### PR DESCRIPTION
The Arlo plugin attempts to discover the associated basestation(s) for the camera(s). Older basestations (like the VMB4000) advertise themselves as `siren` instead of `basestation`, so this PR allows these basestations to be discovered correctly. Tested working with Arlo Pro 2 cameras paired to VMB4000v3.

As a side note, I don't get any audio, but not sure if that's a plugin problem or a problem with how the basestation is advertising itself.