### PR TITLE
Update python cpu reporting

### DIFF
--- a/server/python/plugin-remote.py
+++ b/server/python/plugin-remote.py
@@ -490,7 +490,7 @@ async def async_main(loop: AbstractEventLoop):
                     heapTotal = 0
             stats = {
                 'type': 'stats',
-                'cpuUsage': {
+                'cpu': {
                     'user': ptime,
                     'system': 0,
                 },


### PR DESCRIPTION
The scrypted web ui looks to be reading from `cpu`: https://github.com/koush/scrypted/blob/64f696599c5bd09070e7716976f05404d635d6cf/plugins/core/ui/src/components/plugin/PluginStats.vue#L67 and is being published on the nodejs side as `cpu`: https://github.com/koush/scrypted/blob/227b287f1ee19f354a9174b8aef8bf475fe42efe/server/src/plugin/plugin-remote-worker.ts#L21

Might need to change this as well?
https://github.com/koush/scrypted/blob/cc43273f3417000ebe05fc22de75ae9faeddc07b/server/src/plugin/plugin-host.ts#L59