### PR TITLE
server, client: connectRPCObject for web api clients

### DIFF
--- a/packages/client/examples/connectRPCObject.ts
+++ b/packages/client/examples/connectRPCObject.ts
@@ -1,0 +1,31 @@
+import { Camera } from '@scrypted/types';
+import { connectScryptedClient } from '../dist/packages/client/src';
+
+import https from 'https';
+
+const httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+})
+
+async function example() {
+    const sdk = await connectScryptedClient({
+        baseUrl: 'https://localhost:10443',
+        pluginId: "@scrypted/core",
+        username: process.env.SCRYPTED_USERNAME || 'admin',
+        password: process.env.SCRYPTED_PASSWORD || 'swordfish',
+        axiosConfig: {
+            httpsAgent,
+        }
+    });
+    console.log('server version', sdk.serverVersion);
+
+    const office = sdk.systemManager.getDeviceByName<Camera>("Office");
+    const mo = await office.takePicture();
+
+    console.log("standard rpc object", mo);
+
+    const remote = await sdk.connectRPCObject(mo);
+    console.log("connectRPCObject object", remote);
+}
+
+example();

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -749,7 +749,7 @@ export async function connectScryptedClient(options: ScryptedClientOptions): Pro
                         const serializer = createRpcDuplexSerializer({
                             write: data => clusterPeerSocket.send(data),
                         });
-                        clusterPeerSocket.on('message', data => serializer.onData(Buffer.from(data)));
+                        clusterPeerSocket.on('message', data => serializer.onData(data));
 
                         const clusterPeer = new RpcPeer(clientName || 'engine.io-client', "cluster-proxy", (message, reject, serializationContext) => {
                             try {
@@ -759,7 +759,7 @@ export async function connectScryptedClient(options: ScryptedClientOptions): Pro
                                 reject?.(e);
                             }
                         });
-                        serializer.setupRpcPeer(rpcPeer);
+                        serializer.setupRpcPeer(clusterPeer);
                         clusterPeer.tags.localPort = 65535 + 1; // beyond max port number
                         peerReady = true;
                         return { clusterPeer, clusterSecret };

--- a/server/src/plugin/connect-rpc-object.ts
+++ b/server/src/plugin/connect-rpc-object.ts
@@ -13,11 +13,12 @@ export function setupConnectRPCObjectProxy(scrypted: ScryptedRuntime, port: numb
     }
 
     const socket = net.connect(port, '127.0.0.1');
-    connection.emit('port', (socket.address() as net.AddressInfo).port);
-    connection.emit('secret', scrypted.clusterSecret);
+    socket.on('connect', () => {
+        connection.send(scrypted.clusterSecret);
 
-    socket.on('close', () => connection.close());
-    socket.on('data', data => connection.send(data));
-    connection.on('close', () => socket.destroy());
-    connection.on('message', message => socket.write(message));
+        socket.on('close', () => connection.close());
+        socket.on('data', data => connection.send(data.toString()));
+        connection.on('close', () => socket.destroy());
+        connection.on('message', message => socket.write(message.toString()));
+    });
 };

--- a/server/src/plugin/connect-rpc-object.ts
+++ b/server/src/plugin/connect-rpc-object.ts
@@ -1,0 +1,23 @@
+import net from "net";
+import { Socket } from "engine.io";
+import { IOSocket } from "../io";
+import { ScryptedRuntime } from "../runtime";
+
+/*
+ * Handle incoming connections that will be
+ * proxied to a connectRPCObject socket.
+ */
+export function setupConnectRPCObjectProxy(scrypted: ScryptedRuntime, port: number, connection: Socket & IOSocket) {
+    if (!port) {
+        throw new Error("invalid port");
+    }
+
+    const socket = net.connect(port, '127.0.0.1');
+    connection.emit('port', (socket.address() as net.AddressInfo).port);
+    connection.emit('secret', scrypted.clusterSecret);
+
+    socket.on('close', () => connection.close());
+    socket.on('data', data => connection.send(data));
+    connection.on('close', () => socket.destroy());
+    connection.on('message', message => socket.write(message));
+};

--- a/server/src/plugin/connect-rpc-object.ts
+++ b/server/src/plugin/connect-rpc-object.ts
@@ -12,13 +12,11 @@ export function setupConnectRPCObjectProxy(scrypted: ScryptedRuntime, port: numb
         throw new Error("invalid port");
     }
 
-    const socket = net.connect(port, '127.0.0.1');
-    socket.on('connect', () => {
-        connection.send(scrypted.clusterSecret);
+    connection.send(scrypted.clusterSecret);
 
-        socket.on('close', () => connection.close());
-        socket.on('data', data => connection.send(data.toString()));
-        connection.on('close', () => socket.destroy());
-        connection.on('message', message => socket.write(message.toString()));
-    });
+    const socket = net.connect(port, '127.0.0.1');
+    socket.on('close', () => connection.close());
+    socket.on('data', data => connection.send(data));
+    connection.on('close', () => socket.destroy());
+    connection.on('message', message => socket.write(message));
 };

--- a/server/src/plugin/plugin-remote-worker.ts
+++ b/server/src/plugin/plugin-remote-worker.ts
@@ -26,14 +26,14 @@ export interface StartPluginRemoteOptions {
     onClusterPeer(peer: RpcPeer): void;
 }
 
-interface ClusterObject {
+export interface ClusterObject {
     id: string;
     port: number;
     proxyId: string;
     source: number;
 }
 
-type ConnectRPCObject = (id: string, secret: string, sourcePeerPort: number) => Promise<any>;
+export type ConnectRPCObject = (id: string, secret: string, sourcePeerPort: number) => Promise<any>;
 
 export function startPluginRemote(mainFilename: string, pluginId: string, peerSend: (message: RpcMessage, reject?: (e: Error) => void, serializationContext?: any) => void, startPluginRemoteOptions?: StartPluginRemoteOptions) {
     const peer = new RpcPeer('unknown', 'host', peerSend);


### PR DESCRIPTION
Uses a new engine.io endpoint to serve as the transport for connectRPCObject requests coming from the web client.