### PR TITLE
Replace deprecated function from example webhook-motion-sensor and webhook-thermometer

### DIFF
--- a/plugins/core/fs/examples/webhook-motion-sensor.ts
+++ b/plugins/core/fs/examples/webhook-motion-sensor.ts
@@ -17,7 +17,7 @@ class WebhookExample implements HttpRequestHandler {
 
 device.handleTypes(ScryptedInterface.MotionSensor);
 
-endpointManager.getInsecurePublicLocalEndpoint(device.nativeId)
+endpointManager.getLocalEndpoint(device.nativeId, { insecure: true, public: true })
     .then(endpoint => console.log('motion webhook:', endpoint));
 
 export default WebhookExample;

--- a/plugins/core/fs/examples/webhook-thermometer.ts
+++ b/plugins/core/fs/examples/webhook-thermometer.ts
@@ -15,7 +15,7 @@ class WebhookExample implements HttpRequestHandler {
 
 device.handleTypes(ScryptedInterface.Thermometer);
 
-endpointManager.getInsecurePublicLocalEndpoint(device.nativeId)
+endpointManager.getLocalEndpoint(device.nativeId, { insecure: true, public: true })
     .then(endpoint => {
         console.log('motion webhook:', endpoint);
         console.log('example:');


### PR DESCRIPTION
Replaced deprecated functions in example script files.
Changed `getInsecurePublicLocalEndpoint` to `getLocalEndpoint`.