### PR TITLE
Fix Node 20.12.2 child_process.spawn .cmd EINVAL on Windows

### DIFF
--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -45,7 +45,7 @@ try {
 catch (e) {
 }
 const child_process = require('child_process');
-child_process.spawn('$($NPX_PATH_ESCAPED)', ['-y', 'scrypted', 'serve'], {
+child_process.spawn('$NPX_PATH_ESCAPED', ['-y', 'scrypted', 'serve'], {
     stdio: 'inherit',
     // allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
     shell: true,

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -47,7 +47,7 @@ catch (e) {
 const child_process = require('child_process');
 child_process.spawn('$($NPX_PATH_ESCAPED)', ['-y', 'scrypted', 'serve'], {
     stdio: 'inherit',
-    # allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+    // allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
     shell: true,
 });
 "@

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -35,7 +35,7 @@ npm install --prefix $SCRYPTED_HOME @koush/node-windows --save
 
 $NPX_PATH = (Get-Command npx).Path
 # The path needs double quotes to handle spaces in the directory path
-$NPX_PATH_ESCAPED = `"${$NPX_PATH.replace('\', '\\')}"`
+$NPX_PATH_ESCAPED = '"${$NPX_PATH.replace('\', '\\')}"'
 
 $SERVICE_JS = @"
 const fs = require('fs');

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -35,7 +35,7 @@ npm install --prefix $SCRYPTED_HOME @koush/node-windows --save
 
 $NPX_PATH = (Get-Command npx).Path
 # The path needs double quotes to handle spaces in the directory path
-$NPX_PATH_ESCAPED = '"' + ${$NPX_PATH.replace('\', '\\')} + '"'
+$NPX_PATH_ESCAPED = '"' + $NPX_PATH.replace('\', '\\') + '"'
 
 $SERVICE_JS = @"
 const fs = require('fs');

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -34,7 +34,8 @@ $SCRYPTED_HOME_ESCAPED_PATH = $SCRYPTED_HOME.replace('\', '\\')
 npm install --prefix $SCRYPTED_HOME @koush/node-windows --save
 
 $NPX_PATH = (Get-Command npx).Path
-$NPX_PATH_ESCAPED = $NPX_PATH.replace('\', '\\')
+# The path needs double quotes to handle spaces in the directory path
+$NPX_PATH_ESCAPED = `"${$NPX_PATH.replace('\', '\\')}"`
 
 $SERVICE_JS = @"
 const fs = require('fs');
@@ -46,6 +47,8 @@ catch (e) {
 const child_process = require('child_process');
 child_process.spawn('$($NPX_PATH_ESCAPED)', ['-y', 'scrypted', 'serve'], {
     stdio: 'inherit',
+    # allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+    shell: true,
 });
 "@
 

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -35,7 +35,7 @@ npm install --prefix $SCRYPTED_HOME @koush/node-windows --save
 
 $NPX_PATH = (Get-Command npx).Path
 # The path needs double quotes to handle spaces in the directory path
-$NPX_PATH_ESCAPED = '"${$NPX_PATH.replace('\', '\\')}"'
+$NPX_PATH_ESCAPED = '"' + ${$NPX_PATH.replace('\', '\\')} + '"'
 
 $SERVICE_JS = @"
 const fs = require('fs');

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -24,6 +24,8 @@ async function runCommand(command: string, ...args: string[]) {
             // https://github.com/lovell/sharp/blob/eefaa998725cf345227d94b40615e090495c6d09/lib/libvips.js#L115C19-L115C46
             SHARP_IGNORE_GLOBAL_LIBVIPS: 'true',
         },
+        // allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+        shell: os.platform() === 'win32' ? true : undefined,
     });
     await once(cp, 'exit');
     if (cp.exitCode)

--- a/server/src/plugin/plugin-npm-dependencies.ts
+++ b/server/src/plugin/plugin-npm-dependencies.ts
@@ -72,6 +72,8 @@ export async function installOptionalDependencies(console: Console, packageJson:
         const cp = npmExecFunction(['--prefix', nodePrefix, 'install'], {
             cwd: nodePrefix,
             stdio: 'inherit',
+            // allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+            shell: os.platform() === 'win32' ? true : undefined,
         });
 
         await once(cp, 'exit');


### PR DESCRIPTION
Fixes https://github.com/koush/scrypted/issues/1453 incompatibility with Node 20.12.2 on Windows. https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2

I looked for all usages of `child_process.spawn` which invoked a `.cmd` file and added `shell: true` (conditionally since I didn't want to change non-Windows behavior)

I also wrapped the `NPX_PATH_ESCAPED` because the path will contain spaces e.g. `C:\\Program Files\\nodejs\\npx.cmd` which doesn't work with `shell: true`

There were other usages of `child_process.spawn` which were for `ffmpeg` and `ffplay` which I don't think needs any change since those are `.exe` files.