### PR TITLE
server: expose backup as a service

### DIFF
--- a/server/src/runtime.ts
+++ b/server/src/runtime.ts
@@ -46,6 +46,7 @@ import { getNpmPackageInfo, PluginComponent } from './services/plugin';
 import { ServiceControl } from './services/service-control';
 import { UsersService } from './services/users';
 import { getState, ScryptedStateManager, setState } from './state';
+import { Backup } from './services/backup';
 
 interface DeviceProxyPair {
     handler: PluginDeviceProxyHandler;
@@ -102,6 +103,7 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
     addressSettings = new AddressSettings(this);
     usersService = new UsersService(this);
     info = new Info();
+    backup = new Backup(this);
     pluginHosts = new Map<string, RuntimeHost>();
 
     constructor(public mainFilename: string, public datastore: Level, insecure: http.Server, secure: https.Server, app: express.Application) {
@@ -443,6 +445,8 @@ export class ScryptedRuntime extends PluginHttp<HttpPluginData> {
                 return this.addressSettings;
             case "users":
                 return this.usersService;
+            case 'backup':
+                return this.backup;
         }
     }
 

--- a/server/src/scrypted-server-main.ts
+++ b/server/src/scrypted-server-main.ts
@@ -384,28 +384,7 @@ async function start(mainFilename: string, options?: {
 
     app.get('/web/component/backup', async (req, res) => {
         try {
-            const backupDbPath = path.join(volumeDir, 'backup.db');
-            await fs.promises.rm(backupDbPath, {
-                recursive: true,
-                force: true,
-            });
-
-            const backupDb = new Level(backupDbPath);
-            await backupDb.open();
-            for await (const [key, value] of db.iterator()) {
-                await backupDb.put(key, value);
-            }
-            await backupDb.close();
-
-            const backupZip = path.join(volumeDir, 'backup.zip');
-            await fs.promises.rm(backupZip, {
-                recursive: true,
-                force: true,
-            });
-
-            const zip = new AdmZip();
-            await zip.addLocalFolderPromise(backupDbPath, {});
-            const zipBuffer = await zip.toBufferPromise();
+            const zipBuffer = await scrypted.backup.createBackup();
             // the file is a normal zip file, but an extension is added to prevent safari, etc, from unzipping it automatically.
             res.header('Content-Disposition', 'attachment; filename="scrypted.zip.backup"')
             res.send(zipBuffer);

--- a/server/src/services/backup.ts
+++ b/server/src/services/backup.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+import Level from '../level';
+import { getScryptedVolume } from '../plugin/plugin-volume';
+import AdmZip from 'adm-zip';
+import { ScryptedRuntime } from '../runtime';
+
+export class Backup {
+    constructor(public runtime: ScryptedRuntime) {}
+
+    async createBackup(): Promise<Buffer> {
+        const volumeDir = getScryptedVolume();
+
+        const backupDbPath = path.join(volumeDir, 'backup.db');
+        await fs.promises.rm(backupDbPath, {
+            recursive: true,
+            force: true,
+        });
+
+        const backupDb = new Level(backupDbPath);
+        await backupDb.open();
+        for await (const [key, value] of this.runtime.datastore.iterator()) {
+            await backupDb.put(key, value);
+        }
+        await backupDb.close();
+
+        const backupZip = path.join(volumeDir, 'backup.zip');
+        await fs.promises.rm(backupZip, {
+            recursive: true,
+            force: true,
+        });
+
+        const zip = new AdmZip();
+        await zip.addLocalFolderPromise(backupDbPath, {});
+        return zip.toBufferPromise();
+    }
+}


### PR DESCRIPTION
Moves the backup endpoint logic to a service that can be accessed by plugins with `systemManager.getComponent('backup')`.