### PR TITLE
cli, client, server: add interactive `npx scrypted shell`

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -221,8 +221,8 @@ async function main() {
         console.log('install successful. id:', response.data.id);
     }
     else if (process.argv[2] === 'shell') {
-        if (!process.stdout.isTTY) {
-            throw Error("must be a tty for interactive shell");
+        if (!process.stdout.isTTY || !process.stdin.isTTY) {
+            throw Error("shell can only be used in interactive mode");
         }
         const ip = process.argv[3] || '127.0.0.1';
         const login = await getOrDoLogin(ip);

--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -138,6 +138,7 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
                     }
                 });
                 connection.on('close', () => cp.kill());
+                cp.onExit(() => connection.close());
             }
             catch (e) {
                 connection.close();


### PR DESCRIPTION
This change adds a new command, `npx scrypted shell [localhost[:10443]]` which will connect the client's TTY to the Scrypted server engine.io/shell endpoint. The server has also been updated to close the engine.io connection when the remote shell exits. This changed server behavior does not impact core plugin (web terminal client), and is used to terminate the `npx scrypted shell` process.

I ran into some dependency issues when trying to build `cli`, namely it looks like `client` is missing the `engine.io` package. Perhaps it needs to be added before publishing.