### PR TITLE
server & core: send terminal size info

### DIFF
--- a/plugins/core/ui/src/components/builtin/ShellComponent.vue
+++ b/plugins/core/ui/src/components/builtin/ShellComponent.vue
@@ -37,16 +37,22 @@ export default {
     const rootLocation = `${window.location.protocol}//${window.location.host}`;
     this.socket = eio(rootLocation, options);
 
+    this.socket.send(JSON.stringify({ dim: { cols: term.cols, rows: term.rows } }));
+
     this.socket.on("message", (data) => {
-      term.write(new Uint8Array(Buffer.from(data)));
+      term.write(new Uint8Array(Buffer.from(JSON.parse(data).data)));
     });
 
     term.onData((data) => {
-      this.socket.send(data);
+      this.socket.send(JSON.stringify({ data }));
+    });
+
+    term.on('resize', dim => {
+      this.socket.send(JSON.stringify({ dim }));
     });
 
     term.onBinary((data) => {
-      this.socket.send(data);
+      this.socket.send(JSON.stringify({ data }));
     });
   },
   destroyed() {

--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -119,8 +119,15 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
                 const spawn = require('node-pty-prebuilt-multiarch').spawn as typeof ptySpawn;
                 const cp = spawn(process.env.SHELL, [], {
                 });
-                cp.onData(data => connection.send(data));
-                connection.on('message', message => cp.write(message.toString()));
+                cp.onData(data => connection.send(JSON.stringify({data})));
+                connection.on('message', message => {
+                    const parsed = JSON.parse(message.toString());
+                    if (parsed.data) {
+                        cp.write(parsed.data);
+                    } else if (parsed.dim) {
+                        cp.resize(parsed.dim.cols, parsed.dim.rows);
+                    }
+                });
                 connection.on('close', () => cp.kill());
             }
             catch (e) {


### PR DESCRIPTION
Whenever I use the shell terminal for anything nontrivial, it frequently misbehaves by wrapping output in odd ways. This PR is a coordinated change between server and core by updating the engine.io/shell endpoint's interface to send annotated packets - aside from data messages, a `dim` packet can be sent to change the pty dimensions on the server side.

We can see all the screen real estate being used here:
![image](https://github.com/koush/scrypted/assets/5090934/efeb8df9-4425-410f-b83c-1dd6ba7c658e)
