### PR TITLE
ONVIF: ignore invalid (array) ONVIF events from Axis cameras

### DIFF
--- a/plugins/onvif/src/onvif-api.ts
+++ b/plugins/onvif/src/onvif-api.ts
@@ -90,8 +90,9 @@ export class OnvifCameraAPI {
 
             const eventTopic = stripNamespaces(event.topic._);
 
-            if (event.message.message.data && event.message.message.data.simpleItem) {
+            if (event.message.message.data && event.message.message.data.simpleItem && event.message.message.data.simpleItem.$) {
                 const dataValue = event.message.message.data.simpleItem.$.Value;
+
                 if (eventTopic.includes('MotionAlarm')) {
                     // ret.emit('event', OnvifEvent.MotionBuggy);
                     if (dataValue)


### PR DESCRIPTION
Some ONVIF events from Axis cameras seem to come in as arrays with multiple events. They don't appear related to motion, so ignoring them resolves a crash

https://discord.com/channels/882329362295316500/1193557841051664425/1193896551974707340