### PR TITLE
snapshot: tell ffmpeg pipe input format

### DIFF
--- a/plugins/snapshot/src/ffmpeg-image-filter.ts
+++ b/plugins/snapshot/src/ffmpeg-image-filter.ts
@@ -89,7 +89,7 @@ function ffmpegCreateOutputArguments(inputArguments: string[], options: FFmpegIm
 
 export function ffmpegFilterImageBuffer(inputJpeg: Buffer, options: FFmpegImageFilterOptions) {
     const inputArguments = [
-        '-f', 'jpeg_pipe',
+        '-f', 'image2pipe',
         '-i', 'pipe:4',
     ];
 

--- a/plugins/snapshot/src/ffmpeg-image-filter.ts
+++ b/plugins/snapshot/src/ffmpeg-image-filter.ts
@@ -89,6 +89,7 @@ function ffmpegCreateOutputArguments(inputArguments: string[], options: FFmpegIm
 
 export function ffmpegFilterImageBuffer(inputJpeg: Buffer, options: FFmpegImageFilterOptions) {
     const inputArguments = [
+        '-f', 'jpeg_pipe',
         '-i', 'pipe:4',
     ];
 
@@ -198,7 +199,7 @@ export async function ffmpegFilterImageStream(cp: ChildProcess, options: FFmpegI
                 ++count;
                 last = jpeg;
             });
-    
+
             await once(pipe, 'jpeg');
             await Promise.any([once(cp, 'exit'), sleep(options.time)]).catch(() => {});
             if (!last)


### PR DESCRIPTION
Snapshots of raw images (e.g. via the snapshot url) frequently results in error when rescaling. A sample stacktrace:
```
[Snapshot Plugin]: -hide_banner -y -i pipe:[REDACTED] -filter_complex scale='min(512,iw)':-2 -frames:v 1 -f image2 pipe:3
[Snapshot Plugin]: pipe:4: Invalid data found when processing input
[Snapshot Plugin]: ffmpeg exited
[Snapshot Plugin]: Snapshot failed Error: ffmpeg input to image conversion failed with exit code: 1, /usr/bin/ffmpeg -hide_banner -y -i pipe:4 -filter_complex scale='min(512,iw)':-2 -frames:v 1 -f image2 pipe:3
[Snapshot Plugin]:     at /src/ffmpeg-image-filter.ts:177:23
[Snapshot Plugin]:     at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

It looks like this might be a side effect due to switching from static ffmpeg to system ffmpeg (maybe because static ffmpeg is a later version), since static ffmpeg doesn't produce the same error. Explicitly telling system ffmpeg to use `jpeg_pipe` makes it much happier.