### PR TITLE
fix(iface logic): Added net to the hlper functions to also detect ifa…

### DIFF
--- a/plugins/core/src/main.ts
+++ b/plugins/core/src/main.ts
@@ -18,7 +18,7 @@ const { systemManager, deviceManager, endpointManager } = sdk;
 export function getAddresses() {
     const addresses: string[] = [];
     for (const [iface, nif] of Object.entries(os.networkInterfaces())) {
-        if (iface.startsWith('en') || iface.startsWith('eth') || iface.startsWith('wlan')) {
+        if (iface.startsWith('en') || iface.startsWith('eth') || iface.startsWith('wlan') || iface.startsWith('net')) {
             addresses.push(iface);
             addresses.push(...nif.map(addr => addr.address));
         }

--- a/plugins/homekit/src/hap-utils.ts
+++ b/plugins/homekit/src/hap-utils.ts
@@ -66,7 +66,7 @@ export function createHAPUsername() {
 }
 
 export function getAddresses() {
-    const addresses = Object.entries(os.networkInterfaces()).filter(([iface]) => iface.startsWith('en') || iface.startsWith('eth') || iface.startsWith('wlan')).map(([_, addr]) => addr).flat().map(info => info.address).filter(address => address);
+    const addresses = Object.entries(os.networkInterfaces()).filter(([iface]) => iface.startsWith('en') || iface.startsWith('eth') || iface.startsWith('wlan') || iface.startsWith('net')).map(([_, addr]) => addr).flat().map(info => info.address).filter(address => address);
     return addresses;
 }
 


### PR DESCRIPTION
This adds logic to discover interfaces that also start with `net` 

This fixes #1436 

Also, I am not sure if your intention was to filter out `lo` or other adapters but flipping the logic to exclude might be easier to maintain with iface naming moving forward.