### PR TITLE
fix ring alarm state when changing modes

### DIFF
--- a/plugins/ring/src/main.ts
+++ b/plugins/ring/src/main.ts
@@ -699,8 +699,9 @@ export class RingLocationDevice extends ScryptedDeviceBase implements DeviceProv
                     updateLocationMode(response.mode);
                 });
             });
-        }).catch(_ => {
-            this.console.warn(`no security panel found, updates will not be recieved on this subscription`)
+        }).catch(error => {
+            // could not find a security panel for location
+            // not logging this error as it is a valid case to not have a security panel
         });
 
         if (location.hasAlarmBaseStation) {

--- a/plugins/ring/src/main.ts
+++ b/plugins/ring/src/main.ts
@@ -690,6 +690,18 @@ export class RingLocationDevice extends ScryptedDeviceBase implements DeviceProv
             }
         }
         location.onLocationMode.subscribe(updateLocationMode);
+        
+        // if the location has a base station, updates when arming/disarming are not sent to the `onLocationMode` subscription
+        // instead we subscribe to the security panel, which is updated during arming actions
+        location.getSecurityPanel().then(panel => {
+            panel.onData.subscribe(_ => { 
+                location.getLocationMode().then(response => {
+                    updateLocationMode(response.mode);
+                });
+            });
+        }).catch(_ => {
+            this.console.warn(`no security panel found, updates will not be recieved on this subscription`)
+        });
 
         if (location.hasAlarmBaseStation) {
             location.getLocationMode().then(response => {


### PR DESCRIPTION
I have no idea what is being done in homebridge, but this solution I came up with definitely works for me.
I did find that the `location.onLocationMode.subscribe` is explicitly **not** used if the location has a base station, which my location does. It's possible we might be over updating the location mode with this change for some users if they don't have a base station and also have a security panel, but it wasn't updating at all previously for my very simple ring setup. I'm also not sure what type of ring location doesn't have a base station but still can be armed, that part is a little confusing.