### PR TITLE
server: patch os.networkInterfaces for android compatibility

### DIFF
--- a/server/src/compatibility.ts
+++ b/server/src/compatibility.ts
@@ -1,0 +1,29 @@
+import os from 'os';
+
+export const SCRYPTED_INSTALL_ENVIRONMENT_ANDROID = "android";
+
+function ensureAndroidCompatibility() {
+    /*
+     * On Android, Scrypted can run within a standard Linux filesystem through proot.
+     * However, os.networkInterfaces() is incompatible and will raise an error.
+     * We can instead pass the required data through environment variables.
+     *
+     * The SCRYPTED_NETINTERFACES variable contains JSON-formatted data in the same
+     * format as os.networkInterfaces().
+     */
+    let scryptedInterfaces: any = {};
+    if (process.env.SCRYPTED_NETINTERFACES) {
+        try {
+            scryptedInterfaces = JSON.parse(process.env.SCRYPTED_NETINTERFACES);
+        } catch (e) {
+            console.error("Failed to parse SCRYPTED_NETINTERFACES: " + e);
+        }
+    }
+    os.networkInterfaces = () => scryptedInterfaces;
+}
+
+export function ensureCompatibility() {
+    if (process.env.SCRYPTED_INSTALL_ENVIRONMENT === SCRYPTED_INSTALL_ENVIRONMENT_ANDROID) {
+        ensureAndroidCompatibility();
+    }
+}

--- a/server/src/scrypted-main-exports.ts
+++ b/server/src/scrypted-main-exports.ts
@@ -9,6 +9,7 @@ import { PluginError } from './plugin/plugin-error';
 import { getScryptedVolume } from './plugin/plugin-volume';
 import { RPCResultError, startPeriodicGarbageCollection } from './rpc';
 import type { Runtime } from './scrypted-server-main';
+import { ensureCompatibility } from './compatibility';
 
 export function isChildProcess() {
     return process.argv[2] === 'child' || process.argv[2] === 'child-thread'
@@ -17,6 +18,8 @@ export function isChildProcess() {
 function start(mainFilename: string, options?: {
     onRuntimeCreated?: (runtime: Runtime) => Promise<void>,
 }) {
+    ensureCompatibility();
+
     if (!global.gc) {
         v8.setFlagsFromString('--expose_gc')
         global.gc = vm.runInNewContext("gc");

--- a/server/src/server-settings.ts
+++ b/server/src/server-settings.ts
@@ -29,14 +29,7 @@ function nodeIpAddress(family: number): string[] {
         ...costlyNetworks,
     ];
 
-    let interfaces: any;
-    try {
-        interfaces = os.networkInterfaces();
-    } catch {
-        // bjia56: When running in secured environments like UserLAnd in Android, os.networkInterfaces()
-        // is unable to get addresses and throws an error. Therefore, assume we can't find any addresses.
-        return [];
-    }
+    const interfaces = os.networkInterfaces();
 
     const all = Object.keys(interfaces)
         .map((nic) => {


### PR DESCRIPTION
Replace `os.networkInterfaces` with a function that reads from an environment variable, if the install target is set to `android`. This patch is done early in the node process stack for both scrypted server and node plugins.

Undos #1474 since the workaround is no longer needed after this change.