### PR TITLE
server & core: handle binary terminal data

### DIFF
--- a/plugins/core/ui/src/components/builtin/ShellComponent.vue
+++ b/plugins/core/ui/src/components/builtin/ShellComponent.vue
@@ -37,16 +37,22 @@ export default {
     const rootLocation = `${window.location.protocol}//${window.location.host}`;
     this.socket = eio(rootLocation, options);
 
+    this.socket.send(JSON.stringify({ dim: { cols: term.cols, rows: term.rows } }));
+
     this.socket.on("message", (data) => {
-      term.write(new Uint8Array(Buffer.from(data)));
+      term.write(new Uint8Array(Buffer.from(JSON.parse(data).data)));
     });
 
     term.onData((data) => {
-      this.socket.send(data);
+      this.socket.send(JSON.stringify({ data }));
+    });
+
+    term.on('resize', dim => {
+      this.socket.send(JSON.stringify({ dim }));
     });
 
     term.onBinary((data) => {
-      this.socket.send(data);
+      this.socket.send(JSON.stringify({ data }));
     });
   },
   destroyed() {

--- a/plugins/core/ui/src/components/builtin/ShellComponent.vue
+++ b/plugins/core/ui/src/components/builtin/ShellComponent.vue
@@ -40,19 +40,20 @@ export default {
     this.socket.send(JSON.stringify({ dim: { cols: term.cols, rows: term.rows } }));
 
     this.socket.on("message", (data) => {
-      term.write(new Uint8Array(Buffer.from(JSON.parse(data).data)));
+      term.write(new Uint8Array(Buffer.from(data)));
     });
 
     term.onData((data) => {
-      this.socket.send(JSON.stringify({ data }));
+      this.socket.send(JSON.stringify({ d: data }));
+    });
+
+    term.onBinary((data) => {
+      // https://github.com/xtermjs/xterm.js/blob/2e02c37e528c1abc200ce401f49d0d7eae330e63/typings/xterm.d.ts#L859-L868
+      this.socket.send(Buffer.from(data, 'binary'));
     });
 
     term.on('resize', dim => {
       this.socket.send(JSON.stringify({ dim }));
-    });
-
-    term.onBinary((data) => {
-      this.socket.send(JSON.stringify({ data }));
     });
   },
   destroyed() {

--- a/plugins/core/ui/src/components/builtin/ShellComponent.vue
+++ b/plugins/core/ui/src/components/builtin/ShellComponent.vue
@@ -44,7 +44,7 @@ export default {
     });
 
     term.onData((data) => {
-      this.socket.send(JSON.stringify({ d: data }));
+      this.socket.send(Buffer.from(data, 'utf8'));
     });
 
     term.onBinary((data) => {

--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -126,9 +126,15 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
                         return;
                     }
 
-                    const parsed = JSON.parse(message.toString());
-                    if (parsed.dim) {
-                        cp.resize(parsed.dim.cols, parsed.dim.rows);
+                    try {
+                        const parsed = JSON.parse(message.toString());
+                        if (parsed.dim) {
+                            cp.resize(parsed.dim.cols, parsed.dim.rows);
+                        }
+                    } catch (e) {
+                        // we should only get here if an outdated core plugin
+                        // is sending us string data instead of buffer data
+                        console.log(e);
                     }
                 });
                 connection.on('close', () => cp.kill());

--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -119,8 +119,15 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
                 const spawn = require('node-pty-prebuilt-multiarch').spawn as typeof ptySpawn;
                 const cp = spawn(process.env.SHELL, [], {
                 });
-                cp.onData(data => connection.send(data));
-                connection.on('message', message => cp.write(message.toString()));
+                cp.onData(data => connection.send(JSON.stringify({data})));
+                connection.on('message', message => {
+                    const parsed = JSON.parse(message.toString());
+                    if (parsed.data) {
+                        cp.write(parsed.data);
+                    } else if (parsed.dim) {
+                        cp.resize(parsed.dim.cols, parsed.dim.rows);
+                    }
+                });
                 connection.on('close', () => cp.kill());
             }
             catch (e) {

--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -127,9 +127,7 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
                     }
 
                     const parsed = JSON.parse(message.toString());
-                    if (parsed.d) {
-                        cp.write(parsed.d);
-                    } else if (parsed.dim) {
+                    if (parsed.dim) {
                         cp.resize(parsed.dim.cols, parsed.dim.rows);
                     }
                 });

--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -119,11 +119,16 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
                 const spawn = require('node-pty-prebuilt-multiarch').spawn as typeof ptySpawn;
                 const cp = spawn(process.env.SHELL, [], {
                 });
-                cp.onData(data => connection.send(JSON.stringify({data})));
+                cp.onData(data => connection.send(data));
                 connection.on('message', message => {
+                    if (Buffer.isBuffer(message)) {
+                        cp.write(message.toString());
+                        return;
+                    }
+
                     const parsed = JSON.parse(message.toString());
-                    if (parsed.data) {
-                        cp.write(parsed.data);
+                    if (parsed.d) {
+                        cp.write(parsed.d);
                     } else if (parsed.dim) {
                         cp.resize(parsed.dim.cols, parsed.dim.rows);
                     }


### PR DESCRIPTION
Follow up to #1148 

Binary data now treated properly as such. Also optimizes the common data transfer cases by reducing the bytes sent in the stringified message and removing stringification entirely for server-sent data.