### PR TITLE
Use node v18.17.0 for local Windows installation

### DIFF
--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -8,7 +8,7 @@ sc.exe stop scrypted.exe
 iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Install node.js
-choco upgrade -y nodejs-lts --version=18.14.0
+choco upgrade -y nodejs-lts --version=18.17.0
 
 # Install Python
 choco upgrade -y python39


### PR DESCRIPTION
The minimum version of node required for the `sharp` package is `v18.17.0`.

```
PS C:\Windows\System32> npm install --prefix $SCRYPTED_HOME @koush/node-windows --save
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'sharp@0.33.2',
npm WARN EBADENGINE   required: { libvips: '>=8.15.1', node: '^18.17.0 || ^20.3.0 || >=21.0.0' },
npm WARN EBADENGINE   current: { node: 'v18.14.0', npm: '9.3.1' }
npm WARN EBADENGINE }
```

Signed-off-by: Ali Yahya <amyahya@gmail.com>