### PR TITLE
server: treat self.device as future

### DIFF
--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -81,10 +81,7 @@ class DeviceProxy(object):
 
     def __apply__(self, method: str, args: list):
         if not self.device:
-            self.device = Future()
-            asyncio.get_event_loop().create_task(self.systemManager.api.getDeviceById(self.id)).add_done_callback(
-                lambda f: self.device.set_result(f.result())
-            )
+            self.device = asyncio.ensure_future(self.systemManager.api.getDeviceById(self.id))
 
         async def apply():
             device = await self.device

--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -81,7 +81,10 @@ class DeviceProxy(object):
 
     def __apply__(self, method: str, args: list):
         if not self.device:
-            self.device = self.systemManager.api.getDeviceById(self.id)
+            self.device = Future()
+            asyncio.get_event_loop().create_task(self.systemManager.api.getDeviceById(self.id)).add_done_callback(
+                lambda f: self.device.set_result(f.result())
+            )
 
         async def apply():
             device = await self.device

--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -56,7 +56,7 @@ class DeviceProxy(object):
     def __init__(self, systemManager: SystemManager, id: str):
         self.systemManager = systemManager
         self.id = id
-        self.device: asyncio.Future[Any] = None
+        self.device: asyncio.Future[rpc.RpcProxy] = None
 
     def __getattr__(self, name):
         if name == 'id':

--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -56,7 +56,7 @@ class DeviceProxy(object):
     def __init__(self, systemManager: SystemManager, id: str):
         self.systemManager = systemManager
         self.id = id
-        self.device: asyncio.Future[rpc.RpcPeer] = None
+        self.device: asyncio.Future[Any] = None
 
     def __getattr__(self, name):
         if name == 'id':


### PR DESCRIPTION
Repro in a Python REPL:
```python
d = systemManager.getDeviceByName("MyCamera")
await d.getVideoStreamOptions()
await d.getVideoStreamOptions()
```
Gives error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/brettjia/workspace/scrypted/server/python/plugin_remote.py", line 87, in apply
    device = await self.device
RuntimeError: cannot reuse already awaited coroutine
```