### PR TITLE
Homekit camera close recording tweaks

### DIFF
--- a/plugins/homekit/src/types/camera.ts
+++ b/plugins/homekit/src/types/camera.ts
@@ -117,7 +117,7 @@ addSupportedType({
                 },
                 closeRecordingStream(streamId, reason) {
                     const r = openRecordingStreams.get(streamId);
-                    r?.throw(new Error(reason?.toString()));
+                    console.log(`motion recording closed ${reason > 0 ? `(error code: ${reason})` : ''}`);
                     openRecordingStreams.delete(streamId);
                 },
                 updateRecordingActive(active) {

--- a/plugins/homekit/src/types/camera/camera-recording.ts
+++ b/plugins/homekit/src/types/camera/camera-recording.ts
@@ -371,7 +371,7 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
         }
     }
     catch (e) {
-        console.log(`motion recording completed ${e}`);
+        console.log(`motion recording error ${e}`);
     }
     finally {
         console.log(`motion recording finished`);

--- a/plugins/homekit/src/types/camera/camera-recording.ts
+++ b/plugins/homekit/src/types/camera/camera-recording.ts
@@ -323,7 +323,7 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
         for await (const box of generator) {
             if (!isOpen())
                 return;
-
+            
             const { header, type, data } = box;
             // console.log('motion fragment box', type);
 
@@ -355,6 +355,8 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
                     needSkip = false;
                     continue;
                 }
+                if (!isOpen())
+                    return;
                 const fragment = Buffer.concat(pending);
                 saveFragment(i, fragment);
                 pending = [];

--- a/plugins/homekit/src/types/camera/camera-recording.ts
+++ b/plugins/homekit/src/types/camera/camera-recording.ts
@@ -321,6 +321,9 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
         let moov: Buffer[];
 
         for await (const box of generator) {
+            if (!isOpen())
+                return;
+
             const { header, type, data } = box;
             // console.log('motion fragment box', type);
 
@@ -361,8 +364,6 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
                     data: fragment,
                     isLast,
                 }
-                if (!isOpen())
-                    return;
                 yield recordingPacket;
                 if (wasLast)
                     break;


### PR DESCRIPTION
Fix `r?.throw` because the generator is already closed/finished by the time it runs, so it never triggers the `catch()`

Added `console.log` to print a more friendly error message (only include error code is if it's >0)

Moved `!isOpen()` check. HAP requests last fragment even though it's already closed the recording stream. Now the fragment request is ignored entirely (rather than just skipping the `yield`).