### PR TITLE
tapo: normalize fetch header case

### DIFF
--- a/plugins/tapo/src/tapo-api.ts
+++ b/plugins/tapo/src/tapo-api.ts
@@ -36,6 +36,7 @@ export class TapoAPI {
                 'Content-Type': 'multipart/mixed; boundary=--client-stream-boundary--',
             },
             responseType: 'buffer',
+            normalizeHeaders: true,
         });
 
         if (response.statusCode !== 401)
@@ -57,6 +58,7 @@ export class TapoAPI {
                 'Content-Type': 'multipart/mixed; boundary=--client-stream-boundary--',
             },
             responseType: 'readable',
+            normalizeHeaders: true,
         })
 
         const tapo = new TapoAPI();

--- a/server/src/fetch/http-fetch.ts
+++ b/server/src/fetch/http-fetch.ts
@@ -84,7 +84,8 @@ export async function httpFetch<T extends HttpFetchOptions<Readable>>(options: T
     }
 
     const nodeHeaders: Record<string, string[]> = {};
-    for (const [k, v] of headers) {
+    for (let [k, v] of headers) {
+        if (options.normalizeHeaders) k = k.replace(/((?:^|-)\w)/g, v => v.toUpperCase());
         if (nodeHeaders[k]) {
             nodeHeaders[k].push(v);
         }

--- a/server/src/fetch/http-fetch.ts
+++ b/server/src/fetch/http-fetch.ts
@@ -85,6 +85,7 @@ export async function httpFetch<T extends HttpFetchOptions<Readable>>(options: T
 
     const nodeHeaders: Record<string, string[]> = {};
     for (let [k, v] of headers) {
+        // Normalize header names to capitalized kebab-case (`content-type` => `Content-Type`)
         if (options.normalizeHeaders) k = k.replace(/((?:^|-)\w)/g, v => v.toUpperCase());
         if (nodeHeaders[k]) {
             nodeHeaders[k].push(v);

--- a/server/src/fetch/index.ts
+++ b/server/src/fetch/index.ts
@@ -11,6 +11,7 @@ export interface HttpFetchOptionsBase<B> {
     ignoreStatusCode?: boolean;
     body?: B | string | ArrayBufferView | any;
     withCredentials?: boolean;
+    normalizeHeaders?: boolean;
 }
 
 export interface HttpFetchJsonOptions<B> extends HttpFetchOptionsBase<B> {


### PR DESCRIPTION
Fixes two-way audio on tapo cameras that require case-sensitive http headers.