### PR TITLE
reolink: Added device detection + trackmix stream

### DIFF
--- a/plugins/reolink/src/reolink-api.ts
+++ b/plugins/reolink/src/reolink-api.ts
@@ -19,6 +19,27 @@ export interface Stream {
     width:     number;
 }
 
+export interface DevInfo {
+    B485:         number;
+    IOInputNum:   number;
+    IOOutputNum:  number;
+    audioNum:     number;
+    buildDay:     string;
+    cfgVer:       string;
+    channelNum:   number;
+    detail:       string;
+    diskNum:      number;
+    exactType:    string;
+    firmVer:      string;
+    frameworkVer: number;
+    hardVer:      string;
+    model:        string;
+    name:         string;
+    pakSuffix:    string;
+    serial:       string;
+    type:         string;
+    wifi:         number;
+}
 
 export class ReolinkCameraClient {
     digestAuth: AxiosDigestAuth;
@@ -109,5 +130,19 @@ export class ReolinkCameraClient {
         });
 
         return response.data?.[0]?.value?.Enc;
+    }
+
+    async getDeviceInfo(): Promise<DevInfo> {
+        const url = new URL(`http://${this.host}/api.cgi`);
+        const params = url.searchParams;
+        params.set('cmd', 'GetDevInfo');
+        params.set('user', this.username);
+        params.set('password', this.password);
+        const response = await this.digestAuth.request({
+            url: url.toString(),
+            httpsAgent: reolinkHttpsAgent,
+        });
+
+        return response.data?.[0]?.value?.DevInfo;
     }
 }


### PR DESCRIPTION
This is a follow up to #1020.

I've added device detection so the `autotrack` stream is only added if it is a TrackMix device and kept the cleanup of loops and arrays etc. There's a lot more we could implement using the device information, could automatically configure a doorbell, set known-good configuration for each model etc. but this is a good place to start.

Unfortunately the way we are interacting with the API seems to not be supported by all devices - my doorbell doesn't seem to like the encoding & info GET requests. Based on the semi-official/supported [python API ](https://github.com/ReolinkCameraAPI/reolinkapipy) we should be generating a token after login to be used in a `POST` request. I've tested this library and seems to work well across all my cameras & doorbell, so maybe a follow-up PR to update the API functions to match it? [See here](https://github.com/ReolinkCameraAPI/reolinkapipy/blob/f15171147bece0286e19c9475ded85f06ecafc06/reolinkapi/handlers/api_handler.py#L104) for the function in question. 