### PR TITLE
common: fix behavior of multiple createLocalDescription calls on firefox

### DIFF
--- a/common/src/rtc-signaling.ts
+++ b/common/src/rtc-signaling.ts
@@ -183,6 +183,15 @@ export class BrowserSignalingSession implements RTCSignalingSession {
     }
 
     async createLocalDescription(type: "offer" | "answer", setup: RTCAVSignalingSetup, sendIceCandidate: RTCSignalingSendIceCandidate) {
+        try {
+            return this.createLocalDescriptionImpl(type, setup, sendIceCandidate);
+        } catch (e) {
+            console.log(e);
+            throw e;
+        }
+    }
+
+    async createLocalDescriptionImpl(type: "offer" | "answer", setup: RTCAVSignalingSetup, sendIceCandidate: RTCSignalingSendIceCandidate) {
         await this.createPeerConnection(setup);
 
         const gatheringPromise = new Promise(resolve => {
@@ -211,7 +220,12 @@ export class BrowserSignalingSession implements RTCSignalingSession {
         }
 
         if (type === 'offer') {
-            let offer = await this.pc.createOffer({
+            let offer: RTCSessionDescriptionInit = this.pc.localDescription;
+            if (offer) {
+                console.log("early localDescription", offer);
+                return toDescription(this.pc.localDescription);
+            }
+            offer = await this.pc.createOffer({
                 offerToReceiveAudio: !!setup.audio,
                 offerToReceiveVideo: !!setup.video,
             });

--- a/common/src/rtc-signaling.ts
+++ b/common/src/rtc-signaling.ts
@@ -196,8 +196,8 @@ export class BrowserSignalingSession implements RTCSignalingSession {
 
         const gatheringPromise = new Promise(resolve => {
             this.pc.onicecandidate = ev => {
+                console.log("local candidate", ev.candidate);
                 if (ev.candidate) {
-                    // console.log("local candidate", ev.candidate);
                     sendIceCandidate?.(JSON.parse(JSON.stringify(ev.candidate)));
                 }
                 else {

--- a/common/src/rtc-signaling.ts
+++ b/common/src/rtc-signaling.ts
@@ -220,10 +220,13 @@ export class BrowserSignalingSession implements RTCSignalingSession {
                 return toDescription(offer);
             await set;
             await gatheringPromise;
-            offer = await this.pc.createOffer({
-                offerToReceiveAudio: !!setup.audio,
-                offerToReceiveVideo: !!setup.video,
-            });
+            offer = this.pc.localDescription;
+            if (!offer) {
+                offer = await this.pc.createOffer({
+                    offerToReceiveAudio: !!setup.audio,
+                    offerToReceiveVideo: !!setup.video,
+                });
+            }
             return toDescription(offer);
         }
         else {

--- a/common/src/rtc-signaling.ts
+++ b/common/src/rtc-signaling.ts
@@ -221,7 +221,9 @@ export class BrowserSignalingSession implements RTCSignalingSession {
             await set;
             await gatheringPromise;
             offer = this.pc.localDescription;
+            console.log("localDescription", offer);
             if (!offer) {
+                console.log("need to createOffer again");
                 offer = await this.pc.createOffer({
                     offerToReceiveAudio: !!setup.audio,
                     offerToReceiveVideo: !!setup.video,


### PR DESCRIPTION
On Firefox, it appears that calling `createLocalDescription` multiple times, which triggers multiple `createOffer` calls, will reset the PeerConnection state in such a way that the returned SDP no longer includes any gathered candidates.

In SIP.js, their approach is to initialize a PeerConnection, call `createOffer` once, then when either ICE gathering finishes or a timeout expires, use the `localDescription` property to generate an SDP - their chain of events can be found [here](https://github.com/onsip/SIP.js/blob/2e1c525279c8d6deebb6ecaf3d14477ab7b63310/src/platform/web/session-description-handler/session-description-handler.ts#L272).

This change will allow a Scrypted peer to emulate such behavior by:
- Calling `createLocalDescription` without `sendIceCandidate`, in cases where the browser blocks
- Wait a period of time for ICE to complete or for a timeout
- Call `createLocalDescription` again to get the in-progress or final SDP in `localDescription`