### PR TITLE
improve management of avahi

### DIFF
--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -37,6 +37,11 @@ services:
             # Uncomment next 3 lines for Nvidia GPU support.
             # - NVIDIA_VISIBLE_DEVICES=all
             # - NVIDIA_DRIVER_CAPABILITIES=all
+
+            # Uncomment next line to run avahi-daemon inside the container
+            # Don't use if dbus and avahi run on the host and are bind-mounted
+            # (see below under "volumes")
+            # - SCRYPTED_DOCKER_AVAHI=true
         # runtime: nvidia
 
         volumes:
@@ -56,6 +61,7 @@ services:
 
             # uncomment the following lines to expose Avahi, an mDNS advertiser.
             # make sure Avahi is running on the host machine, otherwise this will not work.
+            # not compatible with Avahi enabled via SCRYPTED_DOCKER_AVAHI=true
             # - /var/run/dbus:/var/run/dbus
             # - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 

--- a/install/docker/fs/etc/s6-overlay/s6-rc.d/avahi/run
+++ b/install/docker/fs/etc/s6-overlay/s6-rc.d/avahi/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ -z "$SCRYPTED_DOCKER_AVAHI" ]
-then
+if [[ "${SCRYPTED_DOCKER_AVAHI}" != "true" ]]; then
+  echo "SCRYPTED_DOCKER_AVAHI != true, not starting avahi-daemon" >/dev/stderr
   while true
   do
     sleep 1000

--- a/install/docker/fs/etc/s6-overlay/s6-rc.d/dbus/run
+++ b/install/docker/fs/etc/s6-overlay/s6-rc.d/dbus/run
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+if [[ "${SCRYPTED_DOCKER_AVAHI}" != "true" ]]; then
+  echo "SCRYPTED_DOCKER_AVAHI != true, not starting dbus-daemon" >/dev/stderr
+  while true
+  do
+    sleep 1000
+  done
+fi
+
 echo "Starting dbus..."
 exec dbus-daemon --system --nofork

--- a/install/docker/fs/etc/s6-overlay/scripts/setup.sh
+++ b/install/docker/fs/etc/s6-overlay/scripts/setup.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+if [[ "${SCRYPTED_DOCKER_AVAHI}" != "true" ]]; then
+  echo "SCRYPTED_DOCKER_AVAHI != true, won't manage dbus nor avahi-daemon" >/dev/stderr
+  exit 0
+fi
+
+if grep -qE " ((/var)?/run/dbus|(/var)?/run/avahi-daemon(/socket)?) " /proc/mounts; then
+  echo "dbus and/or avahi-daemon volumes are bind mounted, won't touch them" >/dev/stderr
+  exit 0
+fi
+
 # make run folders
 mkdir -p /var/run/dbus
 mkdir -p /var/run/avahi-daemon


### PR DESCRIPTION
Trying to address https://github.com/koush/scrypted/issues/936.

Tested locally:

```
scrypted  | s6-rc: info: service s6rc-oneshot-runner: starting
scrypted  | s6-rc: info: service s6rc-oneshot-runner successfully started
scrypted  | s6-rc: info: service fix-attrs: starting
scrypted  | s6-rc: info: service setup: starting
scrypted  | SCRYPTED_DOCKER_AVAHI != true, won't manage dbus nor avahi-daemon
scrypted  | s6-rc: info: service setup successfully started
scrypted  | s6-rc: info: service dbus: starting
scrypted  | s6-rc: info: service dbus successfully started
scrypted  | SCRYPTED_DOCKER_AVAHI != true, not starting dbus-daemon
scrypted  | s6-rc: info: service avahi: starting
scrypted  | s6-rc: info: service fix-attrs successfully started
scrypted  | s6-rc: info: service legacy-cont-init: starting
scrypted  | s6-rc: info: service avahi successfully started
scrypted  | SCRYPTED_DOCKER_AVAHI != true, not starting avahi-daemon
scrypted  | s6-rc: info: service legacy-cont-init successfully started
scrypted  | s6-rc: info: service legacy-services: starting
scrypted  | s6-rc: info: service legacy-services successfully started
```