### PR TITLE
npm-install.sh install auth-fetch package

### DIFF
--- a/npm-install.sh
+++ b/npm-install.sh
@@ -14,7 +14,7 @@ cd $(dirname $0)
 git submodule init
 git submodule update
 
-for directory in sdk common server packages/client
+for directory in sdk common server packages/client packages/auth-fetch
 do
     echo "$directory > npm install"
     pushd $directory


### PR DESCRIPTION
Since a lot of plugins now depend on the `auth-fetch` package, the `npm-install.sh` script should probably set it up so it works out of the box.

Otherwise users will get an error when trying to debug plugins for the first time

```
> @scrypted/snapshot@0.2.34 prescrypted-vscode-launch
> scrypted-webpack

[
  {
    moduleIdentifier: 'C:\\Users\\Long\\Desktop\\scrypted\\sdk\\node_modules\\ts-loader\\index.js!C:\\Users\\Long\\Desktop\\scrypted\\packages\\auth-fetch\\src\\auth-fetch.ts',
    moduleName: '../../packages/auth-fetch/src/auth-fetch.ts',
    loc: '79:68-93',
    message: "Module not found: Error: Can't resolve 'http-auth-utils' in 'C:\\Users\\Long\\Desktop\\scrypted\\packages\\auth-fetch\\src'",
    moduleId: '../../packages/auth-fetch/src/auth-fetch.ts',
    moduleTrace: [ [Object], [Object] ],
    details: "resolve 'http-auth-utils' in 'C:\\Users\\Long\\Desktop\\scrypted\\packages\\auth-fetch\\src'\n" +
      '  Parsed request is a module\n' +
      '  using description file: C:\\Users\\Long\\Desktop\\scrypted\\packages\\auth-fetch\\package.json (relative path: ./src)\n' +
      '    resolve as module\n' +
      "      C:\\Users\\Long\\Desktop\\scrypted\\packages\\auth-fetch\\src\\node_modules doesn't exist or is not a directory\n" +
```