### PR TITLE
Some quality-of-life fixes for the HomeKit plugin

### DIFF
--- a/plugins/homekit/src/types/common.ts
+++ b/plugins/homekit/src/types/common.ts
@@ -131,6 +131,9 @@ export function addFan(device: ScryptedDevice & Fan & OnOff, accessory: Accessor
                 speed,
             });
         });
+        service.getCharacteristic(Characteristic.RotationSpeed).setProps({
+            minStep: 100 / device.fan?.maxSpeed,
+        });
     }
 
     if (device.fan?.availableModes !== undefined) {

--- a/plugins/homekit/src/types/common.ts
+++ b/plugins/homekit/src/types/common.ts
@@ -69,6 +69,9 @@ export function addCarbonDioxideSensor(device: ScryptedDevice & CO2Sensor, acces
 }
 
 export function addFan(device: ScryptedDevice & Fan & OnOff, accessory: Accessory): Service {
+    if (!device.interfaces.includes(ScryptedInterface.OnOff) && !device.interfaces.includes(ScryptedInterface.Fan))
+        return undefined;
+
     const service = accessory.addService(Service.Fanv2, device.name);
 
     if (device.interfaces.includes(ScryptedInterface.OnOff)) {

--- a/plugins/homekit/src/types/thermostat.ts
+++ b/plugins/homekit/src/types/thermostat.ts
@@ -96,6 +96,12 @@ addSupportedType({
 
         bindCharacteristic(device, ScryptedInterface.TemperatureSetting, service, Characteristic.TargetHeatingCoolingState,
             () => toTargetMode(device.thermostatMode));
+        
+        if (!device.thermostatAvailableModes.includes(ThermostatMode.Auto)) {
+            service.getCharacteristic(Characteristic.TargetHeatingCoolingState).setProps({
+                maxValue: Characteristic.TargetHeatingCoolingState.COOL // Disable 'Auto' mode
+            });
+        }
 
         service.getCharacteristic(Characteristic.TargetTemperature)
             .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {


### PR DESCRIPTION
Whilst working on a plugin for the Sensibo smart AC controller, I made a few changes to the HomeKit plugin to gracefully handle thermostats that don't have a fan or support an 'auto' mode. I also added a minimum step for the fan speed, which causes the Home app to 'stick' to valid fan speeds when adjusting the speed.

P.S. Hoping I've done this correctly,  but let me know if I need to change anything or if there's a procedure for PRs I should have followed.