### PR TITLE
dummy-device: mock device for Battery and Charger

### DIFF
--- a/plugins/dummy-device/.gitignore
+++ b/plugins/dummy-device/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+out/
+node_modules/
+dist/
+.venv

--- a/plugins/dummy-device/.npmignore
+++ b/plugins/dummy-device/.npmignore
@@ -1,0 +1,10 @@
+.DS_Store
+out/
+node_modules/
+*.map
+fs
+src
+.vscode
+dist/*.js
+dist/*.txt
+__pycache__

--- a/plugins/dummy-device/.vscode/launch.json
+++ b/plugins/dummy-device/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Scrypted Debugger",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "${config:scrypted.debugHost}",
+                "port": 10081
+            },
+            "justMyCode": false,
+            "preLaunchTask": "scrypted: deploy+debug",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/../../server/python/",
+                    "remoteRoot": "${config:scrypted.serverRoot}/python",
+                },
+                {
+                    "localRoot": "${workspaceFolder}/src",
+                    "remoteRoot": "${config:scrypted.volumeRoot}/plugin.zip"
+                },
+
+            ]
+        }
+    ]
+}

--- a/plugins/dummy-device/.vscode/settings.json
+++ b/plugins/dummy-device/.vscode/settings.json
@@ -1,0 +1,27 @@
+
+{
+    // specify the following paths on the target scrypted server:
+    // 1) where @scrypted/server node module resides: this may either be a checkout or a install.
+    // 2) where the scrypted "volume" data is located on the server. ie, the docker volume.
+    // the following default examples are provided for local and docker installations,
+    // only modifying the debugHost should be necessary:
+
+    // local installation
+    // "scrypted.debugHost": "192.168.2.119",
+    // "scrypted.serverRoot": "/home/pi/.scrypted/node_modules/@scrypted/server",
+    // "scrypted.volumeRoot": "/home/pi/.scrypted/volume",
+
+    // docker installation
+    // "scrypted.debugHost": "192.168.2.109",
+    "scrypted.serverRoot": "/server/node_modules/@scrypted/server",
+    "scrypted.volumeRoot": "/server/volume",
+
+    // local checkout
+    "scrypted.debugHost": "127.0.0.1",
+    //"scrypted.serverRoot": "/Volumes/Dev/scrypted/server",
+    //"scrypted.volumeRoot": "${config:scrypted.serverRoot}/volume",
+
+    "python.analysis.extraPaths": [
+        "./node_modules/@scrypted/sdk/types/scrypted_python"
+    ]
+}

--- a/plugins/dummy-device/.vscode/tasks.json
+++ b/plugins/dummy-device/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "scrypted: deploy+debug",
+            "type": "shell",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "command": "npm run scrypted-vscode-launch ${config:scrypted.debugHost}",
+        },
+    ]
+}

--- a/plugins/dummy-device/README.md
+++ b/plugins/dummy-device/README.md
@@ -1,0 +1,5 @@
+# Dummy Devices
+
+## Usage
+
+This dummy device plugin lets you create dummy devices that implement various Scrypted interfaces using manually-configured data.

--- a/plugins/dummy-device/package-lock.json
+++ b/plugins/dummy-device/package-lock.json
@@ -1,0 +1,83 @@
+{
+   "name": "@scrypted/dummy-device",
+   "version": "0.0.1",
+   "lockfileVersion": 2,
+   "requires": true,
+   "packages": {
+      "": {
+         "name": "@scrypted/dummy-device",
+         "version": "0.0.1",
+         "devDependencies": {
+            "@scrypted/sdk": "file:../../sdk"
+         }
+      },
+      "../../sdk": {
+         "name": "@scrypted/sdk",
+         "version": "0.2.97",
+         "dev": true,
+         "license": "ISC",
+         "dependencies": {
+            "@babel/preset-typescript": "^7.18.6",
+            "adm-zip": "^0.4.13",
+            "axios": "^0.21.4",
+            "babel-loader": "^9.1.0",
+            "babel-plugin-const-enum": "^1.1.0",
+            "esbuild": "^0.15.9",
+            "ncp": "^2.0.0",
+            "raw-loader": "^4.0.2",
+            "rimraf": "^3.0.2",
+            "tmp": "^0.2.1",
+            "ts-loader": "^9.4.2",
+            "typescript": "^4.9.4",
+            "webpack": "^5.75.0",
+            "webpack-bundle-analyzer": "^4.5.0"
+         },
+         "bin": {
+            "scrypted-changelog": "bin/scrypted-changelog.js",
+            "scrypted-debug": "bin/scrypted-debug.js",
+            "scrypted-deploy": "bin/scrypted-deploy.js",
+            "scrypted-deploy-debug": "bin/scrypted-deploy-debug.js",
+            "scrypted-package-json": "bin/scrypted-package-json.js",
+            "scrypted-setup-project": "bin/scrypted-setup-project.js",
+            "scrypted-webpack": "bin/scrypted-webpack.js"
+         },
+         "devDependencies": {
+            "@types/node": "^18.11.18",
+            "@types/stringify-object": "^4.0.0",
+            "stringify-object": "^3.3.0",
+            "ts-node": "^10.4.0",
+            "typedoc": "^0.23.21"
+         }
+      },
+      "node_modules/@scrypted/sdk": {
+         "resolved": "../../sdk",
+         "link": true
+      }
+   },
+   "dependencies": {
+      "@scrypted/sdk": {
+         "version": "file:../../sdk",
+         "requires": {
+            "@babel/preset-typescript": "^7.18.6",
+            "@types/node": "^18.11.18",
+            "@types/stringify-object": "^4.0.0",
+            "adm-zip": "^0.4.13",
+            "axios": "^0.21.4",
+            "babel-loader": "^9.1.0",
+            "babel-plugin-const-enum": "^1.1.0",
+            "esbuild": "^0.15.9",
+            "ncp": "^2.0.0",
+            "raw-loader": "^4.0.2",
+            "rimraf": "^3.0.2",
+            "stringify-object": "^3.3.0",
+            "tmp": "^0.2.1",
+            "ts-loader": "^9.4.2",
+            "ts-node": "^10.4.0",
+            "typedoc": "^0.23.21",
+            "typescript": "^4.9.4",
+            "webpack": "^5.75.0",
+            "webpack-bundle-analyzer": "^4.5.0"
+         }
+      }
+   }
+}

--- a/plugins/dummy-device/package.json
+++ b/plugins/dummy-device/package.json
@@ -1,0 +1,38 @@
+{
+   "name": "@scrypted/dummy-device",
+   "version": "0.0.1",
+   "description": "Scrypted Dummy Device Plugin",
+   "keywords": [
+      "scrypted",
+      "plugin",
+      "dummy",
+      "device"
+   ],
+   "scripts": {
+      "scrypted-setup-project": "scrypted-setup-project",
+      "prescrypted-setup-project": "scrypted-package-json",
+      "build": "scrypted-webpack",
+      "prepublishOnly": "NODE_ENV=production scrypted-webpack",
+      "prescrypted-vscode-launch": "scrypted-webpack",
+      "scrypted-vscode-launch": "scrypted-deploy-debug",
+      "scrypted-deploy-debug": "scrypted-deploy-debug",
+      "scrypted-debug": "scrypted-debug",
+      "scrypted-deploy": "scrypted-deploy",
+      "scrypted-readme": "scrypted-readme",
+      "scrypted-package-json": "scrypted-package-json"
+   },
+   "scrypted": {
+      "name": "Dummy Device Plugin",
+      "runtime": "python",
+      "type": "DeviceProvider",
+      "interfaces": [
+         "DeviceProvider",
+         "DeviceCreator"
+      ],
+      "pluginDependencies": [
+      ]
+   },
+   "devDependencies": {
+      "@scrypted/sdk": "file:../../sdk"
+   }
+}

--- a/plugins/dummy-device/src/dummy/__init__.py
+++ b/plugins/dummy-device/src/dummy/__init__.py
@@ -1,0 +1,1 @@
+from .plugin import DummyDevicePlugin

--- a/plugins/dummy-device/src/dummy/device.py
+++ b/plugins/dummy-device/src/dummy/device.py
@@ -4,18 +4,9 @@ import scrypted_sdk
 from scrypted_sdk import ScryptedDeviceBase
 from scrypted_sdk.types import (
     ScryptedInterface,
-    ScryptedDeviceType,
-    MediaObject,
-    FFmpegInput,
     Settings,
     Setting,
     SettingValue,
-    Camera,
-    ResponsePictureOptions,
-    RequestPictureOptions,
-    VideoCamera,
-    ResponseMediaStreamOptions,
-    RequestMediaStreamOptions,
     Battery,
     Charger,
     ChargeState,
@@ -23,25 +14,12 @@ from scrypted_sdk.types import (
 
 
 SUPPORTED_INTERFACES = [
-    ScryptedInterface.Camera.value,
-    ScryptedInterface.VideoCamera.value,
     ScryptedInterface.Battery.value,
     ScryptedInterface.Charger.value,
 ]
 
-SUPPORTED_TYPES = [
-    ScryptedDeviceType.Camera.value,
-]
 
-
-class DummyDevice(ScryptedDeviceBase, Settings, Camera, VideoCamera, Battery, Charger):
-    @property
-    def picture_url(self):
-        return self.storage.getItem("picture_url")
-
-    @property
-    def video_url(self):
-        return self.storage.getItem("video_url")
+class DummyDevice(ScryptedDeviceBase, Settings, Battery, Charger):
 
     async def getSettings(self) -> List[Setting]:
         settings: List[Setting] = [
@@ -56,26 +34,6 @@ class DummyDevice(ScryptedDeviceBase, Settings, Camera, VideoCamera, Battery, Ch
             }
         ]
 
-        if ScryptedInterface.Camera.value in self.interfaces:
-            settings.extend([
-                {
-                    "group": ScryptedInterface.Camera.value,
-                    "key": "storage:picture_url",
-                    "title": "Picture URL",
-                    "description": "Media URL to use as the snapshot picture. Can be either a static image or a video stream.",
-                    "value": self.picture_url,
-                }
-            ])
-        if ScryptedInterface.VideoCamera.value in self.interfaces:
-            settings.extend([
-                {
-                    "group": ScryptedInterface.VideoCamera.value,
-                    "key": "storage:video_url",
-                    "title": "Video URL",
-                    "description": "Media URL to use as the video stream.",
-                    "value": self.video_url,
-                }
-            ])
         if ScryptedInterface.Battery.value in self.interfaces:
             settings.extend([
                 {
@@ -102,10 +60,7 @@ class DummyDevice(ScryptedDeviceBase, Settings, Camera, VideoCamera, Battery, Ch
         return settings
 
     async def putSetting(self, key: str, value: SettingValue) -> None:
-        if key.startswith("storage:"):
-            key = key.split(":")[1]
-            self.storage.setItem(key, value)
-        elif key == "interfaces":
+        if key == "interfaces":
             await scrypted_sdk.deviceManager.onDeviceDiscovered({
                 "nativeId": self.nativeId,
                 "name": self.name,
@@ -115,34 +70,3 @@ class DummyDevice(ScryptedDeviceBase, Settings, Camera, VideoCamera, Battery, Ch
         else:
             setattr(self, key, value)
         await self.onDeviceEvent(ScryptedInterface.Settings.value, None)
-
-    async def getPictureOptions(self) -> List[ResponsePictureOptions]:
-        return []
-
-    async def takePicture(self, options: RequestPictureOptions = None) -> MediaObject:
-        if not self.picture_url:
-            raise Exception("no picture url configured")
-        return await scrypted_sdk.mediaManager.createMediaObjectFromUrl(self.picture_url)
-
-    async def getVideoStreamOptions(self) -> List[ResponseMediaStreamOptions]:
-        return [
-            {
-                "id": "default",
-                "name": 'Dummy',
-                "tool": 'ffmpeg',
-            }
-        ]
-
-    async def getVideoStream(self, options: RequestMediaStreamOptions = None) -> MediaObject:
-        if not self.video_url:
-            raise Exception("no video url configured")
-
-        arguments = ["-i", self.video_url]
-        if not self.video_url.startswith("rtsp"):
-            arguments = ["-re"] + arguments
-
-        ffmpeg_input: FFmpegInput = {
-            "url": self.video_url,
-            "inputArguments": arguments,
-        }
-        return await scrypted_sdk.mediaManager.createFFmpegMediaObject(ffmpeg_input)

--- a/plugins/dummy-device/src/dummy/device.py
+++ b/plugins/dummy-device/src/dummy/device.py
@@ -1,0 +1,148 @@
+from typing import List
+
+import scrypted_sdk
+from scrypted_sdk import ScryptedDeviceBase
+from scrypted_sdk.types import (
+    ScryptedInterface,
+    ScryptedDeviceType,
+    MediaObject,
+    FFmpegInput,
+    Settings,
+    Setting,
+    SettingValue,
+    Camera,
+    ResponsePictureOptions,
+    RequestPictureOptions,
+    VideoCamera,
+    ResponseMediaStreamOptions,
+    RequestMediaStreamOptions,
+    Battery,
+    Charger,
+    ChargeState,
+)
+
+
+SUPPORTED_INTERFACES = [
+    ScryptedInterface.Camera.value,
+    ScryptedInterface.VideoCamera.value,
+    ScryptedInterface.Battery.value,
+    ScryptedInterface.Charger.value,
+]
+
+SUPPORTED_TYPES = [
+    ScryptedDeviceType.Camera.value,
+]
+
+
+class DummyDevice(ScryptedDeviceBase, Settings, Camera, VideoCamera, Battery, Charger):
+    @property
+    def picture_url(self):
+        return self.storage.getItem("picture_url")
+
+    @property
+    def video_url(self):
+        return self.storage.getItem("video_url")
+
+    async def getSettings(self) -> List[Setting]:
+        settings: List[Setting] = [
+            {
+                "group": "General",
+                "key": "interfaces",
+                "title": "Scrypted Interfaces",
+                "description": "Choice of the supported Scrypted interfaces that this device should implement.",
+                "value": self.providedInterfaces,
+                "choices": SUPPORTED_INTERFACES,
+                "multiple": True,
+            }
+        ]
+
+        if ScryptedInterface.Camera.value in self.interfaces:
+            settings.extend([
+                {
+                    "group": ScryptedInterface.Camera.value,
+                    "key": "storage:picture_url",
+                    "title": "Picture URL",
+                    "description": "Media URL to use as the snapshot picture. Can be either a static image or a video stream.",
+                    "value": self.picture_url,
+                }
+            ])
+        if ScryptedInterface.VideoCamera.value in self.interfaces:
+            settings.extend([
+                {
+                    "group": ScryptedInterface.VideoCamera.value,
+                    "key": "storage:video_url",
+                    "title": "Video URL",
+                    "description": "Media URL to use as the video stream.",
+                    "value": self.video_url,
+                }
+            ])
+        if ScryptedInterface.Battery.value in self.interfaces:
+            settings.extend([
+                {
+                    "group": ScryptedInterface.Battery.value,
+                    "key": "batteryLevel",
+                    "title": "Battery Level",
+                    "description": "The device's battery percentage level, from 0 to 100.",
+                    "value": self.batteryLevel,
+                    "type": "number",
+                }
+            ])
+        if ScryptedInterface.Charger.value in self.interfaces:
+            settings.extend([
+                {
+                    "group": ScryptedInterface.Charger.value,
+                    "key": "chargeState",
+                    "title": "Charge State",
+                    "description": "The device's charge state, one of the available options.",
+                    "value": self.chargeState,
+                    "choices": [c.value for c in ChargeState],
+                }
+            ])
+
+        return settings
+
+    async def putSetting(self, key: str, value: SettingValue) -> None:
+        if key.startswith("storage:"):
+            key = key.split(":")[1]
+            self.storage.setItem(key, value)
+        elif key == "interfaces":
+            await scrypted_sdk.deviceManager.onDeviceDiscovered({
+                "nativeId": self.nativeId,
+                "name": self.name,
+                "interfaces": value,
+                "type": self.type,
+            })
+        else:
+            setattr(self, key, value)
+        await self.onDeviceEvent(ScryptedInterface.Settings.value, None)
+
+    async def getPictureOptions(self) -> List[ResponsePictureOptions]:
+        return []
+
+    async def takePicture(self, options: RequestPictureOptions = None) -> MediaObject:
+        if not self.picture_url:
+            raise Exception("no picture url configured")
+        return await scrypted_sdk.mediaManager.createMediaObjectFromUrl(self.picture_url)
+
+    async def getVideoStreamOptions(self) -> List[ResponseMediaStreamOptions]:
+        return [
+            {
+                "id": "default",
+                "name": 'Dummy',
+                "tool": 'ffmpeg',
+            }
+        ]
+
+    async def getVideoStream(self, options: RequestMediaStreamOptions = None) -> MediaObject:
+        if not self.video_url:
+            raise Exception("no video url configured")
+
+        arguments = ["-i", self.video_url]
+        if not self.video_url.startswith("rtsp"):
+            arguments = ["-re"] + arguments
+
+        ffmpeg_input: FFmpegInput = {
+            "url": self.video_url,
+            "inputArguments": arguments,
+        }
+        return await scrypted_sdk.mediaManager.createFFmpegMediaObject(ffmpeg_input)

--- a/plugins/dummy-device/src/dummy/plugin.py
+++ b/plugins/dummy-device/src/dummy/plugin.py
@@ -1,0 +1,56 @@
+import asyncio
+import uuid
+from typing import List
+
+import scrypted_sdk
+from scrypted_sdk import ScryptedDeviceBase
+from scrypted_sdk.types import DeviceProvider, DeviceCreator, DeviceCreatorSettings, Setting, ScryptedDeviceType, ScryptedInterface
+
+from .device import DummyDevice, SUPPORTED_TYPES
+
+
+class DummyDevicePlugin(ScryptedDeviceBase, DeviceProvider, DeviceCreator):
+    devices: dict
+    devices_lock: asyncio.Lock
+
+    def __init__(self, nativeId: str = None):
+        super().__init__(nativeId)
+        self.devices = {}
+        self.devices_lock = asyncio.Lock()
+
+    async def getCreateDeviceSettings(self) -> List[Setting]:
+        return [
+            {
+                "key": "name",
+                "title": "Dummy Device Name",
+                "placeholder": "My Dummy Device",
+            },
+            {
+                "key": "type",
+                "title": "Device Type",
+                "choices": SUPPORTED_TYPES,
+            }
+        ]
+
+    async def createDevice(self, settings: DeviceCreatorSettings) -> str:
+        if settings.get("name", "") == "":
+            raise Exception("cannot create device with empty name")
+        if settings.get("type", "") == "":
+            raise Exception("cannot create device with empty type")
+
+        id = str(uuid.uuid4())
+        await scrypted_sdk.deviceManager.onDeviceDiscovered({
+            "nativeId": id,
+            "name": settings["name"],
+            "interfaces": [ScryptedInterface.Settings.value],
+            "type": settings["type"],
+        })
+
+    async def getDevice(self, nativeId: str) -> DummyDevice:
+        async with self.devices_lock:
+            if nativeId not in self.devices:
+                self.devices[nativeId] = DummyDevice(nativeId)
+            return self.devices[nativeId]
+
+    async def releaseDevice(self, id: str, nativeId: str) -> None:
+        pass

--- a/plugins/dummy-device/src/dummy/plugin.py
+++ b/plugins/dummy-device/src/dummy/plugin.py
@@ -6,7 +6,7 @@ import scrypted_sdk
 from scrypted_sdk import ScryptedDeviceBase
 from scrypted_sdk.types import DeviceProvider, DeviceCreator, DeviceCreatorSettings, Setting, ScryptedDeviceType, ScryptedInterface
 
-from .device import DummyDevice, SUPPORTED_TYPES
+from .device import DummyDevice
 
 
 class DummyDevicePlugin(ScryptedDeviceBase, DeviceProvider, DeviceCreator):
@@ -25,25 +25,18 @@ class DummyDevicePlugin(ScryptedDeviceBase, DeviceProvider, DeviceCreator):
                 "title": "Dummy Device Name",
                 "placeholder": "My Dummy Device",
             },
-            {
-                "key": "type",
-                "title": "Device Type",
-                "choices": SUPPORTED_TYPES,
-            }
         ]
 
     async def createDevice(self, settings: DeviceCreatorSettings) -> str:
         if settings.get("name", "") == "":
             raise Exception("cannot create device with empty name")
-        if settings.get("type", "") == "":
-            raise Exception("cannot create device with empty type")
 
         id = str(uuid.uuid4())
         await scrypted_sdk.deviceManager.onDeviceDiscovered({
             "nativeId": id,
             "name": settings["name"],
             "interfaces": [ScryptedInterface.Settings.value],
-            "type": settings["type"],
+            "type": ScryptedDeviceType.API.value,
         })
 
     async def getDevice(self, nativeId: str) -> DummyDevice:

--- a/plugins/dummy-device/src/main.py
+++ b/plugins/dummy-device/src/main.py
@@ -1,0 +1,4 @@
+from dummy import DummyDevicePlugin
+
+def create_scrypted_plugin():
+    return DummyDevicePlugin()

--- a/plugins/dummy-device/tsconfig.json
+++ b/plugins/dummy-device/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES2021",
+        "resolveJsonModule": true,
+        "moduleResolution": "Node16",
+        "esModuleInterop": true,
+        "sourceMap": true
+    },
+    "include": [
+        "src/**/*"
+    ]
+}


### PR DESCRIPTION
This was useful while testing the battery prebuffer changes, to build an aggregate device with a camera + dummy battery/charger. Open to discussing if it makes sense as a separate plugin or merged into dummy-switch somehow.