### PR TITLE
actions: tests for platform-specific install scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test_linux_local:
+    name: Test Linux local installation
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Run install script
+        run: |
+          cat ./docker/install-scrypted-dependencies-linux.sh | sudo SERVICE_USER=$USER bash
+          
+      - name: Test server is running
+        run: |
+          curl -k https://localhost:10443/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Test server is running
         run: |
           systemctl status scrypted.service
-          curl -k --connect-timeout 300 https://localhost:10443/
+          curl -k --retry 20 --retry-connrefused --retry-max-time 600 https://localhost:10443/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,4 @@ jobs:
       - name: Test server is running
         run: |
           systemctl status scrypted.service
-          journalctl -u scrypted.service --no-pager
-          curl -k https://localhost:10443/
+          curl -k --connect-timeout 300 https://localhost:10443/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,6 @@ jobs:
           
       - name: Test server is running
         run: |
+          systemctl status scrypted.service
+          journalctl -u scrypted.service --no-pager
           curl -k https://localhost:10443/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
   pull_request:
   workflow_dispatch:
-
+  
 jobs:
   test_linux_local:
     name: Test Linux local installation
@@ -22,4 +22,37 @@ jobs:
       - name: Test server is running
         run: |
           systemctl status scrypted.service
-          curl -k --retry 20 --retry-connrefused --retry-max-time 600 https://localhost:10443/
+          curl -k --retry 20 --retry-all-errors --retry-max-time 600 https://localhost:10443/
+          
+  test_mac_local:
+    name: Test Mac local installation
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Run install script
+        run: |
+          mkdir -p ~/.scrypted
+          bash ./docker/install-scrypted-dependencies-mac.sh
+          
+      - name: Test server is running
+        run: |
+          curl -k --retry 20 --retry-all-errors --retry-max-time 600 https://localhost:10443/
+          
+  test_windows_local:
+    name: Test Windows local installation
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Run install script
+        run: |
+          .\docker\install-scrypted-dependencies-win.ps1
+          
+      - name: Test server is running
+        run: |
+          curl -k --retry 20 --retry-all-errors --retry-max-time 600 https://localhost:10443/

--- a/docker/install-scrypted-dependencies-linux.sh
+++ b/docker/install-scrypted-dependencies-linux.sh
@@ -64,6 +64,8 @@ fi
 
 # this is not RUN as we do not care about the result
 USER_HOME=$(eval echo ~$SERVICE_USER)
+echo "Creating $USER_HOME/.scrypted if it does not exist"
+mkdir -p $USER_HOME/.scrypted
 echo "Setting permissions on $USER_HOME/.scrypted"
 chown -R $SERVICE_USER $USER_HOME/.scrypted
 
@@ -89,8 +91,6 @@ Environment="NODE_OPTIONS=$NODE_OPTIONS"
 WantedBy=multi-user.target
 
 EOT
-
-set -x
 
 RUN systemctl daemon-reload
 RUN systemctl enable scrypted.service

--- a/docker/install-scrypted-dependencies-linux.sh
+++ b/docker/install-scrypted-dependencies-linux.sh
@@ -64,8 +64,6 @@ fi
 
 # this is not RUN as we do not care about the result
 USER_HOME=$(eval echo ~$SERVICE_USER)
-echo "Creating $USER_HOME/.scrypted if it does not exist"
-mkdir -p $USER_HOME/.scrypted
 echo "Setting permissions on $USER_HOME/.scrypted"
 chown -R $SERVICE_USER $USER_HOME/.scrypted
 

--- a/docker/install-scrypted-dependencies-linux.sh
+++ b/docker/install-scrypted-dependencies-linux.sh
@@ -18,7 +18,7 @@ systemctl stop scrypted.service
 # bad hack to run a dockerfile like a shell script.
 
 RUN() {
-    echo "Running: $@"
+    # echo "Running: $@"
     $@
     if [ $? -ne 0 ]
     then
@@ -89,6 +89,8 @@ Environment="NODE_OPTIONS=$NODE_OPTIONS"
 WantedBy=multi-user.target
 
 EOT
+
+set -x
 
 RUN systemctl daemon-reload
 RUN systemctl enable scrypted.service

--- a/docker/install-scrypted-dependencies-linux.sh
+++ b/docker/install-scrypted-dependencies-linux.sh
@@ -18,7 +18,7 @@ systemctl stop scrypted.service
 # bad hack to run a dockerfile like a shell script.
 
 RUN() {
-    # echo "Running: $@"
+    echo "Running: $@"
     $@
     if [ $? -ne 0 ]
     then


### PR DESCRIPTION
I'm open to discussing whether or not something like this would be useful to have in general, but I figured it could be helpful to kick off a set of tests to verify scrypted installs on different platforms.

Right now this only tests the installation, but I intend to add more functional testing, including installing plugins that need system dependencies.