### PR TITLE
Fix Windows server install with installDir containing space

### DIFF
--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -14,8 +14,12 @@ const EXIT_FILE = '.exit';
 const UPDATE_FILE = '.update';
 
 async function runCommand(command: string, ...args: string[]) {
-    if (os.platform() === 'win32')
+    if (os.platform() === 'win32') {
         command += '.cmd';
+        // wrap each argument in a quote to handle spaces in paths
+        // https://github.com/nodejs/node/issues/38490#issuecomment-927330248
+        args = args.map(arg => '"' + arg + '"');
+    }
     console.log('running', command, ...args);
     const cp = child_process.spawn(command, args, {
         stdio: 'inherit',

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -43,7 +43,7 @@ async function runCommandEatError(command: string, ...args: string[]) {
 
 export async function runServer(installDir: string) {
     console.log('Starting scrypted main...');
-    await runCommand('npm', '--prefix', '"'+installDir+'"', 'exec', 'scrypted-serve');
+    await runCommand('npm', '--prefix', installDir, 'exec', 'scrypted-serve');
 }
 
 async function startServer(installDir: string) {
@@ -98,7 +98,7 @@ export async function installServe(installVersion: string, ignoreError?: boolean
         version: process.version,
     }));
 
-    const args = ['--prefix', '"'+installDir+'"', 'install', '--production', `@scrypted/server@${installVersion}`]
+    const args = ['--prefix', installDir, 'install', '--production', `@scrypted/server@${installVersion}`]
     if (ignoreError)
         await runCommandEatError('npm', ...args);
     else
@@ -137,7 +137,7 @@ export async function serveMain(installVersion?: string) {
 
         if (fs.existsSync(UPDATE_FILE)) {
             console.log('Update requested. Installing.');
-            await runCommandEatError('npm', '--prefix', '"'+installDir+'"', 'install', '--production', '@scrypted/server@latest').catch(e => {
+            await runCommandEatError('npm', '--prefix', installDir, 'install', '--production', '@scrypted/server@latest').catch(e => {
                 console.error('Update failed', e);
             });
             console.log('Exiting.');

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -43,7 +43,7 @@ async function runCommandEatError(command: string, ...args: string[]) {
 
 export async function runServer(installDir: string) {
     console.log('Starting scrypted main...');
-    await runCommand('npm', '--prefix', installDir, 'exec', 'scrypted-serve');
+    await runCommand('npm', '--prefix', '"'+installDir+'"', 'exec', 'scrypted-serve');
 }
 
 async function startServer(installDir: string) {
@@ -98,7 +98,7 @@ export async function installServe(installVersion: string, ignoreError?: boolean
         version: process.version,
     }));
 
-    const args = ['--prefix', installDir, 'install', '--production', `@scrypted/server@${installVersion}`]
+    const args = ['--prefix', '"'+installDir+'"', 'install', '--production', `@scrypted/server@${installVersion}`]
     if (ignoreError)
         await runCommandEatError('npm', ...args);
     else
@@ -137,7 +137,7 @@ export async function serveMain(installVersion?: string) {
 
         if (fs.existsSync(UPDATE_FILE)) {
             console.log('Update requested. Installing.');
-            await runCommandEatError('npm', '--prefix', installDir, 'install', '--production', '@scrypted/server@latest').catch(e => {
+            await runCommandEatError('npm', '--prefix', '"'+installDir+'"', 'install', '--production', '@scrypted/server@latest').catch(e => {
                 console.error('Update failed', e);
             });
             console.log('Exiting.');


### PR DESCRIPTION
Addresses issue with installing on Windows when the user profile directory contains a path, e.g. `C:\Users\john doe` https://discord.com/channels/882329362295316500/1237486685030322176/1238683790562431066

The `child_process.spawn` with `shell: true` ([required for Node 20.12.2 on Windows](https://github.com/koush/scrypted/pull/1455)) would fail if there are spaces in the path

