### PR TITLE
homekit: merge SecuritySystem & child Sirens as one Homekit accessory

### DIFF
--- a/plugins/homekit/src/main.ts
+++ b/plugins/homekit/src/main.ts
@@ -184,12 +184,17 @@ export class HomeKitPlugin extends ScryptedDeviceBase implements MixinProvider, 
         }
 
         const plugins = await systemManager.getComponent('plugins');
-
         const accessoryIds = new Set<string>();
-
         const deviceIds = Object.keys(systemManager.getSystemState());
+
+        // when creating accessories in order, some DeviceProviders may merge in
+        // their child devices (and report back which devices are merged via
+        // this.mergedDevices)
+        // we need to ensure that the iteration processes DeviceProviders before
+        // their children, so a reordering is necessary
         const reorderedDeviceIds = reorderDevicesByProvider(deviceIds);
         if (deviceIds.length !== reorderedDeviceIds.length) {
+            // safety check in case something went wrong
             throw Error(`error in device reordering, expected ${deviceIds.length} devices but only got ${reorderedDeviceIds.length}!`);
         }
 

--- a/plugins/homekit/src/main.ts
+++ b/plugins/homekit/src/main.ts
@@ -193,9 +193,15 @@ export class HomeKitPlugin extends ScryptedDeviceBase implements MixinProvider, 
         // we need to ensure that the iteration processes DeviceProviders before
         // their children, so a reordering is necessary
         const reorderedDeviceIds = reorderDevicesByProvider(deviceIds);
+
+        // safety checks in case something went wrong
         if (deviceIds.length !== reorderedDeviceIds.length) {
-            // safety check in case something went wrong
             throw Error(`error in device reordering, expected ${deviceIds.length} devices but only got ${reorderedDeviceIds.length}!`);
+        }
+        const uniqueDeviceIds = new Set<string>(deviceIds);
+        const uniqueReorderedIds = new Set<string>(reorderedDeviceIds);
+        if (uniqueDeviceIds.size !== uniqueReorderedIds.size) {
+            throw Error(`error in device reordering, expected ${uniqueDeviceIds.size} unique devices but only got ${uniqueReorderedIds.size} entries!`);
         }
 
         for (const id of reorderedDeviceIds) {

--- a/plugins/homekit/src/types/common.ts
+++ b/plugins/homekit/src/types/common.ts
@@ -1,14 +1,21 @@
-import sdk, { Fan, AirQuality, AirQualitySensor, CO2Sensor, NOXSensor, PM10Sensor, PM25Sensor, ScryptedDevice, ScryptedInterface, VOCSensor, FanMode, OnOff } from "@scrypted/sdk";
+import sdk, { Fan, AirQuality, AirQualitySensor, CO2Sensor, NOXSensor, PM10Sensor, PM25Sensor, ScryptedDevice, ScryptedInterface, VOCSensor, FanMode, OnOff, DeviceProvider, ScryptedDeviceType } from "@scrypted/sdk";
 import { bindCharacteristic } from "../common";
 import { Accessory, Characteristic, CharacteristicEventTypes, Service, uuid } from '../hap';
 import type { HomeKitPlugin } from "../main";
+import { getService as getOnOffService } from "./onoff-base";
 
-const { deviceManager } = sdk;
+const { deviceManager, systemManager } = sdk;
 
 export function makeAccessory(device: ScryptedDevice, homekitPlugin: HomeKitPlugin, suffix?: string): Accessory {
     const mixinStorage = deviceManager.getMixinStorage(device.id, homekitPlugin.nativeId);
     const resetId = mixinStorage.getItem('resetAccessory') || '';
     return new Accessory(device.name, uuid.generate(resetId + device.id + (suffix ? '-' + suffix : '')));
+}
+
+export function getChildDevices(device: ScryptedDevice & DeviceProvider): ScryptedDevice[] {
+    const ids = Object.keys(systemManager.getSystemState());
+    const allDevices = ids.map(id => systemManager.getDeviceById(id));
+    return allDevices.filter(d => d.providerId == device.id);
 }
 
 export function addAirQualitySensor(device: ScryptedDevice & AirQualitySensor & PM10Sensor & PM25Sensor & VOCSensor & NOXSensor, accessory: Accessory): Service {
@@ -34,7 +41,7 @@ export function addAirQualitySensor(device: ScryptedDevice & AirQualitySensor & 
     const airQualityService = accessory.addService(Service.AirQualitySensor);
     bindCharacteristic(device, ScryptedInterface.AirQualitySensor, airQualityService, Characteristic.AirQuality,
         () => airQualityToHomekit(device.airQuality));
-    
+
     if (device.interfaces.includes(ScryptedInterface.PM10Sensor)) {
         bindCharacteristic(device, ScryptedInterface.PM10Sensor, airQualityService, Characteristic.PM10Density,
             () => device.pm10Density || 0);
@@ -157,4 +164,32 @@ export function addFan(device: ScryptedDevice & Fan & OnOff, accessory: Accessor
     }
 
     return service;
+}
+
+/*
+ * addChildSirens looks for siren-type child devices of the given device provider
+ * and merges them as switches to the accessory represented by the device provider.
+ *
+ * Returns the services created as well as all of the child siren devices which have
+ * been merged.
+ */
+export function addChildSirens(device: ScryptedDevice & DeviceProvider, accessory: Accessory): { services: Service[], devices: (ScryptedDevice & OnOff)[] } {
+    if (!device.interfaces.includes(ScryptedInterface.DeviceProvider))
+        return undefined;
+
+    const children = getChildDevices(device);
+    const sirenDevices = [];
+    const services = children.map((child: ScryptedDevice & OnOff) => {
+        if (child.type !== ScryptedDeviceType.Siren || !child.interfaces.includes(ScryptedInterface.OnOff))
+            return undefined;
+
+        const onOffService = getOnOffService(child, accessory, Service.Switch)
+        sirenDevices.push(child);
+        return onOffService;
+    });
+
+    return {
+        services: services.filter(service => !!service),
+        devices: sirenDevices,
+    };
 }

--- a/plugins/homekit/src/types/onoff-base.ts
+++ b/plugins/homekit/src/types/onoff-base.ts
@@ -8,9 +8,7 @@ export function probe(device: DummyDevice): boolean {
     return device.interfaces.includes(ScryptedInterface.OnOff);
 }
 
-export function getAccessory(device: ScryptedDevice & OnOff, homekitPlugin: HomeKitPlugin, serviceType: any): { accessory: Accessory, service: Service } | undefined {
-    const accessory = makeAccessory(device, homekitPlugin);
-
+export function getService(device: ScryptedDevice & OnOff, accessory: Accessory, serviceType: any): Service {
     const service = accessory.addService(serviceType, device.name);
     service.getCharacteristic(Characteristic.On)
         .on(CharacteristicEventTypes.SET, (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
@@ -22,7 +20,12 @@ export function getAccessory(device: ScryptedDevice & OnOff, homekitPlugin: Home
         })
 
     bindCharacteristic(device, ScryptedInterface.OnOff, service, Characteristic.On, () => !!device.on);
+    return service;
+}
 
+export function getAccessory(device: ScryptedDevice & OnOff, homekitPlugin: HomeKitPlugin, serviceType: any): { accessory: Accessory, service: Service } | undefined {
+    const accessory = makeAccessory(device, homekitPlugin);
+    const service = getService(device, accessory, serviceType);
     return {
         accessory,
         service,

--- a/plugins/homekit/src/util.ts
+++ b/plugins/homekit/src/util.ts
@@ -3,9 +3,10 @@ import sdk, { ScryptedInterface } from '@scrypted/sdk';
 const { systemManager } = sdk;
 
 /*
- * flattenDeviceTree uses BFS to traverse the given device mapping
- * and produce a list of device ids. deviceId is the node of the tree
- * currently being processed, where null is the root of the tree.
+ * flattenDeviceTree performs a modified DFS tree traversal of the given
+ * device mapping to produce a list of device ids. deviceId is the node
+ * of the tree currently being processed, where null is the root of the
+ * tree.
  */
 function flattenDeviceTree(deviceMap: Map<string, string[]>, deviceId: string): string[] {
     const result: string[] = [];

--- a/plugins/homekit/src/util.ts
+++ b/plugins/homekit/src/util.ts
@@ -1,0 +1,41 @@
+import sdk, { ScryptedInterface } from '@scrypted/sdk';
+
+const { systemManager } = sdk;
+
+/*
+ * flattenDeviceTree uses BFS to traverse the given device mapping
+ * and produce a list of device ids. deviceId is the node of the tree
+ * currently being processed, where null is the root of the tree.
+ */
+function flattenDeviceTree(deviceMap: Map<string, string[]>, deviceId: string): string[] {
+    const result: string[] = [];
+    if (!deviceMap.has(deviceId)) // no children
+        return result;
+
+    const children = deviceMap.get(deviceId);
+    result.push(...children);
+    children.map(child =>  result.push(...flattenDeviceTree(deviceMap, child)))
+    return result;
+}
+
+/*
+ * reorderDevicesByProvider returns a new ordering of the provided deviceIds
+ * where it is guaranteed that DeviceProviders are listed before their children.
+ */
+export function reorderDevicesByProvider(deviceIds: string[]): string[] {
+    const providerDeviceIdMap = new Map<string, string[]>();
+
+    deviceIds.map(deviceId => {
+        const device = systemManager.getDeviceById(deviceId);
+
+        // when provider id is equal to device id, this is a root-level device/plugin
+        const providerId = device.providerId !== device.id ? device.providerId : null;
+        if (providerDeviceIdMap.has(providerId)) {
+            providerDeviceIdMap.get(providerId).push(device.id);
+        } else {
+            providerDeviceIdMap.set(providerId, [device.id]);
+        }
+    });
+
+    return flattenDeviceTree(providerDeviceIdMap, null);
+}


### PR DESCRIPTION
This exposes the Scrypted OnOff interface to Homekit's SecuritySystem as a Switch. The Homekit UI will now show both the Arm/Disarm selector as well as the switch.

The intended use is for Arlo's basestation siren to emulate an arm/disarm to reduce the risk of being accidentally toggled.