### PR TITLE
Update Windows installation script

### DIFF
--- a/docker/install-scrypted-dependencies-win.ps1
+++ b/docker/install-scrypted-dependencies-win.ps1
@@ -1,5 +1,16 @@
-winget install -h --id "OpenJS.NodeJS.LTS"
-winget install -h --id "Python.Python.3.10"
+# Install Chocolatey
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+# Install node.js
+choco upgrade -y nodejs-lts --version=18.13.0
+
+# Install Node.js additional tools for Windows to compile native modules
+# https://github.com/nodejs/node/blob/main/tools/msvs/install_tools/install_tools.bat#L55
+choco upgrade -y python visualstudio2019-workload-vctools
+
+# Refresh environment variables for py and npx to work
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
 
 py -m pip install --upgrade pip
 py -m pip install aiofiles debugpy typing_extensions typing opencv-python
@@ -9,7 +20,6 @@ npx -y scrypted@latest install-server
 $USER_HOME_ESCAPED = $env:USERPROFILE.replace('\', '\\')
 $SCRYPTED_HOME = $env:USERPROFILE + '\.scrypted'
 $SCRYPTED_HOME_ESCAPED_PATH = $SCRYPTED_HOME.replace('\', '\\')
-npm install --global --production windows-build-tools
 npm install --prefix $SCRYPTED_HOME node-windows@1.0.0-beta.8 --save
 
 $SERVICE_JS = @"
@@ -19,7 +29,6 @@ try {
 }
 catch (e) {
 }
-
 const child_process = require('child_process');
 child_process.spawn('npx.cmd', ['-y', 'scrypted', 'serve'], {
     stdio: 'inherit',
@@ -32,7 +41,6 @@ $SERVICE_JS | Out-File -Encoding ASCII -FilePath $SERVICE_JS_PATH
 
 $INSTALL_SERVICE_JS = @"
 var Service = require('node-windows').Service;
-
 var svc = new Service({
   name: 'Scrypted',
   description: 'Scrypted Home Automation',
@@ -44,30 +52,19 @@ var svc = new Service({
     },
   ]
 });
-
-svc.on('alreadyuninstalled', () => {
-  svc.install();
-});
-
-svc.on('uninstall', () => {
-  svc.install();
-});
-
-svc.on('error', () => {
-  svc.install();
-});
-
 svc.on('install', () => {
-  svc.start();
+  console.log("Service installed");
 });
-
-svc.uninstall();
+svc.install();
 "@
 
 $INSTALL_SERVICE_JS_PATH = $SCRYPTED_HOME + '\install-service.js'
 $INSTALL_SERVICE_JS | Out-File -Encoding ASCII -FilePath $INSTALL_SERVICE_JS_PATH
 
 node $INSTALL_SERVICE_JS_PATH
+
+# Manually start service, node-windows has issues starting service
+sc start scrypted.exe
 
 Write-Output "Scrypted is now running at: https://localhost:10443/"
 Write-Output "Note that it is https and that you'll be asked to approve/ignore the website certificate."


### PR DESCRIPTION
- Changes to pinned version of Node LTS 18.13.0 https://github.com/koush/scrypted/pull/502#issuecomment-1374325481
- Change to use Chocolatey to install Node and Python (removes dependency on `winget` since the Node.js additional tools already use Chocolatey)
- Remove `windows-build-tools` and install the Node.js additional tools for Windows to compile native modules as recommended by https://github.com/felixrieseberg/windows-build-tools using the official script https://github.com/nodejs/node/blob/main/tools/msvs/install_tools/install_tools.bat#L55 
- Simplify service installer Node script
- Fix service start not working and replace with `sc start`

We can also simplify the uninstallation instructions at https://github.com/koush/scrypted/wiki/Uninstallation#windows to use [`sc.exe`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-delete) directly which avoids the dependency on `node-windows`
```cmd
sc stop scrypted.exe
sc delete scrypted.exe
```