### PR TITLE
server: print python interpreter path

### DIFF
--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -557,6 +557,7 @@ class PluginRemote:
             python_version = 'python%s' % str(
                 sys.version_info[0])+"."+str(sys.version_info[1])
             print('python version:', python_version)
+            print('interpreter:', sys.executable)
 
             python_versioned_directory = '%s-%s-%s' % (
                 python_version, platform.system(), platform.machine())


### PR DESCRIPTION
Mainly useful to identify if someone is using portable-python or system python. 