### PR TITLE
homekit: fix late 2way setup

### DIFF
--- a/plugins/homekit/src/types/camera/camera-streaming.ts
+++ b/plugins/homekit/src/types/camera/camera-streaming.ts
@@ -354,12 +354,11 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
             if (twoWayAudio) {
                 let rtspServer: RtspServer;
                 let track: string;
-                let playing = false;
-                let initializing = false;
+                let twoWayAudioState: 'stopped' | 'starting' | 'started' = 'stopped';
 
-                const initialize = async () => {
+                const start = async () => {
                     try {
-                        initializing = true;
+                        twoWayAudioState = 'starting';
                         const { clientPromise, url } = await listenZeroSingleClient();
                         const rtspUrl = url.replace('tcp', 'rtsp');
                         let sdp = createReturnAudioSdp(session.startRequest.audio);
@@ -390,7 +389,7 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
                             device.stopIntercom();
                             client.destroy();
                             rtspServer = undefined;
-                            playing = false;
+                            twoWayAudioState = 'stopped';
                         }
                         // stop the intercom if the client dies for any reason.
                         // allow the streaming session to continue however.
@@ -399,19 +398,17 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
 
                         rtspServer = new RtspServer(client, sdp);
                         await rtspServer.handlePlayback();
-                        playing = true;
+                        twoWayAudioState = 'started';
                     }
                     catch (e) {
                         console.error('two way audio failed', e);
-                    }
-                    finally {
-                        initializing = false;
+                        twoWayAudioState = 'stopped';
                     }
                 };
 
                 const srtpSession = new SrtpSession(session.aconfig);
                 session.audioReturn.on('message', buffer => {
-                    if (initializing)
+                    if (twoWayAudioState === 'starting')
                         return;
 
                     const decrypted = srtpSession.decrypt(buffer);
@@ -420,8 +417,8 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
                     if (rtp.header.payloadType !== session.startRequest.audio.pt)
                         return;
 
-                    if (!playing)
-                        return initialize();
+                    if (twoWayAudioState !== 'started')
+                        return start();
 
                     rtspServer.sendTrack(track, decrypted, false);
                 });


### PR DESCRIPTION
When my ring doorbell sets up a streaming session, the first message on the audio return channel isn't a request to setup 2way. In that case, the "once" handler would fire (and bail) and when the real 2way setup message would arrive, the setup listener was no longer registered and nothing would happen. This PR moves the 2way setup into the always-on listener, and creates a guard to prevent multiple setup requests from running concurrently. It should also allow retrying the setup if something temporarily went wrong on a previous attempt.