### PR TITLE
alexa: added support for `light`, `outlet`, and `fan` device types

### DIFF
--- a/plugins/alexa/.vscode/settings.json
+++ b/plugins/alexa/.vscode/settings.json
@@ -1,4 +1,4 @@
 
 {
-    "scrypted.debugHost": "koushik-ubuntu",
+    "scrypted.debugHost": "10.10.0.51",
 }

--- a/plugins/alexa/package-lock.json
+++ b/plugins/alexa/package-lock.json
@@ -1,46 +1,50 @@
 {
    "name": "@scrypted/alexa",
-   "version": "0.2.10",
+   "version": "0.3.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/alexa",
-         "version": "0.2.10",
+         "version": "0.3.0",
          "dependencies": {
             "axios": "^1.3.4",
+            "color-convert": "^2.0.1",
+            "color-converter": "^1.4.1",
             "uuid": "^9.0.0"
          },
          "devDependencies": {
             "@scrypted/common": "../../common",
             "@scrypted/sdk": "../../sdk",
+            "@types/debug": "^4.1.12",
             "@types/node": "^18.4.2"
          }
       },
       "../../common": {
+         "name": "@scrypted/common",
          "version": "1.0.1",
          "dev": true,
          "license": "ISC",
          "dependencies": {
             "@scrypted/sdk": "file:../sdk",
             "@scrypted/server": "file:../server",
-            "http-auth-utils": "^3.0.2",
-            "node-fetch-commonjs": "^3.1.1",
-            "typescript": "^4.4.3"
+            "http-auth-utils": "^5.0.1",
+            "typescript": "^5.3.3"
          },
          "devDependencies": {
-            "@types/node": "^16.9.0"
+            "@types/node": "^20.11.0",
+            "ts-node": "^10.9.2"
          }
       },
       "../../sdk": {
          "name": "@scrypted/sdk",
-         "version": "0.2.108",
+         "version": "0.3.5",
          "dev": true,
          "license": "ISC",
          "dependencies": {
             "@babel/preset-typescript": "^7.18.6",
             "adm-zip": "^0.4.13",
-            "axios": "^0.21.4",
+            "axios": "^1.6.5",
             "babel-loader": "^9.1.0",
             "babel-plugin-const-enum": "^1.1.0",
             "esbuild": "^0.15.9",
@@ -81,6 +85,21 @@
          "resolved": "../../sdk",
          "link": true
       },
+      "node_modules/@types/debug": {
+         "version": "4.1.12",
+         "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+         "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+         "dev": true,
+         "dependencies": {
+            "@types/ms": "*"
+         }
+      },
+      "node_modules/@types/ms": {
+         "version": "0.7.34",
+         "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+         "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+         "dev": true
+      },
       "node_modules/@types/node": {
          "version": "18.14.2",
          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
@@ -102,6 +121,27 @@
             "proxy-from-env": "^1.1.0"
          }
       },
+      "node_modules/color-convert": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+         "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+         "dependencies": {
+            "color-name": "~1.1.4"
+         },
+         "engines": {
+            "node": ">=7.0.0"
+         }
+      },
+      "node_modules/color-converter": {
+         "version": "1.4.1",
+         "resolved": "https://registry.npmjs.org/color-converter/-/color-converter-1.4.1.tgz",
+         "integrity": "sha512-95N7bwSWyrGnCUPjtD7f03ovo1s16ZKDT1n7iLJBW3yTG0eH8cGcZ/AUGWdXI4UhU+PSCUNUlwAgLO+gOh9/LA=="
+      },
+      "node_modules/color-name": {
+         "version": "1.1.4",
+         "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+         "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      },
       "node_modules/combined-stream": {
          "version": "1.0.8",
          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -122,9 +162,9 @@
          }
       },
       "node_modules/follow-redirects": {
-         "version": "1.15.2",
-         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-         "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+         "version": "1.15.5",
+         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+         "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
          "funding": [
             {
                "type": "individual",

--- a/plugins/alexa/package.json
+++ b/plugins/alexa/package.json
@@ -1,18 +1,19 @@
 {
    "name": "@scrypted/alexa",
-   "version": "0.2.10",
+   "version": "0.3.0",
    "scripts": {
       "scrypted-setup-project": "scrypted-setup-project",
       "prescrypted-setup-project": "scrypted-package-json",
       "build": "scrypted-webpack",
-      "prepublishOnly": "NODE_ENV=production scrypted-webpack",
+      "prepublishOnly": "scrypted-changelog && NODE_ENV=production scrypted-webpack",
       "prescrypted-vscode-launch": "scrypted-webpack",
       "scrypted-vscode-launch": "scrypted-deploy-debug",
       "scrypted-deploy-debug": "scrypted-deploy-debug",
       "scrypted-debug": "scrypted-debug",
       "scrypted-deploy": "scrypted-deploy",
-      "scrypted-readme": "scrypted-readme",
-      "scrypted-package-json": "scrypted-package-json"
+      "scrypted-changelog": "scrypted-changelog",
+      "scrypted-package-json": "scrypted-package-json",
+      "scrypted-readme": "scrypted-readme"
    },
    "keywords": [
       "scrypted",
@@ -35,11 +36,13 @@
    },
    "dependencies": {
       "axios": "^1.3.4",
+      "color-convert": "^2.0.1",
       "uuid": "^9.0.0"
    },
    "devDependencies": {
-      "@types/node": "^18.4.2",
+      "@scrypted/common": "../../common",
       "@scrypted/sdk": "../../sdk",
-      "@scrypted/common": "../../common"
+      "@types/debug": "^4.1.12",
+      "@types/node": "^18.4.2"
    }
 }

--- a/plugins/alexa/src/alexa.ts
+++ b/plugins/alexa/src/alexa.ts
@@ -1,4 +1,4 @@
-export declare type DisplayCategory = 'ACTIVITY_TRIGGER' | 'CAMERA' | 'CONTACT_SENSOR' | 'DOOR' | 'DOORBELL' | 'GARAGE_DOOR' | 'LIGHT' | 'MICROWAVE' | 'MOTION_SENSOR' | 'OTHER' | 'SCENE_TRIGGER' | 'SECURITY_PANEL' | 'SMARTLOCK' | 'SMARTPLUG' | 'SPEAKER' | 'SWITCH' | 'TEMPERATURE_SENSOR' | 'THERMOSTAT' | 'TV';
+export declare type DisplayCategory = 'ACTIVITY_TRIGGER' | 'CAMERA' | 'CONTACT_SENSOR' | 'DOOR' | 'DOORBELL' | 'GARAGE_DOOR' | 'LIGHT' | 'MICROWAVE' | 'MOTION_SENSOR' | 'OTHER' | 'SCENE_TRIGGER' | 'SECURITY_PANEL' | 'SMARTLOCK' | 'SMARTPLUG' | 'SPEAKER' | 'SWITCH' | 'TEMPERATURE_SENSOR' | 'THERMOSTAT' | 'TV' | 'FAN';
 
 /*
 COMMON DIRECTIVES AND RESPONSES
@@ -116,7 +116,7 @@ export interface ErrorPayload {
     message: string;
 }
 
-export interface ChangePayload {
+export interface ChangePayload extends Payload {
     change: {
         cause: {
             type: "APP_INTERACTION" | "PERIODIC_POLL" | "PHYSICAL_INTERACTION" | "VOICE_INTERACTION" | "RULE_TRIGGER";

--- a/plugins/alexa/src/main.ts
+++ b/plugins/alexa/src/main.ts
@@ -167,7 +167,7 @@ class AlexaPlugin extends ScryptedDeviceBase implements HttpRequestHandler, Mixi
         }
 
         if (!report) {
-            this.console.warn(`${eventDetails.eventInterface}.${eventDetails.property} not supported for device ${eventSource.type}`);
+            debug(`${eventDetails.eventInterface}.${eventDetails.property} not supported for device ${eventSource.type}`);
             return;
         }
 

--- a/plugins/alexa/src/types/fan.ts
+++ b/plugins/alexa/src/types/fan.ts
@@ -1,0 +1,71 @@
+import { OnOff, ScryptedDevice, ScryptedDeviceType, ScryptedInterface } from "@scrypted/sdk";
+import { DiscoveryEndpoint, ChangeReport, Report, Property, ChangePayload, DiscoveryCapability } from "../alexa";
+import { supportedTypes } from ".";
+
+supportedTypes.set(ScryptedDeviceType.Fan, {
+    async discover(device: ScryptedDevice): Promise<Partial<DiscoveryEndpoint>> {
+        if (!device.interfaces.includes(ScryptedInterface.OnOff))
+            return;
+
+        const capabilities: DiscoveryCapability[] = [];
+        capabilities.push({
+            "type": "AlexaInterface",
+            "interface": "Alexa.PowerController",
+            "version": "3",
+            "properties": {
+                "supported": [
+                    {
+                        "name": "powerState"
+                    }
+                ],
+                "proactivelyReported": true,
+                "retrievable": true
+            }
+        });
+
+        return {
+            displayCategories: ['FAN'],
+            capabilities
+        }
+    },
+    async sendReport(eventSource: ScryptedDevice & OnOff): Promise<Partial<Report>> {
+        return {
+            context: {
+                "properties": [
+                    {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": eventSource.on ? "ON" : "OFF",
+                        "timeOfSample": new Date().toISOString(),
+                        "uncertaintyInMilliseconds": 0
+                    } as Property
+                ]
+            }
+        };
+    },
+    async sendEvent(eventSource: ScryptedDevice & OnOff, eventDetails, eventData): Promise<Partial<Report>> {      
+        if (eventDetails.eventInterface !== ScryptedInterface.OnOff)
+            return undefined;
+
+        return {
+            event: {
+                payload: {
+                    change: {
+                        cause: {
+                            type: "PHYSICAL_INTERACTION"
+                        },
+                        properties: [
+                            {
+                                "namespace": "Alexa.PowerController",
+                                "name": "powerState",            
+                                "value": eventData ? "ON" : "OFF",
+                                "timeOfSample": new Date().toISOString(),
+                                "uncertaintyInMilliseconds": 0
+                            } as Property
+                        ]
+                    }
+                } as ChangePayload,
+            }
+        } as Partial<ChangeReport>;
+    }
+});

--- a/plugins/alexa/src/types/index.ts
+++ b/plugins/alexa/src/types/index.ts
@@ -13,8 +13,12 @@ export const supportedTypes = new Map<ScryptedDeviceType, SupportedType>();
 import '../handlers';
 import './camera';
 import './camera/handlers';
+import './light';
+import './light/handlers'
+import './fan';
 import './doorbell';
 import './garagedoor';
+import './outlet';
 import './switch';
 import './switch/handlers';
 import './sensor';

--- a/plugins/alexa/src/types/light.ts
+++ b/plugins/alexa/src/types/light.ts
@@ -1,0 +1,225 @@
+import { Brightness, ColorSettingHsv, ColorSettingTemperature, OnOff, ScryptedDevice, ScryptedDeviceType, ScryptedInterface } from "@scrypted/sdk";
+import { DiscoveryEndpoint, ChangeReport, Report, Property, ChangePayload, DiscoveryCapability, StateReport } from "../alexa";
+import { supportedTypes } from ".";
+
+supportedTypes.set(ScryptedDeviceType.Light, {
+    async discover(device: ScryptedDevice): Promise<Partial<DiscoveryEndpoint>> {
+        if (!device.interfaces.includes(ScryptedInterface.OnOff))
+            return;
+
+        const capabilities: DiscoveryCapability[] = [];
+        if (device.interfaces.includes(ScryptedInterface.OnOff)) {
+            capabilities.push({
+                "type": "AlexaInterface",
+                "interface": "Alexa.PowerController",
+                "version": "3",
+                "properties": {
+                    "supported": [{
+                        "name": "powerState"
+                    }],
+                    "proactivelyReported": true,
+                    "retrievable": true
+                }
+            });
+        }
+
+        if (device.interfaces.includes(ScryptedInterface.Brightness)) {
+            capabilities.push({
+                "type": "AlexaInterface",
+                "interface": "Alexa.BrightnessController",
+                "version": "3",
+                "properties": {
+                    "supported": [{
+                        "name": "brightness"
+                    }],
+                    "proactivelyReported": true,
+                    "retrievable": true
+                }
+            });
+        }
+
+        if (device.interfaces.includes(ScryptedInterface.ColorSettingTemperature)) {
+            capabilities.push({
+                "type": "AlexaInterface",
+                "interface": "Alexa.ColorTemperatureController",
+                "version": "3",
+                "properties": {
+                    "supported": [{
+                        "name": "colorTemperatureInKelvin"
+                    }],
+                    "proactivelyReported": true,
+                    "retrievable": true
+                }
+            });
+        }
+
+        if (device.interfaces.includes(ScryptedInterface.ColorSettingHsv)) {
+            capabilities.push({
+                "type": "AlexaInterface",
+                "interface": "Alexa.ColorController",
+                "version": "3",
+                "properties": {
+                    "supported": [{
+                        "name": "color"
+                    }],
+                    "proactivelyReported": true,
+                    "retrievable": true
+                }
+            });
+        }
+
+        return {
+            displayCategories: ['LIGHT'],
+            capabilities
+        }
+    },
+    async sendReport(eventSource: ScryptedDevice & OnOff & Brightness & ColorSettingHsv & ColorSettingTemperature): Promise<Partial<Report>> {
+        let data = {
+            context: {
+                properties: []
+            }
+            
+        } as Partial<StateReport>;
+
+        if (eventSource.interfaces.includes(ScryptedInterface.OnOff)) {
+            data.context.properties.push({
+                "namespace": "Alexa.PowerController",
+                "name": "powerState",
+                "value": eventSource.on ? "ON" : "OFF",
+                "timeOfSample": new Date().toISOString(),
+                "uncertaintyInMilliseconds": 0
+            });
+        }
+
+        if (eventSource.interfaces.includes(ScryptedInterface.Brightness)) {
+            data.context.properties.push({
+                "namespace": "Alexa.BrightnessController",
+                "name": "brightness",            
+                "value": eventSource.brightness,
+                "timeOfSample": new Date().toISOString(),
+                "uncertaintyInMilliseconds": 0
+            });
+        }        
+
+        if (eventSource.interfaces.includes(ScryptedInterface.ColorSettingHsv) && eventSource.hsv) {
+            data.context.properties.push({
+                "namespace": "Alexa.ColorController",
+                "name": "color",            
+                "value": {
+                    "hue": eventSource.hsv.h,
+                    "saturation": eventSource.hsv.s,
+                    "brightness": eventSource.hsv.v
+                },
+                "timeOfSample": new Date().toISOString(),
+                "uncertaintyInMilliseconds": 0
+            });
+        }
+
+        if (eventSource.interfaces.includes(ScryptedInterface.ColorSettingTemperature) && eventSource.colorTemperature) {
+            data.context.properties.push({
+                "namespace": "Alexa.ColorTemperatureController",
+                "name": "colorTemperatureInKelvin",            
+                "value": eventSource.colorTemperature,
+                "timeOfSample": new Date().toISOString(),
+                "uncertaintyInMilliseconds": 0
+            });
+        }
+
+        return data;
+    },
+    async sendEvent(eventSource: ScryptedDevice & OnOff & Brightness & ColorSettingHsv & ColorSettingTemperature, eventDetails, eventData): Promise<Partial<Report>> {      
+        if (eventDetails.eventInterface == ScryptedInterface.OnOff) 
+            return {
+                event: {
+                    payload: {
+                        change: {
+                            cause: {
+                                type: "PHYSICAL_INTERACTION"
+                            },
+                            properties: [
+                                {
+                                    "namespace": "Alexa.PowerController",
+                                    "name": "powerState",            
+                                    "value": eventData ? "ON" : "OFF",
+                                    "timeOfSample": new Date(eventDetails.eventTime).toISOString(),
+                                    "uncertaintyInMilliseconds": 0
+                                } as Property
+                            ]
+                        }
+                    } as ChangePayload,
+                }
+            } as Partial<ChangeReport>;
+
+        if (eventDetails.eventInterface == ScryptedInterface.Brightness && eventSource.brightness)
+            return {
+                event: {
+                    payload: {
+                        change: {
+                            cause: {
+                                type: "PHYSICAL_INTERACTION"
+                            },
+                            properties: [
+                                {
+                                    "namespace": "Alexa.BrightnessController",
+                                    "name": "brightness",            
+                                    "value": eventSource.brightness,
+                                    "timeOfSample": new Date(eventDetails.eventTime).toISOString(),
+                                    "uncertaintyInMilliseconds": 0
+                                } as Property
+                            ]
+                        }
+                    } as ChangePayload,
+                }
+            } as Partial<ChangeReport>;
+
+        if (eventDetails.eventInterface == ScryptedInterface.ColorSettingHsv && eventSource.hsv)
+            return {
+                event: {
+                    payload: {
+                        change: {
+                            cause: {
+                                type: "PHYSICAL_INTERACTION"
+                            },
+                            properties: [
+                                {
+                                    "namespace": "Alexa.ColorController",
+                                    "name": "color",            
+                                    "value": {
+                                        "hue": eventSource.hsv.h,
+                                        "saturation": eventSource.hsv.s,
+                                        "brightness": eventSource.hsv.v
+                                    },
+                                    "timeOfSample": new Date(eventDetails.eventTime).toISOString(),
+                                    "uncertaintyInMilliseconds": 0
+                                } as Property
+                            ]
+                        }
+                    } as ChangePayload,
+                }
+            } as Partial<ChangeReport>;
+
+        if (eventDetails.eventInterface == ScryptedInterface.ColorSettingTemperature && eventSource.colorTemperature)
+            return {
+                event: {
+                    payload: {
+                        change: {
+                            cause: {
+                                type: "PHYSICAL_INTERACTION"
+                            },
+                            properties: [
+                                {
+                                    "namespace": "Alexa.ColorTemperatureController",
+                                    "name": "colorTemperatureInKelvin",            
+                                    "value": eventSource.colorTemperature,
+                                    "timeOfSample": new Date(eventDetails.eventTime).toISOString(),
+                                    "uncertaintyInMilliseconds": 0
+                                } as Property
+                            ]
+                        }
+                    } as ChangePayload,
+                }
+            } as Partial<ChangeReport>;
+        
+        return undefined;
+    }
+});

--- a/plugins/alexa/src/types/light/handlers.ts
+++ b/plugins/alexa/src/types/light/handlers.ts
@@ -1,0 +1,166 @@
+import { Brightness, ColorHsv, ColorSettingHsv, ColorSettingTemperature, ScryptedDevice, ScryptedInterface } from "@scrypted/sdk";
+import { supportedTypes } from "..";
+import { deviceErrorResponse, sendDeviceResponse } from "../../common";
+import { v4 as createMessageId } from 'uuid';
+import { alexaDeviceHandlers } from "../../handlers";
+import { Directive, Response } from "../../alexa";
+import { error } from "console";
+
+function commonBrightnessResponse(header, endpoint, payload, response, device: ScryptedDevice & Brightness) {
+    const data : Response = {
+        "event": {
+            header,
+            endpoint,
+            payload
+        },
+        "context": {
+            "properties": [
+              {
+                "namespace": "Alexa.PowerController",
+                "name": "brightness",
+                "value": device.brightness,
+                "timeOfSample": new Date().toISOString(),
+                "uncertaintyInMilliseconds": 500
+              }
+            ]
+        }
+    };
+
+    data.event.header.namespace = "Alexa";
+    data.event.header.name = "Response";
+    data.event.header.messageId = createMessageId();
+
+    sendDeviceResponse(data, response, device);
+}
+
+alexaDeviceHandlers.set('Alexa.BrightnessController/SetBrightness', async (request, response, directive: Directive, device: ScryptedDevice & Brightness) => {
+    const supportedType = supportedTypes.get(device.type);
+    if (!supportedType)
+        return;
+
+    const { header, endpoint, payload } = directive;
+    await device.setBrightness((payload as any).brightness)
+
+    commonBrightnessResponse(header, endpoint, payload, response, device);
+});
+
+alexaDeviceHandlers.set('Alexa.BrightnessController/AdjustBrightness', async (request, response, directive: Directive, device: ScryptedDevice & Brightness) => {
+    const supportedType = supportedTypes.get(device.type);
+    if (!supportedType)
+        return;
+
+    const { header, endpoint, payload } = directive;
+    await device.setBrightness(device.brightness + (payload as any).brightnessDelta)
+
+    commonBrightnessResponse(header, endpoint, payload, response, device);
+});
+
+alexaDeviceHandlers.set('Alexa.ColorController/SetColor', async (request, response, directive: Directive, device: ScryptedDevice & ColorSettingHsv) => {
+    const supportedType = supportedTypes.get(device.type);
+    if (!supportedType)
+        return;
+
+    const { header, endpoint, payload } = directive;
+    let hsv : ColorHsv = { 
+        h: (payload as any).color.hue,
+        s: (payload as any).color.saturation, 
+        v: (payload as any).color.brightness
+    };
+
+    if (!device.interfaces.includes(ScryptedInterface.ColorSettingHsv))
+        return deviceErrorResponse("INVALID_REQUEST_EXCEPTION", "Device does not support setting color by HSV.", directive);
+
+    await device.setHsv(hsv.h, hsv.s, hsv.v);
+    hsv = device.hsv;
+
+    const data : Response = {
+        "event": {
+            "header": {
+                "namespace": "Alexa",
+                "name": "Response",
+                "messageId": createMessageId(),
+                "correlationToken": header.correlationToken,
+                "payloadVersion": header.payloadVersion
+            },
+            endpoint,
+            payload
+        },
+        "context": {
+            "properties": [
+              {
+                "namespace": "Alexa.ColorController",
+                "name": "color",
+                "value": {
+                    "hue": hsv.h,
+                    "saturation": hsv.s,
+                    "brightness": hsv.v
+                },
+                "timeOfSample": new Date().toISOString(),
+                "uncertaintyInMilliseconds": 500
+              }
+            ]
+        }
+    };
+
+    sendDeviceResponse(data, response, device);
+});
+
+function commonColorTemperatureResponse(header, endpoint, payload, response, device: ScryptedDevice & ColorSettingTemperature) {
+    const data : Response = {
+        "event": {
+            header,
+            endpoint,
+            payload
+        },
+        "context": {
+            "properties": [
+              {
+                "namespace": "Alexa.ColorTemperatureController",
+                "name": "colorTemperatureInKelvin",
+                "value": device.colorTemperature,
+                "timeOfSample": new Date().toISOString(),
+                "uncertaintyInMilliseconds": 500
+              }
+            ]
+        }
+    };
+
+    data.event.header.namespace = "Alexa";
+    data.event.header.name = "Response";
+    data.event.header.messageId = createMessageId();
+
+    sendDeviceResponse(data, response, device);
+}
+
+alexaDeviceHandlers.set('Alexa.ColorTemperatureController/SetColorTemperature', async (request, response, directive: Directive, device: ScryptedDevice & ColorSettingTemperature) => {
+    const supportedType = supportedTypes.get(device.type);
+    if (!supportedType)
+        return;
+
+    const { header, endpoint, payload } = directive;
+    await device.setColorTemperature((payload as any).colorTemperatureInKelvin)
+
+    commonColorTemperatureResponse(header, endpoint, payload, response, device);
+});
+
+alexaDeviceHandlers.set('Alexa.ColorTemperatureController/IncreaseColorTemperature', async (request, response, directive: Directive, device: ScryptedDevice & ColorSettingTemperature) => {
+    const supportedType = supportedTypes.get(device.type);
+    if (!supportedType)
+        return;
+
+    const { header, endpoint, payload } = directive;
+    await device.setColorTemperature(device.colorTemperature + 500);
+
+    commonColorTemperatureResponse(header, endpoint, payload, response, device);
+});
+
+alexaDeviceHandlers.set('Alexa.ColorTemperatureController/DecreaseColorTemperature', async (request, response, directive: Directive, device: ScryptedDevice & ColorSettingTemperature) => {
+    const supportedType = supportedTypes.get(device.type);
+    if (!supportedType)
+        return;
+
+    const { header, endpoint, payload } = directive;
+    await device.setColorTemperature(device.colorTemperature - 500);
+
+    commonColorTemperatureResponse(header, endpoint, payload, response, device);
+});

--- a/plugins/alexa/src/types/outlet.ts
+++ b/plugins/alexa/src/types/outlet.ts
@@ -1,0 +1,71 @@
+import { OnOff, ScryptedDevice, ScryptedDeviceType, ScryptedInterface } from "@scrypted/sdk";
+import { DiscoveryEndpoint, ChangeReport, Report, Property, ChangePayload, DiscoveryCapability } from "../alexa";
+import { supportedTypes } from ".";
+
+supportedTypes.set(ScryptedDeviceType.Outlet, {
+    async discover(device: ScryptedDevice): Promise<Partial<DiscoveryEndpoint>> {
+        if (!device.interfaces.includes(ScryptedInterface.OnOff))
+            return;
+
+        const capabilities: DiscoveryCapability[] = [];
+        capabilities.push({
+            "type": "AlexaInterface",
+            "interface": "Alexa.PowerController",
+            "version": "3",
+            "properties": {
+                "supported": [
+                    {
+                        "name": "powerState"
+                    }
+                ],
+                "proactivelyReported": true,
+                "retrievable": true
+            }
+        });
+
+        return {
+            displayCategories: ['SMARTPLUG'],
+            capabilities
+        }
+    },
+    async sendReport(eventSource: ScryptedDevice & OnOff): Promise<Partial<Report>> {
+        return {
+            context: {
+                "properties": [
+                    {
+                        "namespace": "Alexa.PowerController",
+                        "name": "powerState",
+                        "value": eventSource.on ? "ON" : "OFF",
+                        "timeOfSample": new Date().toISOString(),
+                        "uncertaintyInMilliseconds": 0
+                    } as Property
+                ]
+            }
+        };
+    },
+    async sendEvent(eventSource: ScryptedDevice & OnOff, eventDetails, eventData): Promise<Partial<Report>> {      
+        if (eventDetails.eventInterface !== ScryptedInterface.OnOff)
+            return undefined;
+
+        return {
+            event: {
+                payload: {
+                    change: {
+                        cause: {
+                            type: "PHYSICAL_INTERACTION"
+                        },
+                        properties: [
+                            {
+                                "namespace": "Alexa.PowerController",
+                                "name": "powerState",            
+                                "value": eventData ? "ON" : "OFF",
+                                "timeOfSample": new Date().toISOString(),
+                                "uncertaintyInMilliseconds": 0
+                            } as Property
+                        ]
+                    }
+                } as ChangePayload,
+            }
+        } as Partial<ChangeReport>;
+    }
+});


### PR DESCRIPTION
Added support to the `alexa` plugin to support `Light`, `Outlet`, and `Fan` device types along with `ColorSettingsHsv` and `ColorSettingTemperature` beyond the standard interfaces. 