### PR TITLE
chromecast: fix stop casting issue

### DIFF
--- a/plugins/chromecast/src/main.ts
+++ b/plugins/chromecast/src/main.ts
@@ -88,7 +88,10 @@ class CastDevice extends ScryptedDeviceBase implements MediaPlayer, Refresh, Eng
         }
 
         client.removeAllListeners();
-        client.close();
+        try {
+          client.close();
+        } catch (e) {
+        }
       }
       client.client.on('close', cleanup);
       client.on('error', err => {
@@ -149,6 +152,14 @@ class CastDevice extends ScryptedDeviceBase implements MediaPlayer, Refresh, Eng
   }
 
   async load(media: string | MediaObject, options: MediaPlayerOptions) {
+    if (this.mediaPlayerPromise) {
+      try {
+        (await this.mediaPlayerPromise).close();
+      } catch (e) {
+      }
+      this.mediaPlayerPromise = undefined;
+      this.mediaPlayerStatus = undefined;
+    }
     let url: string;
     let urlMimeType: string;
 
@@ -341,15 +352,7 @@ class CastDevice extends ScryptedDeviceBase implements MediaPlayer, Refresh, Eng
                 });
               })
 
-              player.getStatus((err, status) => {
-                if (err) {
-                  reject(err);
-                  return;
-                }
-                this.mediaPlayerStatus = status;
-                this.updateState();
-                resolve(player);
-              })
+              resolve(player);
             });
           });
         });

--- a/plugins/core/fs/examples/chromecast-view-camera.ts
+++ b/plugins/core/fs/examples/chromecast-view-camera.ts
@@ -29,7 +29,7 @@ class ChromecastViewCameraExample implements StartStop {
     }
     async stop() {
         device.running = false;
-        return chromecast.stop();
+        await chromecast.stop();
     }
 }
 


### PR DESCRIPTION
Fixes #714 

Sometimes the cached `mediaPlayerPromise` is not the current media player, and sometimes `joinPlayer` returns a player that doesn't respond to `player.getStatus()`. I'm not sure about the root cause, but this PR seems to fix the issue where chromecast streaming cannot be stopped. 

Nest Hub Gen 2 is my only chromecast device, so I don't know if these changes have any side effects on other chromecast devices. 