### PR TITLE
core: use webpack bundled map marker

### DIFF
--- a/plugins/core/ui/src/interfaces/sensors/PositionSensor.vue
+++ b/plugins/core/ui/src/interfaces/sensors/PositionSensor.vue
@@ -24,6 +24,7 @@ import { LMap, LTileLayer, LMarker, LControlAttribution } from "vue2-leaflet";
 import 'leaflet/dist/leaflet.css';
 import RPCInterface from "../RPCInterface.vue";
 
+// https://vue2-leaflet.netlify.app/quickstart/#marker-icons-are-missing
 delete Icon.Default.prototype._getIconUrl;
 Icon.Default.mergeOptions({
   iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),

--- a/plugins/core/ui/src/interfaces/sensors/PositionSensor.vue
+++ b/plugins/core/ui/src/interfaces/sensors/PositionSensor.vue
@@ -13,16 +13,23 @@
     }"
   >
     <l-tile-layer :url="url" :attribution="attribution"></l-tile-layer>
-    <l-marker :lat-lng="position" :icon="icon"></l-marker>
+    <l-marker :lat-lng="position"></l-marker>
     <l-control-attribution position="bottomright" :prefix="prefix"></l-control-attribution>
   </l-map>
 </template>
 
 <script>
-import { latLng, icon } from "leaflet";
+import { latLng, Icon } from "leaflet";
 import { LMap, LTileLayer, LMarker, LControlAttribution } from "vue2-leaflet";
 import 'leaflet/dist/leaflet.css';
 import RPCInterface from "../RPCInterface.vue";
+
+delete Icon.Default.prototype._getIconUrl;
+Icon.Default.mergeOptions({
+  iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+  iconUrl: require('leaflet/dist/images/marker-icon.png'),
+  shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+});
 
 export default {
   mixins: [RPCInterface],
@@ -37,10 +44,6 @@ export default {
       url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       prefix: '<a target="blank" href="https://leafletjs.com/">Leaflet</a>',
       attribution: '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-      icon: icon({
-        iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
-        shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
-      }),
     };
   },
   computed: {

--- a/plugins/core/ui/src/interfaces/sensors/PositionSensor.vue
+++ b/plugins/core/ui/src/interfaces/sensors/PositionSensor.vue
@@ -10,6 +10,7 @@
       doubleClickZoom: false,
       boxZoom: false,
       scrollWheelZoom: false,
+      touchZoom: false,
     }"
   >
     <l-tile-layer :url="url" :attribution="attribution"></l-tile-layer>


### PR DESCRIPTION
The default Leafletjs marker icon has preconfigured values for where to place the image in relation to the pixel coordinate that matches its anchor. This default was previously ignored since the icons were missing, but the alternative did not have the correct anchor coordinates. This change restores the default marker behavior.

Also disables touch-zoom to behave more like a static image.