### PR TITLE
Periodic snapshot timeout

### DIFF
--- a/plugins/homekit/src/types/camera/camera-snapshot.ts
+++ b/plugins/homekit/src/types/camera/camera-snapshot.ts
@@ -24,8 +24,8 @@ export function createSnapshotHandler(device: ScryptedDevice & VideoCamera & Cam
                 width: request.width,
                 height: request.height,
             },
-            // wait up to 2 seconds for the periodic snapshot image, fallback to cached image
-            periodicTimeout: 2000,
+            // wait up to 2 seconds for the snapshot image, fallback to cached image
+            timeout: 2000,
         })
         return await mediaManager.convertMediaObjectToBuffer(media, 'image/jpeg');
     }

--- a/plugins/homekit/src/types/camera/camera-snapshot.ts
+++ b/plugins/homekit/src/types/camera/camera-snapshot.ts
@@ -23,7 +23,9 @@ export function createSnapshotHandler(device: ScryptedDevice & VideoCamera & Cam
             picture: {
                 width: request.width,
                 height: request.height,
-            }
+            },
+            // wait up to 2 seconds for the periodic snapshot image, fallback to cached image
+            periodicTimeout: 2000,
         })
         return await mediaManager.convertMediaObjectToBuffer(media, 'image/jpeg');
     }

--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -293,11 +293,11 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 const cp = this.currentPicture;
                 debounced.catch(() => {});
                 try {
-                    picture = await (options.periodicTimeout ? timeoutPromise(options.periodicTimeout, debounced) : debounced);
+                    picture = await (options.timeout ? timeoutPromise(options.timeout, debounced) : debounced);
                 }
                 catch (e) {
-                    if (options.periodicTimeout)
-                        this.debugConsole.debug(`Periodic snapshot took longer than ${options.periodicTimeout} seconds to retrieve, falling back to cached picture.`)
+                    if (options.timeout)
+                        this.debugConsole.debug(`Periodic snapshot took longer than ${options.timeout} seconds to retrieve, falling back to cached picture.`)
 
                     picture = cp;
                 }

--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -296,6 +296,9 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                     picture = await (options.periodicTimeout ? timeoutPromise(options.periodicTimeout, debounced) : debounced);
                 }
                 catch (e) {
+                    if (options.periodicTimeout)
+                        this.debugConsole.debug(`Periodic snapshot took longer than ${options.periodicTimeout} seconds to retrieve, falling back to cached picture.`)
+
                     picture = cp;
                 }
             }

--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -293,7 +293,7 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 const cp = this.currentPicture;
                 debounced.catch(() => {});
                 try {
-                    picture = await timeoutPromise(1000, debounced);
+                    picture = await (options.periodicTimeout ? timeoutPromise(options.periodicTimeout, debounced) : debounced);
                 }
                 catch (e) {
                     picture = cp;

--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -297,7 +297,7 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 }
                 catch (e) {
                     if (options.timeout)
-                        this.debugConsole.debug(`Periodic snapshot took longer than ${options.timeout} seconds to retrieve, falling back to cached picture.`)
+                        this.debugConsole.log(`Periodic snapshot took longer than ${options.timeout} seconds to retrieve, falling back to cached picture.`)
 
                     picture = cp;
                 }

--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -283,12 +283,14 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 id: options?.id,
                 reason: options?.reason,
             }, eventSnapshot ? 0 : 2000, async () => {
+                const snapshotTimer = Date.now();
                 let picture = await this.takePictureInternal();
                 picture = await this.cropAndScale(picture);
                 this.clearCachedPictures();
                 this.currentPicture = picture;
                 this.currentPictureTime = Date.now();
                 this.lastAvailablePicture = picture;
+                this.debugConsole.debug(`Periodic snapshot took ${(this.currentPictureTime - snapshotTimer) / 1000} seconds to retrieve.`)
                 return picture;
             });
 

--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -76,12 +76,6 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 + 'The http(s) URL that retrieves a jpeg image from your camera.',
             placeholder: 'https://ip:1234/cgi-bin/snapshot.jpg',
         },
-        periodicSnapshotTimeout: {
-            title: 'Periodic snapshot timeout',
-            description: 'The amount of time (in seconds) to wait for a periodic snapshot.',
-            defaultValue: 1,
-            placeholder: '1',
-        },
         snapshotsFromPrebuffer: {
             title: 'Snapshots from Prebuffer',
             description: 'Prefer snapshots from the Rebroadcast Plugin prebuffer when available. This setting uses considerable CPU to convert a video stream into a snapshot. The Default setting will use the camera snapshot and fall back to prebuffer on failure.',
@@ -276,7 +270,6 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
         let picture: Buffer;
         const eventSnapshot = options?.reason === 'event';
         const periodicSnapshot = options?.reason === 'periodic';
-        const { periodicSnapshotTimeout } = this.storageSettings.values;
 
         try {
             const debounced = this.snapshotDebouncer({
@@ -300,10 +293,9 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 const cp = this.currentPicture;
                 debounced.catch(() => {});
                 try {
-                    picture = await timeoutPromise(periodicSnapshotTimeout * 1000, debounced);
+                    picture = await timeoutPromise(1000, debounced);
                 }
                 catch (e) {
-                    this.debugConsole.log(`Periodic snapshot took longer than ${periodicSnapshotTimeout} seconds to retrieve, using previous snapshot.`)
                     picture = cp;
                 }
             }

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -697,6 +697,7 @@ class RequestPictureOptions(TypedDict):
     bulkRequest: bool  # Flag that hints whether multiple cameras are being refreshed by this user request. Can be used to prefetch the snapshots.
     id: str
     periodicRequest: bool  # Flag that hints whether this user request is happening due to a periodic refresh.
+    periodicTimeout: float  # The maximum time in milliseconds to wait for the periodic picture to be taken.
     picture: PictureDimensions  # The native dimensions of the camera.
     reason: Any | Any  # periodic: The requestor will request the snapshot periodically so a recent cached image may be returned. event: The requestor needs an image for event processing or thumbnail. Cached or error images will not be returned.
 

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -697,9 +697,9 @@ class RequestPictureOptions(TypedDict):
     bulkRequest: bool  # Flag that hints whether multiple cameras are being refreshed by this user request. Can be used to prefetch the snapshots.
     id: str
     periodicRequest: bool  # Flag that hints whether this user request is happening due to a periodic refresh.
-    periodicTimeout: float  # The maximum time in milliseconds to wait for the periodic picture to be taken.
     picture: PictureDimensions  # The native dimensions of the camera.
     reason: Any | Any  # periodic: The requestor will request the snapshot periodically so a recent cached image may be returned. event: The requestor needs an image for event processing or thumbnail. Cached or error images will not be returned.
+    timeout: float  # The maximum time in milliseconds to wait for the picture.
 
 class RequestRecordingStreamOptions(TypedDict):
     """Options passed to VideoCamera.getVideoStream to request specific media formats. The audio/video properties may be omitted to indicate no audio/video is available when calling getVideoStreamOptions or no audio/video is requested when calling getVideoStream."""

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -454,9 +454,9 @@ export interface RequestPictureOptions extends PictureOptions {
    */
   bulkRequest?: boolean;
   /**
-   * The maximum time in milliseconds to wait for the periodic picture to be taken.
+   * The maximum time in milliseconds to wait for the picture.
    */
-  periodicTimeout?: number;
+  timeout?: number;
 }
 /**
  * Camera devices can take still photos.

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -453,6 +453,10 @@ export interface RequestPictureOptions extends PictureOptions {
    * Flag that hints whether multiple cameras are being refreshed by this user request. Can be used to prefetch the snapshots.
    */
   bulkRequest?: boolean;
+  /**
+   * The maximum time in milliseconds to wait for the periodic picture to be taken.
+   */
+  periodicTimeout?: number;
 }
 /**
  * Camera devices can take still photos.


### PR DESCRIPTION
I noticed after the snapshot timeout was added in https://github.com/koush/scrypted/commit/0e700a53d0a673e336cdaca7e0265ed3bd30ae2e, my Homekit snapshots were always delayed (the update would show the previous update maybe 70% of the time).

After doing some debugging, I noticed that my specific set up (Dahua/Amcrest 6MP cameras) would always take around a fraction of a second longer (e.g. 1.4 seconds) to return the snapshots. (I've always tried adjusting the snapshot quality but it didn't make a big enough difference). I assume this is just the nature of 6MP snapshots.

I believe the 1 second timeout was added to minimize any delays it may cause HomeKit which is understandable, however I'm willing to sacrifice a marginal delay for more up-to-date snapshots, especially over mobile where the periodic snapshots only update once every 30 seconds.

I thought it would be best if this was a configurable setting with a default of 1 second. 

For me 2 seconds was enough to avoid the issue, and it doesn't appear to have a significant impact on the HomeKit experience.

<img width="1139" alt="image" src="https://github.com/koush/scrypted/assets/484912/1692d076-1a3a-4c0f-99c1-ba0c54306856">

I also added some debug logging of how long the periodic snapshot takes and if it takes longer than the configured timeout, so people can easily debug why their snapshots might be old.

```
[Backyard] Periodic snapshot took 1.421 seconds to retrieve.
[Backyard] Periodic snapshot took longer than 1 seconds to retrieve, using previous snapshot.
```