### PR TITLE
Add SCRYPTED_HOSTNAME setting

### DIFF
--- a/server/src/plugin/plugin-remote.ts
+++ b/server/src/plugin/plugin-remote.ts
@@ -72,9 +72,13 @@ class EndpointManagerImpl implements EndpointManager {
         return id;
     }
 
-    async getUrlSafeIp() {
+    async getUrlSafeHost() {
+        const hostname: string = await this.api.getComponent('SCRYPTED_HOSTNAME');
+        if (hostname) {
+            return hostname;
+        }
         // ipv6 addresses have colons and need to be bracketed for url safety
-        const ip: string = await this.api.getComponent('SCRYPTED_IP_ADDRESS')
+        const ip: string = await this.api.getComponent('SCRYPTED_IP_ADDRESS');
         return ip?.includes(':') ? `[${ip}]` : ip;
     }
 
@@ -133,7 +137,7 @@ class EndpointManagerImpl implements EndpointManager {
         const protocol = options?.insecure ? 'http' : 'https';
         const port = await this.api.getComponent(options?.insecure ? 'SCRYPTED_INSECURE_PORT' : 'SCRYPTED_SECURE_PORT');
         const path = await this.getPath(nativeId, options);
-        const url =  `${protocol}://${await this.getUrlSafeIp()}:${port}${path}`;
+        const url = `${protocol}://${await this.getUrlSafeHost()}:${port}${path}`;
         return url;
     }
 

--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -27,7 +27,7 @@ import { PluginHost } from './plugin/plugin-host';
 import { isConnectionUpgrade, PluginHttp } from './plugin/plugin-http';
 import { WebSocketConnection } from './plugin/plugin-remote-websocket';
 import { getPluginVolume } from './plugin/plugin-volume';
-import { getIpAddress, SCRYPTED_INSECURE_PORT, SCRYPTED_SECURE_PORT } from './server-settings';
+import { getIpAddress, SCRYPTED_HOSTNAME, SCRYPTED_INSECURE_PORT, SCRYPTED_SECURE_PORT } from './server-settings';
 import { AddressSettigns as AddressSettings } from './services/addresses';
 import { Alerts } from './services/alerts';
 import { CORSControl, CORSServer } from './services/cors';
@@ -352,6 +352,8 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
         switch (componentId) {
             case 'SCRYPTED_IP_ADDRESS':
                 return getIpAddress();
+            case 'SCRYPTED_HOSTNAME':
+                return SCRYPTED_HOSTNAME;
             case 'SCRYPTED_INSECURE_PORT':
                 return SCRYPTED_INSECURE_PORT;
             case 'SCRYPTED_SECURE_PORT':

--- a/server/src/server-settings.ts
+++ b/server/src/server-settings.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import * as nodeIp from 'ip';
 
+export const SCRYPTED_HOSTNAME = process.env.SCRYPTED_HOSTNAME;
 export const SCRYPTED_INSECURE_PORT = parseInt(process.env.SCRYPTED_INSECURE_PORT) || 11080;
 export const SCRYPTED_SECURE_PORT = parseInt(process.env.SCRYPTED_SECURE_PORT) || 10443;
 export const SCRYPTED_DEBUG_PORT = parseInt(process.env.SCRYPTED_DEBUG_PORT) || 10081;


### PR DESCRIPTION
When using Scrypted with https and a hostname, video clips fail to display because the URL that Scrypted constructs uses an IP address, which is typically not included in the TLS certificate CN/Subject Alternative Name.

Add support for SCRYPTED_HOSTNAME setting which, if set, is used to construct video clip URLs instead of the server's IP address.

Fixes #367, #445.