### PR TITLE
core: query latest docker image via scrypted server

### DIFF
--- a/plugins/core/package-lock.json
+++ b/plugins/core/package-lock.json
@@ -88,7 +88,7 @@
       },
       "../../sdk": {
          "name": "@scrypted/sdk",
-         "version": "0.2.108",
+         "version": "0.3.4",
          "license": "ISC",
          "dependencies": {
             "@babel/preset-typescript": "^7.18.6",

--- a/plugins/core/ui/src/components/Drawer.vue
+++ b/plugins/core/ui/src/components/Drawer.vue
@@ -173,7 +173,7 @@ export default {
         const version = await info.getVersion();
         const scryptedEnv = await info.getScryptedEnv();
         this.currentVersion = version;
-        const { updateAvailable } = await checkServerUpdate(version, scryptedEnv.SCRYPTED_INSTALL_ENVIRONMENT);
+        const { updateAvailable } = await checkServerUpdate(this.$scrypted.mediaManager, version, scryptedEnv.SCRYPTED_INSTALL_ENVIRONMENT);
         this.updateAvailable = updateAvailable;
       }
 

--- a/plugins/core/ui/src/components/builtin/SettingsComponent.vue
+++ b/plugins/core/ui/src/components/builtin/SettingsComponent.vue
@@ -141,7 +141,7 @@ export default {
         // old scrypted servers dont support this call, or it may be unimplemented
         // in which case fall back and determine what the install type is.
         const scryptedEnv = await info.getScryptedEnv();
-        const { updateAvailable } = await checkServerUpdate(version, scryptedEnv.SCRYPTED_INSTALL_ENVIRONMENT);
+        const { updateAvailable } = await checkServerUpdate(this.$scrypted.mediaManager, version, scryptedEnv.SCRYPTED_INSTALL_ENVIRONMENT);
         this.updateAvailable = updateAvailable;
       }
     },

--- a/plugins/core/ui/src/components/plugin/plugin.ts
+++ b/plugins/core/ui/src/components/plugin/plugin.ts
@@ -1,4 +1,4 @@
-import { DeviceCreator, Scriptable, ScryptedInterface, ScryptedStatic, SystemManager } from '@scrypted/types';
+import { DeviceCreator, MediaObject, Scriptable, ScryptedInterface, ScryptedStatic, SystemManager, MediaManager } from '@scrypted/types';
 import axios, { AxiosResponse } from 'axios';
 import semver from 'semver';
 import { getAllDevices } from '../../common/mixin';
@@ -66,7 +66,7 @@ export async function checkUpdate(npmPackage: string, npmPackageVersion: string)
     };
 }
 
-export async function checkServerUpdate(version: string, installEnvironment: string): Promise<PluginUpdateCheck> {
+export async function checkServerUpdate(mediaManager: MediaManager, version: string, installEnvironment: string): Promise<PluginUpdateCheck> {
     const { updateAvailable, updatePublished, versions } = await checkUpdate(
         "@scrypted/server",
         version
@@ -78,8 +78,9 @@ export async function checkServerUpdate(version: string, installEnvironment: str
         // check if there is a new docker image available, using 'latest' tag
         // this is done so newer server versions in npm are not immediately
         // displayed until a docker image has been published
-        let response: AxiosResponse<any> = await axios.get("https://corsproxy.io?https://hub.docker.com/v2/namespaces/koush/repositories/scrypted/tags/latest");
-        const { data } = response;
+        // due to CORS restrictions, we query this through scrypted server
+        const mo: MediaObject = await mediaManager.createMediaObjectFromUrl('https://hub.docker.com/v2/namespaces/koush/repositories/scrypted/tags/latest');
+        const data: any = await mediaManager.convertMediaObjectToJSON(mo, 'application/json');
         const imagePublished = new Date(data.last_updated);
         console.log(`Latest docker image published ${imagePublished}`);
 


### PR DESCRIPTION
Replaces use of corsproxy with pulling latest docker tag info from scrypted server