### PR TITLE
rknn: update docs to remove dependence on full privileged docker

### DIFF
--- a/plugins/rknn/README.md
+++ b/plugins/rknn/README.md
@@ -2,4 +2,4 @@
 
 This plugin adds object detection capabilities to any camera in Scrypted using the NPU accelerator on ARM64 Rockchip CPUs. Functionality has been tested on RK3588S, but should also work on RK3562, RK3576, and RK3588.
 
-Using this plugin in Docker requires Docker to be run with the `--privileged` flag. When using this plugin in a local install, ensure you have installed Rockchip's `librknnrt.so` as `/usr/lib/librknnrt.so`.
+Using this plugin in Docker requires Docker to be run with the `--security-opt systempaths=unconfined` flag due to a dependency on the `/proc/device-tree/compatible` file. Additionally, use the Docker flag `--device /dev/dri:/dev/dri` to ensure that the `/dev/dri/renderD129` device is accessible. When using this plugin in a local install, ensure you have installed Rockchip's `librknnrt.so` as `/usr/lib/librknnrt.so`.

--- a/plugins/rknn/package-lock.json
+++ b/plugins/rknn/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/rknn",
-   "version": "0.0.1",
+   "version": "0.0.2",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/rknn",
-         "version": "0.0.1",
+         "version": "0.0.2",
          "devDependencies": {
             "@scrypted/sdk": "file:../../sdk"
          }

--- a/plugins/rknn/package.json
+++ b/plugins/rknn/package.json
@@ -45,5 +45,5 @@
    "devDependencies": {
       "@scrypted/sdk": "file:../../sdk"
    },
-   "version": "0.0.1"
+   "version": "0.0.2"
 }


### PR DESCRIPTION
Based on what was discussed in https://github.com/blakeblackshear/frigate-hass-addons/issues/145