### PR TITLE
core: add horizontal padding to aggregate streams

### DIFF
--- a/plugins/core/src/aggregate.ts
+++ b/plugins/core/src/aggregate.ts
@@ -80,7 +80,8 @@ function createVideoCamera(devices: VideoCamera[], console: Console): VideoCamer
 
         for (let i = 0; i < inputs.length; i++) {
             ffmpegInput.inputArguments.push(...inputs[i].inputArguments);
-            filter.push(`[${i}:v] scale=-1:${h},pad=${w}:ih:(ow-iw)/2 [pos${i}];`)
+            // https://superuser.com/a/891478
+            filter.push(`[${i}:v] scale=(iw*sar)*min(${w}/(iw*sar)\\,${h}/ih):ih*min(${w}/(iw*sar)\\,${h}/ih),pad=${w}:${h}:(${w}-iw*min(${w}/iw\\,${h}/ih))/2:(${h}-ih*min(${w}/iw\\,${h}/ih))/2 [pos${i}];`)
         }
         for (let i = inputs.length; i < dim * dim; i++) {
             ffmpegInput.inputArguments.push(


### PR DESCRIPTION
The current video filter to scale source videos for aggregate streaming only handles vertical (width) padding. If the source video instead has a height that's too small for the target aspect ratio (e.g. some Arlo cameras have 1920x1072 instead of 1920x1080), the video filter fails with:
```
[RTC Connection Bridge]: [Parsed_pad_2 @ 0x56539a2a2f40] Padded dimensions cannot be smaller than input dimensions.
[RTC Connection Bridge]: [Parsed_pad_2 @ 0x56539a2a2f40] Failed to configure input pad on Parsed_pad_2
[RTC Connection Bridge]: Error reinitializing filters!
[RTC Connection Bridge]: Failed to inject frame into filter network: Invalid argument
[RTC Connection Bridge]: Error while processing the decoded data for stream #3:0
[RTC Connection Bridge]: Conversion failed!
```

The proposed change uses a filter adapted from the cited superuser post (and that I've previously used in my [sidecar project](https://github.com/bjia56/scrypted-sidecar/blob/01600a43ed7170762fbf4a90d19fdf51e0d7c599/server/src/ffmpeg-to-wrtc.ts#L154) before Scrypted NVR) to calculate the required scaling factor and padding from the video's source dimensions. This should capture both cases where the source is too tall or too wide for the grid aspect ratio.