### PR TITLE
server: add SCRYPTED_COMPATIBILITY_FILE

### DIFF
--- a/server/src/scrypted-main-exports.ts
+++ b/server/src/scrypted-main-exports.ts
@@ -1,5 +1,6 @@
 import dns from 'dns';
 import dotenv from 'dotenv';
+import fs from 'fs';
 import path from 'path';
 import process from 'process';
 import semver from 'semver';
@@ -17,6 +18,13 @@ export function isChildProcess() {
 function start(mainFilename: string, options?: {
     onRuntimeCreated?: (runtime: Runtime) => Promise<void>,
 }) {
+    // Allow including a custom file path for platforms that require
+    // compatibility hacks. For example, Android may need to patch
+    // os functions.
+    if (process.env.SCRYPTED_COMPATIBILITY_FILE && fs.existsSync(process.env.SCRYPTED_COMPATIBILITY_FILE)) {
+        require(process.env.SCRYPTED_COMPATIBILITY_FILE);
+    }
+
     if (!global.gc) {
         v8.setFlagsFromString('--expose_gc')
         global.gc = vm.runInNewContext("gc");


### PR DESCRIPTION
Follow up to #1477 

Sample usage for Android:

`patch.js`
```js
const os = require('os');
os.networkInterfaces = () => JSON.parse(process.env.SCRYPTED_INTERFACES);
```

launch scrypted server as:
```
SCRYPTED_COMPATIBILITY_FILE=/root/patch.js SCRYPTED_INTERFACES='{"eth0":[{"address": "192.168.0.188","family": "IPv4"}]}' npm run serve
```