### PR TITLE
rebroadcast: recover after ffmpeg exits before printing sdp

### DIFF
--- a/common/src/ffmpeg-rebroadcast.ts
+++ b/common/src/ffmpeg-rebroadcast.ts
@@ -269,7 +269,10 @@ export async function startParserSession<T extends string>(ffmpegInput: FFmpegIn
         inputAudioCodec = audio?.codec;
     });
 
-    const sdp = rtsp.sdp.then(sdpString => [Buffer.from(sdpString)]);
+    const sdp = new Promise<Buffer[]>((res, rej) => {
+        rtsp.sdp.then(sdpString => res([Buffer.from(sdpString)]));
+        killed.then(() => rej(new Error("ffmpeg killed before sdp could be parsed")));
+    });
     start();
 
     return {

--- a/common/src/ffmpeg-rebroadcast.ts
+++ b/common/src/ffmpeg-rebroadcast.ts
@@ -269,8 +269,7 @@ export async function startParserSession<T extends string>(ffmpegInput: FFmpegIn
         inputAudioCodec = audio?.codec;
     });
 
-    // sdp might never get parsed if ffmpeg exits without printing anything
-    const sdp = Promise.any([rtsp.sdp.then(sdpString => [Buffer.from(sdpString)]), killed]) as Promise<Buffer[]>;
+    const sdp = rtsp.sdp.then(sdpString => [Buffer.from(sdpString)]);
     start();
 
     return {

--- a/common/src/ffmpeg-rebroadcast.ts
+++ b/common/src/ffmpeg-rebroadcast.ts
@@ -269,7 +269,8 @@ export async function startParserSession<T extends string>(ffmpegInput: FFmpegIn
         inputAudioCodec = audio?.codec;
     });
 
-    const sdp = rtsp.sdp.then(sdpString => [Buffer.from(sdpString)]);
+    // sdp might never get parsed if ffmpeg exits without printing anything
+    const sdp = Promise.any([rtsp.sdp.then(sdpString => [Buffer.from(sdpString)]), killed]) as Promise<Buffer[]>;
     start();
 
     return {

--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -485,7 +485,7 @@ class PrebufferSession {
       // the rtsp parser should always stream copy unless audio is soft muted.
       acodec: audioSoftMuted ? acodec : ['-acodec', 'copy'],
     });
-    this.sdp = parser.sdp;
+    this.sdp = null;
     rbo.parsers.rtsp = parser;
 
     const mo = await this.mixinDevice.getVideoStream(mso);
@@ -508,7 +508,6 @@ class PrebufferSession {
       const { url, sdp, mediaStreamOptions } = json;
 
       session = startRFC4571Parser(this.console, connectRFC4571Parser(url), sdp, mediaStreamOptions, rbo);
-      this.sdp = session.sdp.then(buffers => Buffer.concat(buffers).toString());
     }
     else {
       const moBuffer = await mediaManager.convertMediaObjectToBuffer(mo, ScryptedMimeTypes.FFmpegInput);
@@ -536,7 +535,6 @@ class PrebufferSession {
           audioSoftMuted,
           rtspRequestTimeout: 10000,
         });
-        this.sdp = session.sdp.then(buffers => Buffer.concat(buffers).toString());
       }
       else {
         if (parser === FFMPEG_PARSER_UDP)
@@ -610,7 +608,11 @@ class PrebufferSession {
       }, h264Oddities ? 60000 : 10000);
     }
 
-    await session.sdp;
+    this.sdp = session.sdp.then(buffers => buffers ? Buffer.concat(buffers).toString() : null);
+    const sdp = await session.sdp;
+    if (!sdp) {
+      this.console.warn('no sdp returned by parser')
+    }
 
     // complain to the user about the codec if necessary. upstream may send a audio
     // stream but report none exists (to request muting).
@@ -897,6 +899,9 @@ class PrebufferSession {
 
     const mediaStreamOptions: ResponseMediaStreamOptions = session.negotiateMediaStream(options);
     let sdp = await this.sdp;
+    if (!sdp) {
+      throw Error("parser returned empty sdp");
+    }
     if (!mediaStreamOptions.video?.h264Info && this.usingScryptedParser) {
       mediaStreamOptions.video ||= {};
       mediaStreamOptions.video.h264Info = this.getLastH264Probe();
@@ -1097,7 +1102,11 @@ class PrebufferMixin extends SettingsMixinDeviceBase<VideoCamera> implements Vid
             prebufferSession = session;
             prebufferSession.ensurePrebufferSession();
             await prebufferSession.parserSessionPromise;
-            server.sdp = await prebufferSession.sdp;
+            const sdp = await prebufferSession.sdp;
+            if (!sdp) {
+              throw Error('prebuffer returned empty sdp');
+            }
+            server.sdp = sdp;
             return true;
           }
           if (u.pathname === '/' + session.rtspServerMutedPath) {
@@ -1105,9 +1114,13 @@ class PrebufferMixin extends SettingsMixinDeviceBase<VideoCamera> implements Vid
             prebufferSession = session;
             prebufferSession.ensurePrebufferSession();
             await prebufferSession.parserSessionPromise;
-            const sdp = parseSdp(await prebufferSession.sdp);
-            sdp.msections = sdp.msections.filter(msection => msection.type === 'video');
-            server.sdp = sdp.toSdp();
+            const sdp = await prebufferSession.sdp;
+            if (!sdp) {
+              throw Error('prebuffer returned empty sdp')
+            }
+            const parsedSdp = parseSdp(sdp);
+            parsedSdp.msections = parsedSdp.msections.filter(msection => msection.type === 'video');
+            server.sdp = parsedSdp.toSdp();
             return true;
           }
         }


### PR DESCRIPTION
When an ffmpeg parser session is started, if ffmpeg exits before it is able to print out the sdp, the parse session will hang in `startPrebufferSession` while it waits for the sdp. This prevents the prebuffer restart loop from continuing forward and detecting that the session has already been killed.

The proposed solution is to reject the sdp promise if ffmpeg exits prematurely. The exception will propagate and allow the prebuffer restart loop to try again.