### PR TITLE
server, client: send full ClusterObject on new eio endpoint

### DIFF
--- a/server/src/plugin/connect-rpc-object.ts
+++ b/server/src/plugin/connect-rpc-object.ts
@@ -6,10 +6,11 @@ export interface ClusterObject {
     id: string;
     port: number;
     proxyId: string;
-    source: number;
+    sourcePort: number;
+    sha256: string;
 }
 
-export type ConnectRPCObject = (id: string, secret: string, sourcePeerPort: number) => Promise<any>;
+export type ConnectRPCObject = (o: ClusterObject) => Promise<any>;
 
 /*
  * Handle incoming connections that will be

--- a/server/src/plugin/connect-rpc-object.ts
+++ b/server/src/plugin/connect-rpc-object.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import net from "net";
 import { Socket } from "engine.io";
 import { IOSocket } from "../io";
@@ -15,17 +16,21 @@ export type ConnectRPCObject = (o: ClusterObject) => Promise<any>;
 /*
  * Handle incoming connections that will be
  * proxied to a connectRPCObject socket.
+ *
+ * It is the responsibility of the caller of
+ * this function to verify the signature of
+ * clusterObject using the clusterSecret.
  */
-export function setupConnectRPCObjectProxy(clusterSecret: string, port: number, connection: Socket & IOSocket) {
-    if (!port) {
-        throw new Error("invalid port");
-    }
-
-    connection.send(clusterSecret);
-
-    const socket = net.connect(port, '127.0.0.1');
+export function setupConnectRPCObjectProxy(clusterObject: ClusterObject, connection: Socket & IOSocket) {
+    const socket = net.connect(clusterObject.port, '127.0.0.1');
     socket.on('close', () => connection.close());
     socket.on('data', data => connection.send(data));
     connection.on('close', () => socket.destroy());
     connection.on('message', message => socket.write(message));
 };
+
+
+export function computeClusterObjectHash(o: ClusterObject, clusterSecret: string) {
+    const sha256 = crypto.createHash('sha256').update(`${o.id}${o.port}${o.sourcePort || ''}${o.proxyId}${clusterSecret}`).digest().toString('base64');
+    return sha256;
+}


### PR DESCRIPTION
Also changes the checksums computed on the python side to be symmetric to node's signatures (both now use base64 encoding).