### PR TITLE
Add tsconfig strict to `sdk/types`

### DIFF
--- a/sdk/types/package-lock.json
+++ b/sdk/types/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.5",
       "license": "ISC",
       "devDependencies": {
-        "@types/rimraf": "^3.0.2",
+        "@types/node": "^18.19.15",
         "rimraf": "^3.0.2",
         "ts-node": "^10.9.1"
       }
@@ -75,36 +75,13 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "node_modules/@types/glob": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
-      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
-      "version": "18.7.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.20.tgz",
-      "integrity": "sha512-adzY4vLLr5Uivmx8+zfSJ5fbdgKxX8UMtjtl+17n0B1q1Nz8JEmE151vefMdpD+1gyh+77weN4qEhej/O7budQ==",
-      "dev": true
-    },
-    "node_modules/@types/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
       "dev": true,
       "dependencies": {
-        "@types/glob": "*",
-        "@types/node": "*"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/acorn": {
@@ -321,6 +298,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -399,36 +382,13 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "@types/glob": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
-      "integrity": "sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
-    },
     "@types/node": {
-      "version": "18.7.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.20.tgz",
-      "integrity": "sha512-adzY4vLLr5Uivmx8+zfSJ5fbdgKxX8UMtjtl+17n0B1q1Nz8JEmE151vefMdpD+1gyh+77weN4qEhej/O7budQ==",
-      "dev": true
-    },
-    "@types/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+      "version": "18.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
+      "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
       "dev": true,
       "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
+        "undici-types": "~5.26.4"
       }
     },
     "acorn": {
@@ -585,6 +545,12 @@
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
       "peer": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/sdk/types/package.json
+++ b/sdk/types/package.json
@@ -10,7 +10,7 @@
     "build": "rimraf dist gen && typedoc && ts-node ./src/build.ts && tsc"
   },
   "devDependencies": {
-    "@types/rimraf": "^3.0.2",
+    "@types/node": "^18.19.15",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1"
   },

--- a/sdk/types/tsconfig.json
+++ b/sdk/types/tsconfig.json
@@ -10,6 +10,6 @@
         "strict": true
     },
     "include": [
-        "gen/**/*"
+        "src/**/*"
     ],
 }

--- a/sdk/types/tsconfig.json
+++ b/sdk/types/tsconfig.json
@@ -6,7 +6,8 @@
         "esModuleInterop": true,
         "sourceMap": true,
         "declaration": true,
-        "outDir": "dist"
+        "outDir": "dist",
+        "strict": true
     },
     "include": [
         "gen/**/*"


### PR DESCRIPTION
Slowly adding `tsconfig` `strict` mode to all projects.

`sdk/types` was pretty easy, everything was compatible with strict.

I removed `@types/rimraf` since it didn't seem like it's being used besides the `package.json` `build` CLI command so is not necessary. Added `@types/node` which is necessary.

Fixed `include` path to actually point to `src`.