### PR TITLE
amcrest: Add support for Dahua VTO built-in access control lock as a `Lock`

### DIFF
--- a/plugins/amcrest/README.md
+++ b/plugins/amcrest/README.md
@@ -39,6 +39,8 @@ Each 'Channel' or (camera) Device attached to the NVR must be configured as sepa
 * `Snapshot URL Override` camera's IP address (preferred) or specific port number of NVR for that camera (may work). That is: `http://<camera IP address>/cgi-bin/snapshot.cgi` or `http://<NVR IP address>:<NVR port # for camera>/cgi-bin/snapshot.cgi`
 * `Channel Number Override` camera's channel number as known to DVR
 
+## Dahua Lock/Unlock
+Dahua DTO video intercoms have built-in access control for locks/doors. If you have set the Amcrest plugin up with `Doorbell Type` set to `Dahua Doorbell`, you can enable support for remotely locking/unlocking by enabling/toggle the option `Enable Dahua Lock`.
 
 # Troubleshooting
 ## General

--- a/plugins/amcrest/src/amcrest-api.ts
+++ b/plugins/amcrest/src/amcrest-api.ts
@@ -125,4 +125,20 @@ export class AmcrestCameraClient {
             this.console.log(response.body);
         }
     }
+
+    async unlock(): Promise<boolean> {
+        const response = await this.request({
+            url: `http://${this.ip}/cgi-bin/accessControl.cgi?action=openDoor&channel=1&UserID=101&Type=Remote`,
+            responseType: 'text',
+        });
+        return response.body.includes('OK');
+    }
+
+    async lock(): Promise<boolean> {
+        const response = await this.request({
+            url: `http://${this.ip}/cgi-bin/accessControl.cgi?action=closeDoor&channel=1&UserID=101&Type=Remote`,
+            responseType: 'text',
+        });
+        return response.body.includes('OK');
+    }
 }

--- a/plugins/amcrest/src/main.ts
+++ b/plugins/amcrest/src/main.ts
@@ -1,6 +1,6 @@
 import { ffmpegLogInitialOutput } from '@scrypted/common/src/media-helpers';
 import { readLength } from "@scrypted/common/src/read-stream";
-import sdk, { Camera, DeviceCreatorSettings, DeviceInformation, FFmpegInput, Intercom, MediaObject, MediaStreamOptions, PictureOptions, Reboot, RequestRecordingStreamOptions, ResponseMediaStreamOptions, ScryptedDeviceType, ScryptedInterface, ScryptedMimeTypes, Setting, VideoCameraConfiguration, VideoRecorder } from "@scrypted/sdk";
+import sdk, { Camera, DeviceCreatorSettings, DeviceInformation, FFmpegInput, Intercom, Lock, MediaObject, MediaStreamOptions, PictureOptions, Reboot, RequestRecordingStreamOptions, ResponseMediaStreamOptions, ScryptedDeviceType, ScryptedInterface, ScryptedMimeTypes, Setting, VideoCameraConfiguration, VideoRecorder } from "@scrypted/sdk";
 import child_process, { ChildProcess } from 'child_process';
 import { PassThrough, Readable, Stream } from "stream";
 import { OnvifIntercom } from "../../onvif/src/onvif-intercom";
@@ -22,7 +22,7 @@ function findValue(blob: string, prefix: string, key: string) {
     return parts[1];
 }
 
-class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration, Camera, Intercom, VideoRecorder, Reboot {
+class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration, Camera, Intercom, Lock, VideoRecorder, Reboot {
     eventStream: Stream;
     cp: ChildProcess;
     client: AmcrestCameraClient;
@@ -272,6 +272,16 @@ class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration,
         if (doorbellType == DAHUA_DOORBELL_TYPE) {
             ret.push(
                 {
+                    title: 'Enable Dahua Lock',
+                    key: 'enableDahuaLock',
+                    description: 'Some Dahua Doorbells have a built in lock/door access control.',
+                    type: 'boolean',
+                    value: (this.storage.getItem('enableDahuaLock') === 'true').toString(),
+                }
+            );
+
+            ret.push(
+                {
                     title: 'Multiple Call Buttons',
                     key: 'multipleCallIds',
                     description: 'Some Dahua Doorbells integrate multiple Call Buttons for apartment buildings.',
@@ -462,6 +472,10 @@ class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration,
         if (isDoorbell || twoWayAudio) {
             interfaces.push(ScryptedInterface.Intercom);
         }
+        const enableDahuaLock = this.storage.getItem('enableDahuaLock') === 'true';
+        if (isDoorbell && doorbellType === DAHUA_DOORBELL_TYPE && enableDahuaLock) {
+            interfaces.push(ScryptedInterface.Lock);
+        }
         const continuousRecording = this.storage.getItem('continuousRecording') === 'true';
         if (continuousRecording)
             interfaces.push(ScryptedInterface.VideoRecorder);
@@ -597,6 +611,18 @@ class AmcrestCamera extends RtspSmartCamera implements VideoCameraConfiguration,
 
     showRtspUrlOverride() {
         return false;
+    }
+
+    async lock(): Promise<void> {
+        if (!this.client.lock()) {
+            this.console.error("Could not lock");
+        }
+    }
+
+    async unlock(): Promise<void> {
+        if (!this.client.unlock()) {
+            this.console.error("Could not unlock");
+        }
     }
 }
 


### PR DESCRIPTION
I have a Dahua VTO video intercom that works great with the Amcrest plugin, but also has a built in access control door lock/unlock mechanism that I'd like to use in automation inside of scrypted. This adds support for locking/unlocking when explicitly enabled for Dahua Doorbells.

I have tested this in my system locally and believe it will work with most standard VTO configurations, but happy to submit a video or similar if needed to get this merged.

Thanks!