### PR TITLE
prebuffer: allow battery-powered cameras to prebuffer if they have external power applied

### DIFF
--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -1469,7 +1469,7 @@ class PrebufferMixin extends SettingsMixinDeviceBase<VideoCamera> implements Vid
       }
     }
 
-    const isBatteryPowered = this.mixinDeviceInterfaces.includes(ScryptedInterface.Battery) && !this?.externallyPowered;
+    const isBatteryPowered = this.mixinDeviceInterfaces.includes(ScryptedInterface.Battery) && !this.externallyPowered;
 
     if (!enabledIds.length)
       this.online = true;

--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -1469,7 +1469,7 @@ class PrebufferMixin extends SettingsMixinDeviceBase<VideoCamera> implements Vid
       }
     }
 
-    const isBatteryPowered = this.mixinDeviceInterfaces.includes(ScryptedInterface.Battery);
+    const isBatteryPowered = this.mixinDeviceInterfaces.includes(ScryptedInterface.Battery) && !this?.externallyPowered;
 
     if (!enabledIds.length)
       this.online = true;

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -660,6 +660,7 @@ class AudioSensor:
 
 class Battery:
     batteryLevel: float
+    externallyPowered: bool
     pass
 
 class BinarySensor:
@@ -1266,6 +1267,7 @@ class ScryptedInterfaceProperty(Enum):
     lockState = "lockState"
     entryOpen = "entryOpen"
     batteryLevel = "batteryLevel"
+    externallyPowered = "externallyPowered"
     online = "online"
     fromMimeType = "fromMimeType"
     toMimeType = "toMimeType"
@@ -1541,6 +1543,13 @@ class DeviceState:
     @batteryLevel.setter
     def batteryLevel(self, value: float):
         self.setScryptedProperty("batteryLevel", value)
+
+    @property
+    def externallyPowered(self) -> bool:
+        return self.getScryptedProperty("externallyPowered")
+    @externallyPowered.setter
+    def externallyPowered(self, value: bool):
+        self.setScryptedProperty("externallyPowered", value)
 
     @property
     def online(self) -> bool:
@@ -2016,7 +2025,8 @@ ScryptedInterfaceDescriptors = {
     "name": "Battery",
     "methods": [],
     "properties": [
-      "batteryLevel"
+      "batteryLevel",
+      "externallyPowered"
     ]
   },
   "Refresh": {

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -954,7 +954,16 @@ export interface DeviceDiscovery {
  * Battery retrieves the battery level of battery powered devices.
  */
 export interface Battery {
+  /**
+   * The current battery level of the device, from 0% to 100%.
+   */
   batteryLevel?: number;
+
+  /** 
+   * Set this to true if this battery-powered device is currently using an external power source (e.g. AC, solar).
+   * This will allow for prebuffering on devices that contain a battery.
+   */
+  externallyPowered?: boolean;
 }
 /**
  * Refresh indicates that this device has properties that are not automatically updated, and must be periodically refreshed via polling. Device implementations should never implement their own underlying polling algorithm, and instead implement Refresh to allow Scrypted to manage polling intelligently.


### PR DESCRIPTION
This is a small change to allow cameras to implement the `Battery` interface, but still be able to prebuffer if they are plugged in. This allows battery levels to continue to be reported to Scrypted when plugged in, which is useful while charging battery-powered cameras. It also prevents having to change the interfaces that a device implements when a power source changes, which causes problems when switching power sources and the camera is streaming.