### PR TITLE
SDK types build: calculate required/optional fields from schema

### DIFF
--- a/sdk/types/src/tsconfig.json
+++ b/sdk/types/src/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES2020",
+        "noImplicitAny": true,
+        "esModuleInterop": true,
+        "noEmit": true
+    }
+}

--- a/sdk/types/src/tsconfig.json
+++ b/sdk/types/src/tsconfig.json
@@ -4,6 +4,7 @@
         "target": "ES2020",
         "noImplicitAny": true,
         "esModuleInterop": true,
+        "resolveJsonModule": true,
         "noEmit": true
     }
 }

--- a/sdk/types/tsconfig.typedoc.json
+++ b/sdk/types/tsconfig.typedoc.json
@@ -4,6 +4,7 @@
         "target": "ESNext",
         "noImplicitAny": true,
         "esModuleInterop": true,
+        "resolveJsonModule": true,
         "sourceMap": true,
         "declaration": true,
     },


### PR DESCRIPTION
@koush I noticed you [added support for required properties](https://github.com/koush/scrypted/commit/bee77e121eafaa983b42e5c3634d74f5e3b8d43e) in the `build.ts` but I realised we can actually do this dynamically from the typedoc schema. 

In the future we can improve the types even further for `function toTypescriptType(type: any): string` and `function toPythonType(type: any): string {` but it was too much trouble so ignoring for now.