### PR TITLE
Fix type of canMixin

### DIFF
--- a/common/src/autoenable-mixin-provider.ts
+++ b/common/src/autoenable-mixin-provider.ts
@@ -73,5 +73,5 @@ export abstract class AutoenableMixinProvider extends ScryptedDeviceBase {
         this.storage.setItem('hasEnabledMixin', JSON.stringify(this.hasEnabledMixin));
     }
 
-    abstract canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[]>;
+    abstract canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null>;
 }

--- a/common/src/autoenable-mixin-provider.ts
+++ b/common/src/autoenable-mixin-provider.ts
@@ -73,5 +73,5 @@ export abstract class AutoenableMixinProvider extends ScryptedDeviceBase {
         this.storage.setItem('hasEnabledMixin', JSON.stringify(this.hasEnabledMixin));
     }
 
-    abstract canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null>;
+    abstract canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null | undefined>;
 }

--- a/common/src/autoenable-mixin-provider.ts
+++ b/common/src/autoenable-mixin-provider.ts
@@ -73,5 +73,5 @@ export abstract class AutoenableMixinProvider extends ScryptedDeviceBase {
         this.storage.setItem('hasEnabledMixin', JSON.stringify(this.hasEnabledMixin));
     }
 
-    abstract canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null | undefined>;
+    abstract canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null | undefined | void>;
 }

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -1097,7 +1097,7 @@ class Microphone:
 class MixinProvider:
     """MixinProviders can add and intercept interfaces to other devices to add or augment their behavior."""
 
-    async def canMixin(self, type: ScryptedDeviceType, interfaces: list[str]) -> list[str]:
+    async def canMixin(self, type: ScryptedDeviceType, interfaces: list[str]) -> None | list[str]:
         pass
 
     async def getMixin(self, mixinDevice: Any, mixinDeviceInterfaces: list[ScryptedInterface], mixinDeviceState: WritableDeviceState) -> Any:

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1862,7 +1862,7 @@ export interface MixinProvider {
   /**
    * Called by the system to determine if this provider can create a mixin for the supplied device. Returns null if a mixin can not be created, otherwise returns a list of new interfaces (which may be an empty list) that are provided by the mixin.
    */
-  canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[]>;
+  canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null>;
 
   /**
    * Create a mixin that can be applied to the supplied device.

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1862,7 +1862,7 @@ export interface MixinProvider {
   /**
    * Called by the system to determine if this provider can create a mixin for the supplied device. Returns null if a mixin can not be created, otherwise returns a list of new interfaces (which may be an empty list) that are provided by the mixin.
    */
-  canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null>;
+  canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null | undefined>;
 
   /**
    * Create a mixin that can be applied to the supplied device.

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1862,7 +1862,7 @@ export interface MixinProvider {
   /**
    * Called by the system to determine if this provider can create a mixin for the supplied device. Returns null if a mixin can not be created, otherwise returns a list of new interfaces (which may be an empty list) that are provided by the mixin.
    */
-  canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null | undefined>;
+  canMixin(type: ScryptedDeviceType, interfaces: string[]): Promise<string[] | null | undefined | void>;
 
   /**
    * Create a mixin that can be applied to the supplied device.


### PR DESCRIPTION
Discovered while I'm fixing the strict types for snapshot plugin

I presume because the description specifically mentions "Returns null if a mixin can not be created" and the [usage of `canMixin` checks for null](https://github.com/koush/scrypted/blob/e5d60cf3e00e4bf399a75563aab9b85192af5224/common/src/autoenable-mixin-provider.ts#L51), that `null` is the correct response type here.