### PR TITLE
server: make fetching network interfaces optional

### DIFF
--- a/server/src/server-settings.ts
+++ b/server/src/server-settings.ts
@@ -29,7 +29,14 @@ function nodeIpAddress(family: number): string[] {
         ...costlyNetworks,
     ];
 
-    const interfaces = os.networkInterfaces();
+    let interfaces: any;
+    try {
+        interfaces = os.networkInterfaces();
+    } catch {
+        // bjia56: When running in secured environments like UserLAnd in Android, os.networkInterfaces()
+        // is unable to get addresses and throws an error. Therefore, assume we can't find any addresses.
+        return [];
+    }
 
     const all = Object.keys(interfaces)
         .map((nic) => {


### PR DESCRIPTION
This allows Scrypted server to start up in UserLAnd on Android without rooting.