### PR TITLE
zwave: Fix entry sensor position mapping

### DIFF
--- a/plugins/zwave/src/CommandClasses/EntrySensorToBarrierOperator.ts
+++ b/plugins/zwave/src/CommandClasses/EntrySensorToBarrierOperator.ts
@@ -1,25 +1,19 @@
 import { EntrySensor } from "@scrypted/sdk";
 import type { ValueID } from "@zwave-js/core";
-import { BarrierState } from "zwave-js";
 import { ZwaveDeviceBase } from "./ZwaveDeviceBase";
 
 export class EntrySensorToBarriorOperator extends ZwaveDeviceBase implements EntrySensor {
     static updateState(zwaveDevice: ZwaveDeviceBase, valueId: ValueID) {
-        let currentValue: BarrierState
+        let currentValue: number;
         currentValue = zwaveDevice.getValue(valueId);
 
         switch (currentValue) {
-            case BarrierState.Closed:
+            case 0:
                 zwaveDevice.entryOpen = false;
                 break;
-            case BarrierState.Closing:
-            case BarrierState.Opening:
-            case BarrierState.Open:
-            case BarrierState.Stopped:
+            case 100:
                 zwaveDevice.entryOpen = true;
                 break;
-            default:
-                zwaveDevice.entryOpen = false;
         }
     }
 }

--- a/plugins/zwave/src/CommandClasses/EntryToBarrierOperator.ts
+++ b/plugins/zwave/src/CommandClasses/EntryToBarrierOperator.ts
@@ -15,7 +15,7 @@ export class EntryToBarrierOperator extends ZwaveDeviceBase implements Entry {
         this.entryOpen = (await cc.get()).currentState !== BarrierState.Closed;
     }
     static updateState(zwaveDevice: ZwaveDeviceBase, valueId: ValueID) {
-        zwaveDevice.entryOpen = zwaveDevice.getValue(valueId) !== 'Closed';
+        zwaveDevice.entryOpen = zwaveDevice.getValue(valueId) !== BarrierState.Closed;
     }
 }
 


### PR DESCRIPTION
I kept the sensor, and used the position to determine open or closed, this leaves open the possibility to have partial openings if required later (blinds do this). Also means the UI does not need to change since the sensor is still around.

Also corrected a mapping issue with the EntryToBarrier updateState method