### PR TITLE
Remove Node.js additional tools for Windows from Windows install script

### DIFF
--- a/docker/install-scrypted-dependencies-win.ps1
+++ b/docker/install-scrypted-dependencies-win.ps1
@@ -5,9 +5,8 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/in
 # Install node.js
 choco upgrade -y nodejs-lts --version=18.13.0
 
-# Install Node.js additional tools for Windows to compile native modules
-# https://github.com/nodejs/node/blob/main/tools/msvs/install_tools/install_tools.bat#L55
-choco upgrade -y python visualstudio2019-workload-vctools
+# Install Python
+choco upgrade -y python
 
 # Refresh environment variables for py and npx to work
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 


### PR DESCRIPTION
As discussed on Discord, it wasn't obvious if any libraries still required native compilation. https://discord.com/channels/882329362295316500/890705604849594388/1067562780036694156

If not, then we don't have to install the Node.js additional tools for Windows which is required to compile native modules, saving a lot of time in the installation process (since this installs a pandora's box of dependencies).