### PR TITLE
Windows installation script install Node LTS v18

### DIFF
--- a/docker/install-scrypted-dependencies-win.ps1
+++ b/docker/install-scrypted-dependencies-win.ps1
@@ -1,4 +1,4 @@
-winget install -h OpenJS.NodeJS
+winget install -h --id "OpenJS.NodeJS.LTS"
 winget install -h --id "Python.Python.3.10"
 
 py -m pip install --upgrade pip


### PR DESCRIPTION
Otherwise `OpenJS.NodeJS` defaults to v19 right now which is not supported https://github.com/koush/scrypted/pull/498