### PR TITLE
unifi-protect: Use connectionHost to support cameras distributed between stacked nvrs

### DIFF
--- a/plugins/unifi-protect/src/camera.ts
+++ b/plugins/unifi-protect/src/camera.ts
@@ -317,7 +317,7 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
         const rtspChannel = camera.channels.find(check => check.id.toString() === vso.id);
 
         const { rtspAlias } = rtspChannel;
-        const u = `rtsps://${this.protect.getSetting('ip')}:7441/${rtspAlias}`
+        const u = `rtsps://${camera.connectionHost}:7441/${rtspAlias}`
 
         const data = Buffer.from(JSON.stringify({
             url: u,

--- a/plugins/unifi-protect/src/camera.ts
+++ b/plugins/unifi-protect/src/camera.ts
@@ -280,7 +280,7 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
                 const mainChannel = camera.channels[0];
                 const w = options.picture.width;
                 const h = fitHeightToWidth(mainChannel.width, mainChannel.height, w);
-
+ 
                 size = `&w=${w}&h=${h}`;
             }
         }
@@ -317,7 +317,9 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
         const rtspChannel = camera.channels.find(check => check.id.toString() === vso.id);
 
         const { rtspAlias } = rtspChannel;
-        const u = `rtsps://${camera.connectionHost}:7441/${rtspAlias}`
+        // Use the camera's host from the api, otherwise fallback to user-configured nvr ip
+        const cameraHost = camera.connectionHost || this.protect.getSetting('ip');
+        const u = `rtsps://${cameraHost}:7441/${rtspAlias}`
 
         const data = Buffer.from(JSON.stringify({
             url: u,

--- a/plugins/unifi-protect/src/camera.ts
+++ b/plugins/unifi-protect/src/camera.ts
@@ -280,7 +280,7 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
                 const mainChannel = camera.channels[0];
                 const w = options.picture.width;
                 const h = fitHeightToWidth(mainChannel.width, mainChannel.height, w);
- 
+
                 size = `&w=${w}&h=${h}`;
             }
         }


### PR DESCRIPTION
### Problem
When utilizing stacked NVRs with the `unifi-protect` plugin, we encountered an issue where the plugin failed to generate correct RTSP stream URLs for cameras connected to the secondary NVR. This limitation stemmed from the fact that only the primary IP was available and configurable in the UI. As a result, we could only access camera streams from the primary NVR, rendering those on the secondary NVR inaccessible.

### Action
To address this issue, we revised the approach to generating RTSP stream URLs. Instead of statically utilizing the primary NVR's IP, we integrated the use of the connectionHost property, which is returned from the API for each camera. The `connectionHost` property contains the specific IP address of the host NVR that a camera is connected to, ensuring that the correct IP address is used for generating the RTSP stream URL, whether the camera is on the primary or secondary NVR.

### Result
This modification results in a successful and consistent generation of RTSP stream URLs for all cameras across both primary and secondary NVRs.

### Other Solutions Considered
We evaluated an alternative solution that involved manually adding the secondary IP during the setup process. However, we decided against this approach as it compromises the abstraction of NVR stacking. It would also introduce additional configuration steps, increasing the potential for user errors and complicating the setup process.

cc: @shyawnkarim