### PR TITLE
Enable ipv6 for avahi

### DIFF
--- a/docker/fs/etc/avahi/avahi-daemon.conf
+++ b/docker/fs/etc/avahi/avahi-daemon.conf
@@ -1,7 +1,7 @@
 [server]
 #host-name=
 use-ipv4=yes
-use-ipv6=no
+use-ipv6=yes
 enable-dbus=yes
 ratelimit-interval-usec=1000000
 ratelimit-burst=1000


### PR DESCRIPTION
Enable ipv6 for avahi to allow multiple mdns server on one host