### PR TITLE
webrtc: don't store audio codec before intercom start

### DIFF
--- a/plugins/webrtc/src/wrtc-to-rtsp.ts
+++ b/plugins/webrtc/src/wrtc-to-rtsp.ts
@@ -275,13 +275,12 @@ export async function createRTCPeerConnectionSource(options: {
 
         let destroyProcess: () => void;
 
-        const audioCodec = audioTransceiver?.sender?.codec;
-
         const ic: Intercom = {
             async startIntercom(media: MediaObject) {
                 if (!isPeerConnectionAlive(pc))
                     throw new Error('peer connection is closed');
 
+                const audioCodec = audioTransceiver?.sender?.codec;
                 if (!audioTransceiver?.sender?.sendRtp || !audioCodec)
                     throw new Error('peer connection does not support two way audio');
 


### PR DESCRIPTION
The audio transceiver sender can set its codec after the initial setup, but a null value was being stored if it wasn't immediately available. This PR simply checks the codec whenever the intercom starts rather than using the cached value. 

This (along with #1461) totally fixes my ring pro doorbell two-way audio. It makes sense because when I would force the ring plugin to use the "browser" webrtc endpoint, it immediately turned on 2-way and set up the codec, making the cached value correct. But the web socket ring webrtc endpoint delays 2-way setup, so the initial audio codec is null, and `wrtc-to-rtsp` would error when starting the intercom even though the codec was set up correctly at that point.