### PR TITLE
snapshot: Fix debugConsole error

### DIFF
--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -283,7 +283,7 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 this.currentPicture = picture;
                 this.currentPictureTime = Date.now();
                 this.lastAvailablePicture = picture;
-                this.debugConsole.debug(`Periodic snapshot took ${(this.currentPictureTime - snapshotTimer) / 1000} seconds to retrieve.`)
+                this.debugConsole?.debug(`Periodic snapshot took ${(this.currentPictureTime - snapshotTimer) / 1000} seconds to retrieve.`)
                 return picture;
             });
 
@@ -297,7 +297,7 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
                 }
                 catch (e) {
                     if (options.timeout)
-                        this.debugConsole.log(`Periodic snapshot took longer than ${options.timeout} seconds to retrieve, falling back to cached picture.`)
+                        this.debugConsole?.log(`Periodic snapshot took longer than ${options.timeout} seconds to retrieve, falling back to cached picture.`)
 
                     picture = cp;
                 }


### PR DESCRIPTION
My PR https://github.com/koush/scrypted/pull/1295 had a bug where I was using `this.debugConsole` but it was `undefined` if debug logging wasn't available.