### PR TITLE
Fix Tapo 2-way audio

### DIFF
--- a/plugins/tapo/package.json
+++ b/plugins/tapo/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/tapo",
-   "version": "0.0.11",
+   "version": "0.0.12",
    "description": "Tapo Camera Plugin for Scrypted",
    "scripts": {
       "scrypted-setup-project": "scrypted-setup-project",

--- a/plugins/tapo/src/main.ts
+++ b/plugins/tapo/src/main.ts
@@ -1,5 +1,5 @@
 import { SettingsMixinDeviceBase } from '@scrypted/common/src/settings-mixin';
-import sdk, { DeviceProvider, DeviceState, FFmpegInput, Intercom, MediaObject, MixinProvider, ScryptedDeviceBase, ScryptedDeviceType, ScryptedInterface, ScryptedMimeTypes, Setting, Settings, SettingValue, VideoCamera } from '@scrypted/sdk';
+import sdk, { DeviceProvider, FFmpegInput, Intercom, MediaObject, MixinProvider, ScryptedDeviceBase, ScryptedDeviceType, ScryptedInterface, ScryptedMimeTypes, Setting, Settings, SettingValue, VideoCamera, WritableDeviceState } from '@scrypted/sdk';
 import { StorageSettings } from '@scrypted/sdk/storage-settings';
 import { startRtpForwarderProcess } from '../../webrtc/src/rtp-forwarders';
 import { MpegTSWriter, StreamTypePCMATapo } from './mpegts-writer';
@@ -97,7 +97,7 @@ class TapoIntercom extends ScryptedDeviceBase implements MixinProvider {
         ]
     }
 
-    async getMixin(mixinDevice: any, mixinDeviceInterfaces: ScryptedInterface[], mixinDeviceState: DeviceState): Promise<any> {
+    async getMixin(mixinDevice: any, mixinDeviceInterfaces: ScryptedInterface[], mixinDeviceState: WritableDeviceState): Promise<any> {
         return new TapoIntercomMixin({
             mixinProviderNativeId: this.nativeId,
             group: 'Tapo Two Way Audio',

--- a/plugins/tapo/src/tapo-api.ts
+++ b/plugins/tapo/src/tapo-api.ts
@@ -128,6 +128,7 @@ export class TapoAPI {
                 'X-If-Encrypt': '0',
                 'X-Session-Id': this.backchannelSessionId,
             });
+            this.stream.write('\r\n');
         });
 
         this.stream.on('close', () => pt.destroy());
@@ -149,6 +150,7 @@ export class TapoAPI {
         writeMessage(this.stream, undefined, Buffer.from(JSON.stringify(request)), {
             'Content-Type': 'application/json',
         });
+        this.stream.write('\r\n');
 
         return deferred.promise;
     }

--- a/plugins/tapo/src/tapo-api.ts
+++ b/plugins/tapo/src/tapo-api.ts
@@ -4,7 +4,6 @@ import { readLine } from '@scrypted/common/src/read-stream';
 import { parseHeaders, readBody, readMessage, writeMessage } from '@scrypted/common/src/rtsp-server';
 import crypto from 'crypto';
 import { Duplex, PassThrough, Writable } from 'stream';
-import { BufferParser, StreamParser } from '../../../server/src/http-fetch-helpers';
 import { digestAuthHeader } from './digest-auth';
 
 export function getTapoAdminPassword(cloudPassword: string, useSHA256: boolean) {
@@ -32,17 +31,17 @@ export class TapoAPI {
             credential: undefined,
             url: url,
             ignoreStatusCode: true,
-        }, {
             method: 'POST',
             headers: {
                 'Content-Type': 'multipart/mixed; boundary=--client-stream-boundary--',
             },
-        }, BufferParser);
+            responseType: 'buffer',
+        });
 
         if (response.statusCode !== 401)
             throw new Error('Expected 401 status code for two way audio init')
 
-        const wwwAuthenticate = response.headers['www-authenticate'];
+        const wwwAuthenticate = response.headers.get('www-authenticate') ?? '';
         const useSHA256 = wwwAuthenticate.includes('encrypt_type="3"');
 
         const password = getTapoAdminPassword(options.cloudPassword, useSHA256);
@@ -52,16 +51,16 @@ export class TapoAPI {
         const response2 = await authHttpFetch({
             credential: undefined,
             url: url,
-        }, {
             method: 'POST',
             headers: {
                 'Authorization': auth,
                 'Content-Type': 'multipart/mixed; boundary=--client-stream-boundary--',
             },
-        }, StreamParser)
+            responseType: 'readable',
+        })
 
         const tapo = new TapoAPI();
-        tapo.keyExchange = response2.headers['key-exchange'] as string;
+        tapo.keyExchange = response2.headers.get('key-exchange') ?? '';
         tapo.stream = response2.body.socket;
         tapo.stream.on('close', () => console.error('stream closed'));
         // this.stream.on('data', data => console.log('data', data));


### PR DESCRIPTION
The tapo stream just needed another `\r\n` to accept the requests. Working great for me via the UI and HomeKit (after reload).