### PR TITLE
server: bump python runtime

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "node-dijkstra": "^2.5.0",
     "node-forge": "^1.3.1",
     "node-gyp": "^10.0.1",
-    "py": "npm:@bjia56/portable-python@^0.1.23",
+    "py": "npm:@bjia56/portable-python@^0.1.26",
     "router": "^1.3.8",
     "semver": "^7.6.0",
     "sharp": "^0.33.2",


### PR DESCRIPTION
Should fix:
- Python Codecs installation error due to PyGObject compilation failure on Linux
- `debugpy` crashes on python 3.11