### PR TITLE
Accomodate custom models

### DIFF
--- a/plugins/coreml/src/coreml/__init__.py
+++ b/plugins/coreml/src/coreml/__init__.py
@@ -18,6 +18,9 @@ def parse_label_contents(contents: str):
             ret[row_number] = content.strip()
     return ret
 
+def list_to_dict(list1):
+    return {i: list1[i] for i in range(len(list1))}
+
 
 MIME_TYPE = 'x-scrypted-coreml/x-raw-image'
 
@@ -33,9 +36,15 @@ class CoreMLPlugin(PredictPlugin, scrypted_sdk.BufferConverter, scrypted_sdk.Set
         self.inputheight = self.inputdesc.type.imageType.height
         self.inputwidth = self.inputdesc.type.imageType.width
 
-        labels_contents = scrypted_sdk.zip.open(
-            'fs/coco_labels.txt').read().decode('utf8')
-        self.labels = parse_label_contents(labels_contents)
+        #If .MLModel contains NMSLabels, fetch it from here instead. 
+        try:
+            stringvector = self.modelspec.pipeline.models[1].nonMaximumSuppression.stringClassLabels.vector
+        except Exception as e:
+            print(e)
+            labels_contents = scrypted_sdk.zip.open('fs/coco_labels.txt').read().decode('utf8')
+            self.labels = parse_label_contents(labels_contents)
+        else:
+            self.labels = list_to_dict(stringvector)
 
     # width, height, channels
     def get_input_details(self) -> Tuple[int, int, int]:
@@ -47,11 +56,11 @@ class CoreMLPlugin(PredictPlugin, scrypted_sdk.BufferConverter, scrypted_sdk.Set
     def detect_once(self, input: Image.Image, settings: Any, src_size, cvss):
         out_dict = self.model.predict({'image': input, 'confidenceThreshold': .2 })
 
-        coordinatesList = out_dict['coordinates']
+        coordinatesList = out_dict['coordinates'].astype(float)
 
         objs = []
 
-        for index, confidenceList in enumerate(out_dict['confidence']):
+        for index, confidenceList in enumerate(out_dict['confidence'].astype(float)):
             values = confidenceList
             maxConfidenceIndex = max(range(len(values)), key=values.__getitem__)
             maxConfidence = confidenceList[maxConfidenceIndex]


### PR DESCRIPTION
Tries to fetch the label list from the mlmodel file itself and due to newer converted mlmodels having a different output (float32) it also numpy converts the model output to floats.