### PR TITLE
cli, core: support invoking remote commands

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -236,7 +236,9 @@ async function main() {
             }
         });
 
-        await connectShell(sdk);
+        const separator = process.argv.indexOf("--");
+        const cmd = separator != -1 ? process.argv.slice(separator + 1): [];
+        await connectShell(sdk, ...cmd);
     }
     else {
         console.log('usage:');
@@ -249,7 +251,7 @@ async function main() {
         console.log('   npx scrypted command name-or-id[@127.0.0.1[:10443]] method-name [...method-arguments]');
         console.log('   npx scrypted ffplay name-or-id[@127.0.0.1[:10443]] method-name [...method-arguments]');
         console.log('   npx scrypted create-cert-json /path/to/key.pem /path/to/cert.pem');
-        console.log('   npx scrypted shell [127.0.0.1[:10443]]');
+        console.log('   npx scrypted shell [127.0.0.1[:10443]] [-- cmd [...cmd-args]]');
         console.log();
         console.log('examples:');
         console.log('   npx scrypted install @scrypted/rtsp');

--- a/packages/cli/src/shell.ts
+++ b/packages/cli/src/shell.ts
@@ -1,7 +1,7 @@
 import { DeviceProvider, ScryptedStatic, StreamService } from "@scrypted/types";
 import { createAsyncQueue } from '../../../common/src/async-queue';
 
-export async function connectShell(sdk: ScryptedStatic) {
+export async function connectShell(sdk: ScryptedStatic, ...cmd: string[]) {
     const termSvc = await sdk.systemManager.getDeviceByName<DeviceProvider>("@scrypted/core").getDevice("terminalservice");
     if (!termSvc) {
         throw Error("@scrypted/core does not provide a Terminal Service");
@@ -19,7 +19,7 @@ export async function connectShell(sdk: ScryptedStatic) {
             dataQueue.enqueue(Buffer.alloc(0));
         });
     }
-    ctrlQueue.enqueue({ interactive: Boolean(process.stdin.isTTY) });
+    ctrlQueue.enqueue({ interactive: Boolean(process.stdin.isTTY), cmd: cmd });
 
     const dim = { cols: process.stdout.columns, rows: process.stdout.rows };
     ctrlQueue.enqueue({ dim });

--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -34,8 +34,8 @@ class InteractiveTerminal {
         this.cp.resume();
     }
 
-    write(data: string) {
-        this.cp.write(data);
+    write(data: Buffer) {
+        this.cp.write(data.toString());
     }
 
     sendEOF() {
@@ -82,7 +82,7 @@ class NoninteractiveTerminal {
         this.cp.stderr.resume();
     }
 
-    write(data: any) {
+    write(data: Buffer) {
         this.cp.stdin.write(data);
     }
 
@@ -159,7 +159,7 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
 
                     if (Buffer.isBuffer(message)) {
                         if (cp)
-                            cp.write(message.toString());
+                            cp.write(message);
                         continue;
                     }
 
@@ -181,7 +181,7 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
                         }
                     } catch {
                         if (cp)
-                            cp.write(message.toString());
+                            cp.write(Buffer.from(message));
                     }
                 }
             }

--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -47,7 +47,8 @@ class InteractiveTerminal {
     }
 
     resize(columns: number, rows: number) {
-        this.cp.resize(columns, rows);
+        if (columns > 0 && rows > 0)
+            this.cp.resize(columns, rows);
     }
 }
 
@@ -77,8 +78,8 @@ class NoninteractiveTerminal {
     }
 
     resume() {
-        this.cp.stdout.pause();
-        this.cp.stderr.pause();
+        this.cp.stdout.resume();
+        this.cp.stderr.resume();
     }
 
     write(data: any) {


### PR DESCRIPTION
Allow `npx scrypted shell` to send a remote command and arguments to the TerminalService, instead of just running the shell. Also preserves the buffer format for noninteractive use since the string conversion breaks binary communication over the channel.

Tested with the following, which provides an ssh tunnel over this connection:
`socat -d -d -d tcp-listen:50505,fork,reuseaddr,nodelay exec:"node ./dist/packages/cli/src/main.js shell localhost\:10443 -- socat - tcp\:localhost\:22"`