### PR TITLE
Add Sensibo Smart AC Controller support

### DIFF
--- a/plugins/sensibo/.gitignore
+++ b/plugins/sensibo/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+out/
+node_modules/
+dist/

--- a/plugins/sensibo/.vscode/launch.json
+++ b/plugins/sensibo/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Scrypted Debugger",
+            "address": "${config:scrypted.debugHost}",
+            "port": 10081,
+            "request": "attach",
+            "skipFiles": [
+                "**/plugin-remote-worker.*",
+                "<node_internals>/**"
+            ],
+            "preLaunchTask": "scrypted: deploy+debug",
+            "sourceMaps": true,
+            "localRoot": "${workspaceFolder}/out",
+            "remoteRoot": "/plugin/",
+            "type": "pwa-node"
+        }
+    ]
+}

--- a/plugins/sensibo/.vscode/settings.json
+++ b/plugins/sensibo/.vscode/settings.json
@@ -1,0 +1,4 @@
+
+{
+    "scrypted.debugHost": "127.0.0.1",
+}

--- a/plugins/sensibo/.vscode/tasks.json
+++ b/plugins/sensibo/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "scrypted: deploy+debug",
+            "type": "shell",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "command": "npm run scrypted-vscode-launch ${config:scrypted.debugHost}",
+        },
+    ]
+}

--- a/plugins/sensibo/README.md
+++ b/plugins/sensibo/README.md
@@ -1,0 +1,15 @@
+# Sensibo plugin for Scrypted
+
+This plugin adds support for Sensibo devices to Scrypted, using the Sensibo cloud API. The 'Climate React' system is optionally supported and is used to implement the 'HeatCool' thermostat mode, which automatically adjusts the air conditioner settingsto keep temperatures fixed within a specific temperature range.
+
+In order to use this plugin, an API key must be obtained from 'https://home.sensibo.com/me/api' for the account to which the Sensibo device is registered.
+
+# Build Instructions
+
+1. npm install
+2. Open this plugin director yin VS Code.
+3. Edit `.vscode/settings.json` to point to the IP address of your Scrypted server. The default is `127.0.0.1`, your local machine.
+4. Press Launch (green arrow button in the Run and Debug sidebar) to start debugging.
+  * The VS Code `Terminal` area may show an authentication failure and prompt you to log in to the Scrypted Management Console with `npx scrypted login`. You will only need to do this once. You can then relaunch afterwards.
+ 
+<img width="538" alt="image" src="https://user-images.githubusercontent.com/73924/151676616-c730eb56-26dd-466d-b7f5-25783300b3bc.png">

--- a/plugins/sensibo/package-lock.json
+++ b/plugins/sensibo/package-lock.json
@@ -1,0 +1,168 @@
+{
+   "name": "@scrypted/sensibo",
+   "version": "0.0.1",
+   "lockfileVersion": 2,
+   "requires": true,
+   "packages": {
+      "": {
+         "name": "@scrypted/sensibo",
+         "version": "0.0.1",
+         "hasInstallScript": true,
+         "dependencies": {
+            "@types/node": "^16.6.1",
+            "axios": "^0.24.0"
+         },
+         "devDependencies": {
+            "@scrypted/common": "file:../../common",
+            "@scrypted/sdk": "file:../../sdk"
+         }
+      },
+      "../../common": {
+         "version": "1.0.1",
+         "dev": true,
+         "license": "ISC",
+         "dependencies": {
+            "@scrypted/sdk": "file:../sdk",
+            "@scrypted/server": "file:../server",
+            "http-auth-utils": "^3.0.2",
+            "node-fetch-commonjs": "^3.1.1",
+            "typescript": "^4.4.3"
+         },
+         "devDependencies": {
+            "@types/node": "^16.9.0"
+         }
+      },
+      "../../sdk": {
+         "version": "0.2.53",
+         "dev": true,
+         "license": "ISC",
+         "dependencies": {
+            "@babel/preset-typescript": "^7.18.6",
+            "adm-zip": "^0.4.13",
+            "axios": "^0.21.4",
+            "babel-loader": "^9.1.0",
+            "babel-plugin-const-enum": "^1.1.0",
+            "esbuild": "^0.15.9",
+            "ncp": "^2.0.0",
+            "raw-loader": "^4.0.2",
+            "rimraf": "^3.0.2",
+            "tmp": "^0.2.1",
+            "ts-loader": "^9.4.2",
+            "typescript": "^4.9.4",
+            "webpack": "^5.75.0",
+            "webpack-bundle-analyzer": "^4.5.0"
+         },
+         "bin": {
+            "scrypted-debug": "bin/scrypted-debug.js",
+            "scrypted-deploy": "bin/scrypted-deploy.js",
+            "scrypted-deploy-debug": "bin/scrypted-deploy-debug.js",
+            "scrypted-package-json": "bin/scrypted-package-json.js",
+            "scrypted-readme": "bin/scrypted-readme.js",
+            "scrypted-setup-project": "bin/scrypted-setup-project.js",
+            "scrypted-webpack": "bin/scrypted-webpack.js"
+         },
+         "devDependencies": {
+            "@types/node": "^18.11.18",
+            "@types/stringify-object": "^4.0.0",
+            "stringify-object": "^3.3.0",
+            "ts-node": "^10.4.0",
+            "typedoc": "^0.23.21"
+         }
+      },
+      "node_modules/@scrypted/common": {
+         "resolved": "../../common",
+         "link": true
+      },
+      "node_modules/@scrypted/sdk": {
+         "resolved": "../../sdk",
+         "link": true
+      },
+      "node_modules/@types/node": {
+         "version": "16.18.3",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
+         "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg=="
+      },
+      "node_modules/axios": {
+         "version": "0.24.0",
+         "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+         "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+         "dependencies": {
+            "follow-redirects": "^1.14.4"
+         }
+      },
+      "node_modules/follow-redirects": {
+         "version": "1.15.2",
+         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+         "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+         "funding": [
+            {
+               "type": "individual",
+               "url": "https://github.com/sponsors/RubenVerborgh"
+            }
+         ],
+         "engines": {
+            "node": ">=4.0"
+         },
+         "peerDependenciesMeta": {
+            "debug": {
+               "optional": true
+            }
+         }
+      }
+   },
+   "dependencies": {
+      "@scrypted/common": {
+         "version": "file:../../common",
+         "requires": {
+            "@scrypted/sdk": "file:../sdk",
+            "@scrypted/server": "file:../server",
+            "@types/node": "^16.9.0",
+            "http-auth-utils": "^3.0.2",
+            "node-fetch-commonjs": "^3.1.1",
+            "typescript": "^4.4.3"
+         }
+      },
+      "@scrypted/sdk": {
+         "version": "file:../../sdk",
+         "requires": {
+            "@babel/preset-typescript": "^7.18.6",
+            "@types/node": "^18.11.18",
+            "@types/stringify-object": "^4.0.0",
+            "adm-zip": "^0.4.13",
+            "axios": "^0.21.4",
+            "babel-loader": "^9.1.0",
+            "babel-plugin-const-enum": "^1.1.0",
+            "esbuild": "^0.15.9",
+            "ncp": "^2.0.0",
+            "raw-loader": "^4.0.2",
+            "rimraf": "^3.0.2",
+            "stringify-object": "^3.3.0",
+            "tmp": "^0.2.1",
+            "ts-loader": "^9.4.2",
+            "ts-node": "^10.4.0",
+            "typedoc": "^0.23.21",
+            "typescript": "^4.9.4",
+            "webpack": "^5.75.0",
+            "webpack-bundle-analyzer": "^4.5.0"
+         }
+      },
+      "@types/node": {
+         "version": "16.18.3",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
+         "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg=="
+      },
+      "axios": {
+         "version": "0.24.0",
+         "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+         "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+         "requires": {
+            "follow-redirects": "^1.14.4"
+         }
+      },
+      "follow-redirects": {
+         "version": "1.15.2",
+         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+         "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      }
+   }
+}

--- a/plugins/sensibo/package.json
+++ b/plugins/sensibo/package.json
@@ -1,0 +1,40 @@
+{
+   "name": "@scrypted/sensibo",
+   "version": "0.0.1",
+   "description": "Sensibo Thermostat Plugin for Scrypted",
+   "scripts": {
+      "scrypted-setup-project": "scrypted-setup-project",
+      "postinstall": "scrypted-setup-project",
+      "build": "scrypted-webpack",
+      "prepublishOnly": "NODE_ENV=production scrypted-webpack",
+      "prescrypted-vscode-launch": "scrypted-webpack",
+      "scrypted-vscode-launch": "scrypted-deploy-debug",
+      "scrypted-deploy-debug": "scrypted-deploy-debug",
+      "scrypted-debug": "scrypted-debug",
+      "scrypted-deploy": "scrypted-deploy",
+      "scrypted-readme": "scrypted-readme",
+      "scrypted-package-json": "scrypted-package-json"
+   },
+   "keywords": [
+      "scrypted",
+      "plugin",
+      "sensibo",
+      "thermostat"
+   ],
+   "scrypted": {
+      "name": "Sensibo",
+      "type": "DeviceProvider",
+      "interfaces": [
+         "DeviceProvider",
+         "Settings",
+         "Refresh"
+      ]
+   },
+   "devDependencies": {
+      "@scrypted/sdk": "file:../../sdk"
+   },
+   "dependencies": {
+      "@types/node": "^16.6.1",
+      "axios": "^0.24.0"
+   }
+}

--- a/plugins/sensibo/src/api.ts
+++ b/plugins/sensibo/src/api.ts
@@ -1,0 +1,247 @@
+import { TemperatureUnit } from '@scrypted/sdk';
+import axios from 'axios';
+
+/**
+ * Represents the state of the air conditioner,
+ * the valid values for most of these options are enumerated in remoteCapabilities.
+ */
+ export interface AcState {
+    on?: boolean;
+    mode?: string;
+    targetTemperature?: number;
+    /**
+     * 'C' for Celcius or 'F' for Farenheit.
+     */
+    temperatureUnit?: string;
+    fanLevel?: string;
+    swing?: string;
+    horizontalSwing?: string;
+    light?: string;
+}
+
+/**
+ * Configuration options for the 'Climate React' system, which turns the AC on/off when
+ * a certain temperature or humidity threshold is reached.
+ */
+ export interface SmartMode {
+    enabled?: boolean;
+    /**
+     * The type of measurement to monitor, one of "temperature", "humidity" or "feelsLike".
+     */
+    type?: string;
+    /**
+     * The low threshold, acState will be set to lowTemperatureState when the selected sensor
+     * drops below this threshold (despite the name, this value is used for humidity as well).
+     */
+    lowTemperatureThreshold?: number;
+    /**
+     * The high threshold, acState will be set to highTemperatureState when the selected sensor
+     * rises above this threshold (despite the name, this value is used for humidity as well).
+     */
+    highTemperatureThreshold?: number;
+    lowTemperatureState?: AcState;
+    highTemperatureState?: AcState;
+}
+
+/**
+ * Measurements recorded by the sensors in the Sensibo Pod.
+ */
+interface Measurements {
+    temperature?: number;
+    humidity?: number;
+}
+
+/**
+ * Details for the room-level location of the Sensibo Pod.
+ */
+interface Room {
+    name: string;
+}
+
+/**
+ * Set of valid temperature values for a given mode, as supported by the emulated remote.
+ */
+interface TemperatureOptions {
+    isNative?: boolean;
+    values?: number[];
+}
+
+/**
+ * Set of valid configutation options for a given mode, as supported by the emulated remote.
+ */
+interface ModeCapabilities {
+    temperatures?: { [temperatureUnit: string]: TemperatureOptions }
+    fanLevels?: string[];
+    swing?: string[];
+    horizontalSwing?: string[];
+    light?: string[];
+}
+
+/**
+ * Configuration options supported by the emulated remote.
+ */
+interface RemoteCapabilities {
+    modes?: { [mode: string]: ModeCapabilities };
+}
+
+/**
+ * Information about the Sensibo Pod.
+ */
+interface PodInfo {
+    id: string;
+    productModel: string;
+    firmwareType: string;
+    firmwareVersion: string;
+    serial: string;
+    macAddress: string;
+    room: Room;
+    acState: AcState;
+    measurements: Measurements;
+    smartMode: SmartMode;
+    remoteCapabilities: RemoteCapabilities;
+    remoteFlavor: string;
+}
+
+export class SensiboPod {
+    apiKey: string;
+
+    podInfo: PodInfo;
+    // nextAcState acts as a delta on currentAcState, storing only the settings which should be
+    // updated on currentAcState next time the state is pushed - preserving changes made by the
+    // Sensibo app or AC remote.
+    currentAcState: AcState;
+    nextAcState: AcState;
+    // nextSmartMode replaces the whole smartMode configuration if set - reflecting how the smartmode
+    // endpoint works. currentSmartMode will be 'null' if no temperature thresholds are set, since
+    // that's what the API returns when this is the case.
+    currentSmartMode?: SmartMode;
+    nextSmartMode?: SmartMode;
+    measurements: Measurements;
+    remoteFlavor: string;
+
+    constructor(apiKey: string, podInfo: PodInfo) {
+        this.apiKey = apiKey;
+        this.podInfo = podInfo;
+        this.currentAcState = podInfo.acState ?? {} as AcState;
+        this.nextAcState = {} as AcState;
+        this.currentSmartMode = podInfo.smartMode;
+        this.nextSmartMode = null;
+        this.measurements = podInfo.measurements;
+        this.remoteFlavor = podInfo.remoteFlavor;
+    }
+
+    async _pushAcState() : Promise<void> {
+        const delta = this.nextAcState;
+        this.nextAcState = {} as AcState;
+        // Don't push the state delta if it's empty, since any POST request to the API
+        // seems to trigger an IR command from the pod (and beep from the AC) - even if
+        // there's no actual change made to the AC state.
+        if (delta && Object.keys(delta).length === 0) {
+            return;
+        }
+        // I'm assuming here that the POST requests will be sent out in the same order
+        // that axios.post is called, so no locking mechanism is needed to protect this API endpoint.
+        const res = await axios.post(
+            `https://home.sensibo.com/api/v2/pods/${this.podInfo.id}/acStates?apiKey=${this.apiKey}`,
+            { "acState": delta }
+        ).catch(function (error) {
+            if (error.response) {
+                return error.response;
+            } else {
+                console.error(`Error whilst writing pod AcState (No response from server, Message: ${error.message})`);
+                throw error;
+            }
+        });
+        if (!res.data) {
+            console.error(`Error whilst writing pod AcState (Empty response from server, HTTP Status: ${res.status})`);
+        } else if (res.data.status != "success") {
+            console.error(`Error whilst writing pod AcState (HTTP Status: ${res.status}, API Status: ${res.data.status}, Reason: ${res.data.reason}, Message: ${res.data.message})`);
+        }
+    }
+
+    async _pushSmartMode() : Promise<void> {
+        if (!this.nextSmartMode) {
+            return;
+        }
+        const nextSmartMode = this.nextSmartMode;
+        this.nextSmartMode = null;
+        // See the comment on axios.post in _pushAcMode.
+        const res = await axios.post(
+            `https://home.sensibo.com/api/v2/pods/${this.podInfo.id}/smartmode?apiKey=${this.apiKey}`,
+            nextSmartMode
+        ).catch(function (error) {
+            if (error.response) {
+                return error.response;
+            } else {
+                console.error(`Error whilst writing pod SmartMode (No response from server, Message: ${error.message})`);
+                throw error;
+            }
+        });
+        if (!res.data) {
+            console.error(`Error whilst writing pod SmartMode (No response from server, HTTP Status: ${res.status})`);
+        } else if (res.data.status != "success") {
+            console.error(`Error whilst writing pod SmartMode (HTTP Status: ${res.status}, API Status: ${res.data.status}, Reason: ${res.data.reason}, Message: ${res.data.message})`);
+        }
+    }
+
+    async _pullAll() : Promise<void> {
+        const res = await axios.get(
+            `https://home.sensibo.com/api/v2/pods/${this.podInfo.id}?fields=acState,smartMode,measurements,remoteFlavor&apiKey=${this.apiKey}`
+        ).catch(function (error) {
+            if (error.response) {
+                return error.response;
+            } else {
+                console.error(`Error whilst reading pod state (No response from server, Message: ${error.message})`);
+                throw error;
+            }
+        });
+        if (!res.data) {
+            console.error(`Error whilst reading pod state (No response from server, HTTP Status: ${res.status})`);
+            return;
+        } else if (res.data.status != "success") {
+            console.error(`Error whilst reading pod state (HTTP Status: ${res.status}, API Status: ${res.data.status}, Reason: ${res.data.reason}, Message: ${res.data.message})`);
+            return;
+        }
+        this.currentAcState = res.data.result.acState ?? {} as AcState;
+        this.currentSmartMode = res.data.result.smartMode ?? {} as SmartMode;
+        this.measurements = res.data.result.measurements;
+        this.remoteFlavor = res.data.result.remoteFlavor;
+    }
+
+    async sync() : Promise<void> {
+        await this._pushAcState();
+        await this._pushSmartMode();
+        await this._pullAll();
+    }
+}
+
+export class SensiboAPI {
+    apiKey: string;
+
+    constructor(apiKey: string) {
+        this.apiKey = apiKey;
+    }
+
+    async discoverPods() : Promise<SensiboPod[]> {
+        const res = await axios.get(
+            `https://home.sensibo.com/api/v2/users/me/pods?fields=id,productModel,firmwareType,firmwareVersion,serial,macAddress,room,acState,measurements,smartMode,remoteCapabilities,remoteFlavor&apiKey=${this.apiKey}`
+        ).catch(function (error) {
+            if (error.response) {
+                return error.response;
+            } else {
+                console.error(`Error whilst discovering pods (No response from server, Message: ${error.message})`);
+                throw error;
+            }
+        });
+        if (!res.data) {
+            console.error(`Error whilst discovering pods (No response from server, HTTP Status: ${res.status})`);
+            return;
+        } else if (res.data.status != "success") {
+            console.error(`Error whilst discovering pods (HTTP Status: ${res.status}, API Status: ${res.data.status}, Reason: ${res.data.reason}, Message: ${res.data.message})`);
+            return;
+        }
+        // We only support the Sensibo air conditioners, so filter out anything that's not a Sensibo Sky, Air or derivative thereof
+        return res.data.result.filter((podInfo: PodInfo) => podInfo.productModel.includes('sky') || podInfo.productModel.includes('air'))
+            .map((podInfo: PodInfo) => new SensiboPod(this.apiKey, podInfo));
+    }
+}

--- a/plugins/sensibo/src/main.ts
+++ b/plugins/sensibo/src/main.ts
@@ -1,0 +1,416 @@
+import { StorageSettings } from '@scrypted/sdk/storage-settings';
+import sdk, { Device, DeviceInformation, DeviceProvider, HumiditySensor, Refresh, Fan, ScryptedDeviceBase, ScryptedDeviceType, ScryptedInterface, Setting, Settings, TemperatureSetting, TemperatureUnit, Thermometer, ThermostatMode, FanMode, FanState, FanStatus, TemperatureSettingStatus, TemperatureCommand } from '@scrypted/sdk';
+import { SensiboAPI, SensiboPod, SmartMode } from './api';
+
+const { deviceManager } = sdk;
+
+function celsiusToFarenheit(degrees: number): number {
+    return (degrees * 1.8) + 32;
+}
+
+function fahrenheitToCelsius(degrees: number): number {
+    return (degrees - 32) / 1.8;
+}
+
+const sensiboModeToThermostatMode = new Map([
+    ['cool', ThermostatMode.Cool],
+    ['heat', ThermostatMode.Heat],
+    ['fan', ThermostatMode.FanOnly],
+    ['dry', ThermostatMode.Dry],
+    ['auto', ThermostatMode.Auto]
+]);
+
+// Generate an inverse map for sensiboModeToThermostatMode
+const thermostatModeToSensiboMode = new Map<ThermostatMode, string>(
+    Array.from(sensiboModeToThermostatMode).map((entry) => [entry[1], entry[0]])
+);
+
+class SensiboThermostat extends ScryptedDeviceBase implements TemperatureSetting, Thermometer, HumiditySensor, Fan, Refresh, Settings {
+    pod: SensiboPod;
+    storageSettings = new StorageSettings(this, {
+        useSmartMode: {
+            title: 'Map HeatCool to Climate React',
+            key: 'useSmartMode',
+            type: 'boolean',
+            defaultValue: false,
+            description: 'If enabled, HeatCool mode will be provided using the Climate React function of the Sensibo Pod. This will override the existing Climate React configuration.'
+        }
+    });
+    supportedFanSpeeds: string[];
+    useSmartMode: boolean;
+    smartModeConfig: SmartMode;
+    remoteFlavor: string;
+
+    constructor(pod: SensiboPod) {
+        super(pod.podInfo.id);
+        this.pod = pod;
+        this.remoteFlavor = pod.remoteFlavor;
+        this.useSmartMode = this.storageSettings.values.useSmartMode;
+        // Set a default configuration for smartMode, reading defaults from the Sensibo cloud
+        // (if an existing configuration is presentss).
+        this.smartModeConfig = {
+            enabled: false,
+            type: "temperature",
+            lowTemperatureThreshold: this.pod.currentSmartMode?.lowTemperatureThreshold ?? 0,
+            lowTemperatureState: {
+                on: this.pod.currentSmartMode?.lowTemperatureState?.on ?? false,
+                mode: 'heat',
+                targetTemperature: this.pod.currentSmartMode?.lowTemperatureThreshold ?? 0,
+                temperatureUnit: 'C'
+            },
+            highTemperatureThreshold: this.pod.currentSmartMode?.highTemperatureThreshold ?? 0,
+            highTemperatureState: {
+                on: this.pod.currentSmartMode?.highTemperatureState?.on ?? false,
+                mode: 'cool',
+                targetTemperature: this.pod.currentSmartMode?.highTemperatureThreshold ?? 0,
+                temperatureUnit: 'C'
+            }
+        } as SmartMode;
+
+        // Configure supported AC modes based on remoteCapabilities
+        const thermostatAvailableModes = [
+            ThermostatMode.Off,
+            ...Object.entries(this.pod.podInfo.remoteCapabilities.modes).map(
+                ([mode, _]) => sensiboModeToThermostatMode.get(mode)
+            ),
+            // Enable HeatCool mode if control of smartMode is allowed
+            ...(this.useSmartMode ? [ThermostatMode.HeatCool] : [])
+        ];
+
+        this.temperatureSetting = {
+            availableModes: thermostatAvailableModes
+        } as TemperatureSettingStatus;
+
+        // Configure supported fan modes/speeds based on remoteCapabilities
+        // We assume that fan levels are the same for all modes, which may not be true in all cases
+        const fanLevels = Object.entries(this.pod.podInfo.remoteCapabilities.modes)[0][1].fanLevels;
+        this.supportedFanSpeeds = fanLevels.filter((level) => level != 'auto');
+        var availableModes = [];
+        if (this.supportedFanSpeeds.length > 0) {
+            availableModes.push(FanMode.Manual);
+        }
+        if (fanLevels.includes) {
+            availableModes.push(FanMode.Auto);
+        }
+
+        const swingOptions = Object.entries(this.pod.podInfo.remoteCapabilities.modes)[0][1].swing;
+
+        this.fan = {
+            speed: 0,
+            ...(availableModes.length > 0 ? {
+                mode: availableModes[0],
+                availableModes: availableModes,
+                active: false
+            } : {}),
+            maxSpeed: this.supportedFanSpeeds.length - 1,
+            ...(swingOptions?.length > 0 ? {
+                swing: false
+            } : {})
+        } as FanStatus;
+
+        this.updateFromCurrentAcState();
+    }
+
+    async getSettings(): Promise<Setting[]> {
+        return this.storageSettings.getSettings();
+    }
+
+    async putSetting(key: string, value: string | number | boolean) {
+        await this.storageSettings.putSetting(key, value);
+
+        if (key === this.storageSettings.keys.useSmartMode) {
+            this.log.a(`HeatCool mode ${value === true ? 'enabled' : 'disabled'}, the Sensibo plugin will restart momentarily.`);
+            deviceManager.requestRestart();
+        }
+    }
+
+    updateFromCurrentAcState() {
+        // Thermostat interface
+        var nextTemperatureSetting = this.temperatureSetting;
+        if (this.useSmartMode && this.pod.currentSmartMode?.enabled) {
+            nextTemperatureSetting.mode = ThermostatMode.HeatCool;
+            nextTemperatureSetting.activeMode = sensiboModeToThermostatMode.get(this.pod.currentAcState.mode);
+        } else if (this.pod.currentAcState.on) {
+            nextTemperatureSetting.mode = sensiboModeToThermostatMode.get(this.pod.currentAcState.mode);
+            if (nextTemperatureSetting.mode === ThermostatMode.Auto) {
+                // Guess the active mode based on the ambient and target temperatures
+                if (this.pod.measurements.temperature < this.thermostatSetpoint) {
+                    nextTemperatureSetting.activeMode = ThermostatMode.Heat;
+                } else {
+                    nextTemperatureSetting.activeMode = ThermostatMode.Cool;
+                }
+            } else {
+                nextTemperatureSetting.activeMode = this.thermostatMode;
+            }
+        } else {
+            nextTemperatureSetting.mode = ThermostatMode.Off;
+            nextTemperatureSetting.activeMode = this.thermostatMode;
+        }
+
+        if (this.pod.currentAcState.temperatureUnit === 'F') {
+            nextTemperatureSetting.setpoint = fahrenheitToCelsius(this.pod.currentAcState.targetTemperature);
+        } else {
+            nextTemperatureSetting.setpoint = this.pod.currentAcState.targetTemperature;
+        }
+
+        if (this.useSmartMode) {
+            nextTemperatureSetting.setpoint = [
+                this.smartModeConfig.lowTemperatureThreshold,
+                this.smartModeConfig.highTemperatureThreshold
+            ];
+        }
+
+        this.temperatureSetting = nextTemperatureSetting;
+        // Decode temperatureSetting to legacy interface
+        // TODO: Remove when not needed
+        if (Array.isArray(nextTemperatureSetting.setpoint)) {
+            this.thermostatSetpointLow = nextTemperatureSetting.setpoint[0];
+            this.thermostatSetpointHigh = nextTemperatureSetting.setpoint[1];
+        } else {
+            this.thermostatSetpoint = nextTemperatureSetting.setpoint;
+        }
+        this.thermostatMode = nextTemperatureSetting.mode;
+        this.thermostatActiveMode = nextTemperatureSetting.activeMode;
+
+        // Thermometer interface
+        this.temperature = this.pod.measurements.temperature;
+        if (this.pod.currentAcState.temperatureUnit === 'F') {
+            this.temperatureUnit = TemperatureUnit.F;
+        } else {
+            this.temperatureUnit = TemperatureUnit.C;
+        }
+
+        // HumiditySensor interface
+        this.humidity = this.pod.measurements.humidity;
+
+        // Fan interface
+        var nextFan = this.fan;
+        if (this.pod.currentAcState.fanLevel == 'auto') {
+            nextFan.mode = FanMode.Auto;
+        } else {
+            nextFan.mode = FanMode.Manual;
+            nextFan.speed = this.supportedFanSpeeds.indexOf(this.pod.currentAcState.fanLevel);
+        }
+        if (this.pod.currentAcState.swing !== undefined) {
+            nextFan.swing = this.pod.currentAcState.swing != 'stopped';
+        }
+        nextFan.active = this.pod.currentAcState.on;
+        this.fan = nextFan;
+    }
+
+    async _sync() : Promise<void> {
+        if (this.useSmartMode) {
+            this.pod.nextSmartMode = this.smartModeConfig;
+        }
+        await this.pod.sync();
+        if (this.pod.remoteFlavor != this.remoteFlavor) {
+            // Remote type has changed on the Sensibo, reload the plugin
+            this.log.a('The remote emulated by the pod has changed, the Sensibo plugin will restart momentarily.');
+            deviceManager.requestRestart();
+        }
+        this.updateFromCurrentAcState();
+    }
+
+    podUsesFahrenheit() : boolean {
+        if (typeof this.pod.nextAcState.temperatureUnit !== undefined) {
+            return this.pod.nextAcState.temperatureUnit === 'F';
+        } else {
+            return this.pod.currentAcState.temperatureUnit === 'F';
+        }
+    }
+
+    async setTemperature(command: TemperatureCommand): Promise<void> {
+        if (command.mode === ThermostatMode.Off) {
+            this.pod.nextAcState.on = false;
+            this.smartModeConfig.enabled = false;
+        } else if (command.mode === ThermostatMode.HeatCool) {
+            // HeatCool mode is implemented using the SmartMode/'Climate React'
+            // system in the Sensibo Pod, which switches the AC from heat to cool
+            // based on the temperature sensor in the pod.
+            this.pod.nextAcState.on = false;
+            this.smartModeConfig.enabled = true;
+        } else if (command.mode !== undefined) {
+            this.pod.nextAcState.on = true;
+            this.smartModeConfig.enabled = false;
+            this.pod.nextAcState.mode = thermostatModeToSensiboMode.get(command.mode);
+        }
+
+        if (Array.isArray(command.setpoint)) {
+            const [low, high] = command.setpoint;
+            // Note that the temperature thresholds for smart mode are always in degrees Celsius,
+            // so we don't need to adjust them based on the display units. Temperature targets are
+            // in degrees Celsius because we set high/lowTemperatureState.temperatureUnit to degrees
+            // Celsius in the constructor.
+            if (high !== undefined) {
+                this.smartModeConfig.highTemperatureThreshold = high;
+                this.smartModeConfig.highTemperatureState.on = true;
+                this.smartModeConfig.highTemperatureState.targetTemperature = high;
+            }
+            if (low !== undefined) {
+                this.smartModeConfig.lowTemperatureThreshold = low;
+                this.smartModeConfig.lowTemperatureState.on = true;
+                this.smartModeConfig.lowTemperatureState.targetTemperature = low;
+            }
+        } else if (command.setpoint !== undefined) {
+            // The Sensibo API expects temperature to be set in whatever units are
+            // specified by acState.temperatureUnit, but Scrypted uses celsius internally -
+            // so we'll need to translate between celsius and fahrenheit whenever the units
+            // differ.
+            this.pod.nextAcState.targetTemperature =
+                this.podUsesFahrenheit() ? celsiusToFarenheit(command.setpoint) : command.setpoint;
+        }
+
+        await this._sync();
+    }
+
+    async setThermostatMode(mode: ThermostatMode): Promise<void> {
+        return this.setTemperature({mode: mode} as TemperatureCommand);
+    }
+
+    async setThermostatSetpoint(degrees: number): Promise<void> {
+        return this.setTemperature({setpoint: degrees} as TemperatureCommand);
+    }
+
+    async setThermostatSetpointHigh(high: number): Promise<void> {
+        this.setTemperature({setpoint: [undefined, high]} as TemperatureCommand)
+    }
+
+    async setThermostatSetpointLow(low: number): Promise<void> {
+        this.setTemperature({setpoint: [low, undefined]} as TemperatureCommand)
+    }
+
+    async setTemperatureUnit(temperatureUnit: TemperatureUnit): Promise<void> {
+        const wasFahrenheit = this.podUsesFahrenheit();
+        this.pod.nextAcState.temperatureUnit = temperatureUnit === TemperatureUnit.F ? 'F' : 'C';
+        const isFahrenheit = this.podUsesFahrenheit();
+
+        // Convert pending temperature changes to match the new temperature unit
+        if (wasFahrenheit && !isFahrenheit) {
+            if (typeof this.pod.nextAcState.targetTemperature !== undefined) {
+                this.pod.nextAcState.targetTemperature =
+                    fahrenheitToCelsius(this.pod.nextAcState.targetTemperature);
+            }
+        } else if (!wasFahrenheit && isFahrenheit) {
+            if (typeof this.pod.nextAcState.targetTemperature !== undefined) {
+                this.pod.nextAcState.targetTemperature =
+                celsiusToFarenheit(this.pod.nextAcState.targetTemperature);
+            }
+        }
+
+        await this._sync();
+    }
+
+    async setFan(fan: FanState): Promise<void> {
+        if (fan.speed !== undefined || fan.mode === FanMode.Manual) {
+            this.pod.nextAcState.fanLevel = this.supportedFanSpeeds[
+                fan.speed ?? this.fan.speed
+            ];
+        };
+        if (fan.mode === FanMode.Auto) {
+            this.pod.nextAcState.fanLevel = 'auto';
+        }
+
+        if (fan.swing !== undefined) {
+            if (fan.swing) {
+                this.pod.nextAcState.swing = 'rangeFull';
+            } else {
+                this.pod.nextAcState.swing = 'stopped';
+            }
+        }
+
+        await this._sync();
+    }
+
+    async getRefreshFrequency(): Promise<number> {
+        // Apparently Sensibo requested the homebridge plugin set their refresh frequency
+        // to 90 seconds, so we do the same here.
+        return 90;
+    }
+
+    async refresh(refreshInterface: string, userInitiated: boolean): Promise<void> {
+        await this._sync();
+    }
+
+}
+
+class SensiboProvider extends ScryptedDeviceBase implements DeviceProvider, Settings {
+    storageSettings = new StorageSettings(this, {
+        apiKey: {
+            title: 'API Key',
+            key: 'apiKey',
+            description: 'Sensibo Cloud API Key, obtained from https://home.sensibo.com/me/api.'
+        }
+    });
+    devices = new Map<string, any>();
+    api: SensiboAPI;
+
+    constructor(nativeId?: string) {
+        super(nativeId);
+
+        const apiKey = this.storageSettings.values.apiKey;
+        if (apiKey) {
+            this.log.clearAlerts();
+            this.api = new SensiboAPI(apiKey);
+            this.discoverDevices();
+        } else {
+            this.log.a('Enter your API key to connect your Sensibo devices (https://home.sensibo.com/me/api).');
+        }
+    }
+
+    async getSettings(): Promise<Setting[]> {
+        return this.storageSettings.getSettings();
+    }
+
+    async putSetting(key: string, value: string | number | boolean) {
+        await this.storageSettings.putSetting(key, value);
+
+        if (key === this.storageSettings.keys.apiKey) {
+            this.log.a('API key changed, the Sensibo plugin will restart momentarily.');
+            deviceManager.requestRestart();
+        }
+    }
+
+    async discoverDevices() {
+        const pods = await this.api.discoverPods();
+
+        const devices = pods.map(pod => ({
+                nativeId: pod.podInfo.id,
+                name: `${pod.podInfo.room.name} AC`,
+                type: ScryptedDeviceType.Thermostat,
+                interfaces: [
+                    ScryptedInterface.TemperatureSetting,
+                    ScryptedInterface.Thermometer,
+                    ScryptedInterface.HumiditySensor,
+                    ScryptedInterface.Fan,
+                    ScryptedInterface.Refresh,
+                    ScryptedInterface.Settings
+                ],
+                info: {
+                    model: pod.podInfo.productModel,
+                    manufacturer: 'Sensibo',
+                    version: pod.podInfo.firmwareType,
+                    firmware: pod.podInfo.firmwareVersion,
+                    serialNumber: pod.podInfo.serial,
+                    mac: pod.podInfo.macAddress
+                } as DeviceInformation,
+                room: pod.podInfo.room.name
+            } as Device));
+
+        await deviceManager.onDevicesChanged({
+            devices: devices
+        });
+
+        for (const pod of pods) {
+            this.devices.set(pod.podInfo.id, new SensiboThermostat(pod));
+        }
+    }
+
+    async getDevice(nativeId: string) {
+        return this.devices.get(nativeId);
+    }
+
+    async releaseDevice(id: string, nativeId: string): Promise<void> {
+    }
+}
+
+export default SensiboProvider;

--- a/plugins/sensibo/tsconfig.json
+++ b/plugins/sensibo/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES2021",
+        "resolveJsonModule": true,
+        "moduleResolution": "Node16",
+        "esModuleInterop": true,
+        "sourceMap": true
+    },
+    "include": [
+        "src/**/*"
+    ]
+}


### PR DESCRIPTION
Hi,

As I mentioned on Discord a while back, I've been writing a Sensibo plugin that adds basic support for the Sensibo family of 'smart' cloud-based AC controllers. These are effectively IR blasters designed specifically for dumb air conditioners and which can receive and decode commands from the original AC remote to keep the 'smart' cloud-based system in sync with the 'dumb' air conditioner. This plugin is most useful for the Sensibo Sky, as the other Sensibo devices have native HomeKit support.

As the Sensibo devices don't have a local control interface, a Sensibo account and API key are required for use (API keys can be generated at https://home.sensibo.com/me/api).

TODO:
- Support filter cleaning notifications (it doesn't appear to be documented anywhere, but the Thermostat interface does support the 'Filter Life Level' and 'Filter Change Indication' characteristics)
- Test with other Sensibo devices (I only have a Sensibo Sky to test with)

I've implemented both the new TemperatureSetting interface and the original (now deprecated) one, but for HeatCool mode I'm not sure which order to put the high and low set points in the new 'temperatureSetting.setpoint' field.

Please let me know what you think!