### PR TITLE
cli, core, ui: add `npx scrypted shell` and support interactive/noninteractive shells

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.69",
       "license": "ISC",
       "dependencies": {
-        "@scrypted/client": "^1.1.43",
-        "@scrypted/types": "^0.2.66",
+        "@scrypted/client": "^1.2.1",
+        "@scrypted/types": "^0.2.98",
         "adm-zip": "^0.5.10",
         "axios": "^0.21.4",
         "engine.io-client": "^5.2.0",
@@ -46,6 +46,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
@@ -71,15 +87,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@scrypted/client": {
-      "version": "1.1.43",
-      "resolved": "https://registry.npmjs.org/@scrypted/client/-/client-1.1.43.tgz",
-      "integrity": "sha512-qpeGdqFga/Fx51MoF3E0iBPCjE/SDEIVdGh8Ws5dqw38bxUJD264c9NsNyCguLKyYguErKTAWnQkzqhO0bUbaA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scrypted/client/-/client-1.2.1.tgz",
+      "integrity": "sha512-TVGuIhcVR/WFvE0iJjP1fHWH1/A28T/RoLtFWxU0J+dZzyGtoWnM1Tx0Hqcg3KNxUdzNhmaN+heSArG1HKFTfA==",
       "dependencies": {
-        "@scrypted/types": "^0.2.66",
+        "@scrypted/types": "^0.2.98",
         "axios": "^0.25.0",
-        "engine.io-client": "^6.4.0",
-        "rimraf": "^3.0.2"
+        "engine.io-client": "^6.5.2",
+        "rimraf": "^5.0.5"
       }
     },
     "node_modules/@scrypted/client/node_modules/axios": {
@@ -90,24 +115,84 @@
         "follow-redirects": "^1.14.7"
       }
     },
+    "node_modules/@scrypted/client/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@scrypted/client/node_modules/engine.io-client": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
+      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
+        "engine.io-parser": "~5.2.1",
         "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/@scrypted/client/node_modules/engine.io-parser": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@scrypted/client/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@scrypted/client/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@scrypted/client/node_modules/rimraf": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@scrypted/client/node_modules/ws": {
@@ -131,9 +216,9 @@
       }
     },
     "node_modules/@scrypted/types": {
-      "version": "0.2.66",
-      "resolved": "https://registry.npmjs.org/@scrypted/types/-/types-0.2.66.tgz",
-      "integrity": "sha512-AL2iD7OmpqZlQMlpZKUBHpzL7H1IHhwKOi9uhRbVwG7EIDwenTspqtziH2Hyu0+XeCLf+gN69uQB6Qlz+QPf9A=="
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/@scrypted/types/-/types-0.2.98.tgz",
+      "integrity": "sha512-zO3jmOLbvghOH74fWvbJZhHAn7YMFp6tWPTNU2OdA2epkSv/LT4aMg1jgJtgox46QzKymEfhqGQPrhYzoHqA7g=="
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
@@ -246,6 +331,28 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -282,6 +389,22 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -297,6 +420,19 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -322,6 +458,16 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/engine.io-client": {
       "version": "5.2.0",
@@ -368,6 +514,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fs.realpath": {
@@ -418,6 +579,36 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -444,6 +635,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp": {
@@ -488,6 +687,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
+      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/readline-sync": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
@@ -522,6 +755,124 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ts-node": {
@@ -590,6 +941,104 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,9 +2,9 @@
   "name": "scrypted",
   "version": "1.0.69",
   "description": "",
-  "main": "./dist/main.js",
+  "main": "./dist/packages/cli/src/main.js",
   "bin": {
-    "scrypted": "./dist/main.js"
+    "scrypted": "./dist/packages/cli/src/main.js"
   },
   "scripts": {
     "prebuild": "rimraf dist",
@@ -16,8 +16,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@scrypted/client": "^1.1.43",
-    "@scrypted/types": "^0.2.66",
+    "@scrypted/client": "^1.2.1",
+    "@scrypted/types": "^0.2.98",
     "adm-zip": "^0.5.10",
     "axios": "^0.21.4",
     "engine.io-client": "^5.2.0",

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -263,7 +263,6 @@ async function main() {
                     process.stdin.resume();
             }
         });
-        process.stdin.end(() => queue.end());
 
         async function* generator() {
             try {
@@ -276,12 +275,19 @@ async function main() {
                         // groups of buffer data, but allow string control messages
                         // to be sent without any batching
                         for (let i = 0; i < buffers.length; ++i) {
-                            if (!Buffer.isBuffer(buffers[i]) && i != buffersStart) {
-                                yield Buffer.concat(buffers.slice(buffersStart, i) as Buffer[]);
+                            if (!Buffer.isBuffer(buffers[i])) {
+                                if (i != buffersStart) {
+                                    yield Buffer.concat(buffers.slice(buffersStart, i) as Buffer[]);
+                                }
+                                buffersStart = i + 1;
+                                yield buffers[i];
                             }
-                            buffersStart = i + 1;
-                            yield buffers[i];
                         }
+
+                        if (buffersStart != buffers.length) {
+                            yield Buffer.concat(buffers.slice(buffersStart, buffers.length) as Buffer[]);
+                        }
+
                         continue;
                     }
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -246,6 +246,8 @@ async function main() {
 
         if (process.stdin.isTTY) {
             process.stdin.setRawMode(true);
+        } else {
+            process.stdin.end(() => queue.end());
         }
 
         const dim = { cols: process.stdout.columns, rows: process.stdout.rows };

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -244,7 +244,9 @@ async function main() {
         const termSvcDirect = await sdk.connectRPCObject<StreamService>(termSvc);
         const queue = createAsyncQueue<Buffer | string>();
 
-        process.stdin.setRawMode(true);
+        if (process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+        }
 
         const dim = { cols: process.stdout.columns, rows: process.stdout.rows };
         queue.enqueue(JSON.stringify({ dim }));
@@ -261,6 +263,7 @@ async function main() {
                     process.stdin.resume();
             }
         });
+        process.stdin.end(() => queue.end());
 
         async function* generator() {
             try {

--- a/packages/cli/src/shell.ts
+++ b/packages/cli/src/shell.ts
@@ -56,16 +56,16 @@ export async function connectShell(sdk: ScryptedStatic) {
             }
 
             const dataBuffers = dataQueue.clear();
-            const concat = Buffer.concat(dataBuffers);
-            if (concat.length) {
-                yield concat;
+            if (dataBuffers.length === 0) {
+                const buf = await dataQueue.dequeue();
+                if (buf.length)
+                    yield buf;
                 continue;
             }
 
-            const buf = await dataQueue.dequeue();
-            if (buf.length) {
-                yield buf;
-            }
+            const concat = Buffer.concat(dataBuffers);
+            if (concat.length)
+                yield concat;
         }
     }
 

--- a/packages/cli/src/shell.ts
+++ b/packages/cli/src/shell.ts
@@ -1,0 +1,90 @@
+import { DeviceProvider, ScryptedStatic, StreamService } from "@scrypted/types";
+import { createAsyncQueue } from '../../../common/src/async-queue';
+
+export async function connectShell(sdk: ScryptedStatic) {
+    const termSvc = await sdk.systemManager.getDeviceByName<DeviceProvider>("@scrypted/core").getDevice("terminalservice");
+    if (!termSvc) {
+        throw Error("@scrypted/core does not provide a Terminal Service");
+    }
+
+    const termSvcDirect = await sdk.connectRPCObject<StreamService>(termSvc);
+    const dataQueue = createAsyncQueue<Buffer>();
+    const ctrlQueue = createAsyncQueue<any>();
+
+    if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true);
+    } else {
+        process.stdin.on("end", () => {
+            ctrlQueue.enqueue({ eof: true });
+            dataQueue.enqueue(Buffer.alloc(0));
+        });
+    }
+    ctrlQueue.enqueue({ interactive: Boolean(process.stdin.isTTY) });
+
+    const dim = { cols: process.stdout.columns, rows: process.stdout.rows };
+    ctrlQueue.enqueue({ dim });
+
+    let bufferedLength = 0;
+    const MAX_BUFFERED_LENGTH = 64000;
+    process.stdin.on('data', async data => {
+        bufferedLength += data.length;
+        const promise = dataQueue.enqueue(data).then(() => bufferedLength -= data.length);
+        if (bufferedLength >= MAX_BUFFERED_LENGTH) {
+            process.stdin.pause();
+            await promise;
+            if (bufferedLength < MAX_BUFFERED_LENGTH)
+                process.stdin.resume();
+        }
+    });
+
+    async function* generator() {
+        while (true) {
+            const ctrlBuffers = ctrlQueue.clear();
+            if (ctrlBuffers.length) {
+                for (const ctrl of ctrlBuffers) {
+                    if (ctrl.eof) {
+                        // flush the buffer before sending eof
+                        const dataBuffers = dataQueue.clear();
+                        const concat = Buffer.concat(dataBuffers);
+                        if (concat.length) {
+                            yield concat;
+                        }
+                    }
+                    yield JSON.stringify(ctrl);
+                }
+                continue;
+            }
+
+            const dataBuffers = dataQueue.clear();
+            const concat = Buffer.concat(dataBuffers);
+            if (concat.length) {
+                yield concat;
+                continue;
+            }
+
+            const buf = await dataQueue.dequeue();
+            if (buf.length) {
+                yield buf;
+            }
+        }
+    }
+
+    process.stdout.on('resize', () => {
+        const dim = { cols: process.stdout.columns, rows: process.stdout.rows };
+        ctrlQueue.enqueue({ dim });
+        dataQueue.enqueue(Buffer.alloc(0));
+    });
+
+    try {
+        for await (const message of await termSvcDirect.connectStream(generator())) {
+            if (!message) {
+                process.exit();
+            }
+            process.stdout.write(new Uint8Array(Buffer.from(message)));
+        }
+    } catch {
+        // ignore
+    } finally {
+        process.exit();
+    }
+}

--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -1,29 +1,118 @@
 import { ScryptedDeviceBase, StreamService } from "@scrypted/sdk";
-import type { IPty, spawn as ptySpawn } from 'node-pty-prebuilt-multiarch';
+import { IPty, spawn as ptySpawn } from 'node-pty-prebuilt-multiarch';
 import { createAsyncQueue } from '@scrypted/common/src/async-queue'
+import { ChildProcess, spawn as childSpawn } from "child_process";
 
 export const TerminalServiceNativeId = 'terminalservice';
 
+
+class InteractiveTerminal {
+    cp: IPty
+
+    constructor() {
+        const spawn = require('node-pty-prebuilt-multiarch').spawn as typeof ptySpawn;
+        this.cp = spawn(process.env.SHELL as string, [], {});
+    }
+
+    onExit(fn: (e: { exitCode: number; signal?: number; }) => any) {
+        this.cp.onExit(fn)
+    };
+
+    onData(fn: (e: string) => any) {
+        this.cp.onData(fn);
+    }
+
+    pause() {
+        this.cp.pause();
+    }
+
+    resume() {
+        this.cp.resume();
+    }
+
+    write(data: string) {
+        this.cp.write(data);
+    }
+
+    sendEOF() {
+        // not supported
+    }
+
+    kill(signal?: string) {
+        this.cp.kill(signal);
+    }
+
+    resize(columns: number, rows: number) {
+        this.cp.resize(columns, rows);
+    }
+}
+
+class NoninteractiveTerminal {
+    cp: ChildProcess
+
+    constructor() {
+        this.cp = childSpawn(process.env.SHELL as string);
+    }
+
+    onExit(fn: (code: number, signal: NodeJS.Signals) => void) {
+        return this.cp.on("close", fn);
+    }
+
+    onData(fn: { (chunk: any): void; (chunk: any): void; }) {
+        this.cp.stdout.on("data", fn);
+        this.cp.stderr.on("data", fn);
+    }
+
+    pause() {
+        this.cp.stdout.pause();
+        this.cp.stderr.pause();
+    }
+
+    resume() {
+        this.cp.stdout.pause();
+        this.cp.stderr.pause();
+    }
+
+    write(data: any) {
+        this.cp.stdin.write(data);
+    }
+
+    sendEOF() {
+        this.cp.stdin.end();
+    }
+
+    kill(signal?: number | NodeJS.Signals) {
+        this.cp.kill(signal);
+    }
+
+    resize(columns: number, rows: number) {
+        // not supported
+    }
+}
+
+
 export class TerminalService extends ScryptedDeviceBase implements StreamService {
     async connectStream(input: AsyncGenerator<any, void>): Promise<AsyncGenerator<any, void>> {
-        const spawn = require('node-pty-prebuilt-multiarch').spawn as typeof ptySpawn;
-        const cp: IPty = spawn(process.env.SHELL as string, [], {});
+        let cp: InteractiveTerminal | NoninteractiveTerminal = null;
         const queue = createAsyncQueue<Buffer>();
-        cp.onExit(() => queue.end());
 
-        let bufferedLength = 0;
-        const MAX_BUFFERED_LENGTH = 64000;
-        cp.onData(async data => {
-            const buffer = Buffer.from(data);
-            bufferedLength += buffer.length;
-            const promise = queue.enqueue(buffer).then(() => bufferedLength -= buffer.length);
-            if (bufferedLength >= MAX_BUFFERED_LENGTH) {
-                cp.pause();
-                await promise;
-                if (bufferedLength < MAX_BUFFERED_LENGTH)
-                    cp.resume();
-            }
-        });
+        function registerChildListeners() {
+            cp.onExit(() => queue.end());
+
+            let bufferedLength = 0;
+            const MAX_BUFFERED_LENGTH = 64000;
+            cp.onData(async data => {
+                const buffer = Buffer.from(data);
+                bufferedLength += buffer.length;
+                const promise = queue.enqueue(buffer).then(() => bufferedLength -= buffer.length);
+                if (bufferedLength >= MAX_BUFFERED_LENGTH) {
+                    cp.pause();
+                    await promise;
+                    if (bufferedLength < MAX_BUFFERED_LENGTH)
+                        cp.resume();
+                }
+            });
+        }
 
         async function* generator() {
             try {
@@ -38,36 +127,49 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
                 }
             }
             finally {
-                cp.kill();
+                if (cp)
+                    cp.kill();
             }
         }
 
         (async () => {
             try {
                 for await (const message of input) {
-                    if (!message) {
-                        cp.kill();
-                        return;
-                    }
+                    if (!message)
+                        continue;
+
                     if (Buffer.isBuffer(message)) {
-                        cp.write(message.toString());
+                        if (cp)
+                            cp.write(message.toString());
                         continue;
                     }
+
                     try {
                         const parsed = JSON.parse(message.toString());
                         if (parsed.dim) {
-                            cp.resize(parsed.dim.cols, parsed.dim.rows);
+                            if (cp)
+                                cp.resize(parsed.dim.cols, parsed.dim.rows);
+                        } else if (parsed.eof) {
+                            if (cp)
+                                cp.sendEOF();
+                        } else if ("interactive" in parsed && !cp) {
+                            if (parsed.interactive) {
+                                cp = new InteractiveTerminal();
+                            } else {
+                                cp = new NoninteractiveTerminal();
+                            }
+                            registerChildListeners();
                         }
                     } catch {
-                        cp.write(message.toString());
+                        if (cp)
+                            cp.write(message.toString());
                     }
                 }
             }
             catch (e) {
                 this.console.log(e);
-            }
-            finally {
-                cp.kill();
+                if (cp)
+                    cp.kill();
             }
         })();
 

--- a/plugins/core/ui/src/components/builtin/ShellComponent.vue
+++ b/plugins/core/ui/src/components/builtin/ShellComponent.vue
@@ -34,6 +34,7 @@ export default {
       const termSvcDirect = await this.$scrypted.connectRPCObject(termSvc);
       const queue = createAsyncQueue();
 
+      queue.enqueue(JSON.stringify({ interactive: true }));
       queue.enqueue(JSON.stringify({ dim: { cols: term.cols, rows: term.rows } }));
 
       term.onData(data => queue.enqueue(Buffer.from(data, 'utf8')));


### PR DESCRIPTION
This is a reimplementation of #1153, but following the new design paradigm of using connectRPCObject and buffering data.

~~Unfortunately, I'm not able to get non-interactive shell working for the current setup - testing `echo date | node ./dist/packages/cli/src/main.js shell localhost:10443` closes the connection immediately without any output. Probably needs a change to core plugin to keep the connection half-open if one generator ends before the other, but that's a bit tricky to do since it's unclear when to terminate the child process. In my opinion, that part can wait for later as an enhancement, since interactive shell is going to be the main use case.~~
^ noninteractive use has been implemented in 30db66d2d353dce6b0817bd94c1c5575b5cd090a