### PR TITLE
python-codecs: make annotations compatible to pre-3.10

### DIFF
--- a/plugins/python-codecs/src/main.py
+++ b/plugins/python-codecs/src/main.py
@@ -2,7 +2,7 @@ import traceback
 import asyncio
 import scrypted_sdk
 from scrypted_sdk import Setting, SettingValue
-from typing import Any, List
+from typing import Any, List, Union
 import gstreamer
 import libav
 import vipsimage
@@ -24,7 +24,7 @@ except:
 
 
 class LibavGenerator(scrypted_sdk.ScryptedDeviceBase, scrypted_sdk.VideoFrameGenerator):
-    def __init__(self, nativeId: str | None, z):
+    def __init__(self, nativeId: Union[str, None], z):
         super().__init__(nativeId)
         self.zygote = z
 
@@ -43,7 +43,7 @@ class GstreamerGenerator(
     scrypted_sdk.VideoFrameGenerator,
     scrypted_sdk.Settings,
 ):
-    def __init__(self, nativeId: str | None, z):
+    def __init__(self, nativeId: Union[str, None], z):
         super().__init__(nativeId)
         self.zygote = z
 


### PR DESCRIPTION
Union type annotations with `|` were introduced in python 3.10: https://peps.python.org/pep-0604/
This change makes the annotations compatible with 3.9.

Fixes #995.