### PR TITLE
ring: added night mode support to arm with sensor bypass

### DIFF
--- a/plugins/homekit/package.json
+++ b/plugins/homekit/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/homekit",
-   "version": "1.2.11",
+   "version": "1.2.12",
    "description": "HomeKit Plugin for Scrypted",
    "scripts": {
       "scrypted-setup-project": "scrypted-setup-project",

--- a/plugins/homekit/src/types/garage.ts
+++ b/plugins/homekit/src/types/garage.ts
@@ -22,9 +22,6 @@ addSupportedType({
 
         let targetState = !!device.entryOpen ? Characteristic.TargetDoorState.OPEN : Characteristic.TargetDoorState.CLOSED;
         service.getCharacteristic(Characteristic.TargetDoorState)
-            .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-                callback(null, targetState);
-            })
             .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
                 callback();
                 if (value === Characteristic.TargetDoorState.OPEN) {

--- a/plugins/homekit/src/types/security.ts
+++ b/plugins/homekit/src/types/security.ts
@@ -28,8 +28,6 @@ addSupportedType({
 
             return modes;
         }
-        service.getCharacteristic(Characteristic.SecuritySystemTargetState)
-        .setProps({validValues: systemStates(device.securitySystemState?.supportedModes)});
 
         function toCurrentState(mode: SecuritySystemMode, triggered: boolean) {
             if (!!triggered)
@@ -78,6 +76,7 @@ addSupportedType({
             () => toTargetState(device.securitySystemState?.mode));
 
         service.getCharacteristic(Characteristic.SecuritySystemTargetState)
+        .setProps({validValues: systemStates(device.securitySystemState?.supportedModes)})
         .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
             callback();
             const targetValue = fromTargetState(value as number);

--- a/plugins/homekit/src/types/windowcovering.ts
+++ b/plugins/homekit/src/types/windowcovering.ts
@@ -28,9 +28,6 @@ addSupportedType({
         let targetState = !!device.entryOpen ? 100 : 0;
         service.getCharacteristic(Characteristic.TargetPosition)
             .setProps(props)
-            .on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
-                callback(null, targetState);
-            })
             .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
                 callback();
                 if (value === 100) {

--- a/plugins/ring/package.json
+++ b/plugins/ring/package.json
@@ -44,5 +44,5 @@
       "got": "11.8.2",
       "socket.io-client": "^2.4.0"
    },
-   "version": "0.0.94"
+   "version": "0.0.95"
 }


### PR DESCRIPTION
closes https://github.com/koush/scrypted/issues/482

This PR also fixes two unrelated warnings I noticed in the homekit logs for the garage and window covering type. The following was not needed as we already call `bindCharacteristic`
```
service.getCharacteristic(Characteristic.TargetDoorState)
.on(CharacteristicEventTypes.GET, (callback: NodeCallback<CharacteristicValue>) => {
    callback(null, targetState);
})
```
