### PR TITLE
Add security_opt to allow the container to talk to host avahi daemon

### DIFF
--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
             # Avahi can be used for network discovery by passing in the host daemon
             # or running the daemon inside the container. Choose one or the other.
             # Uncomment next line to run avahi-daemon inside the container.
-            # See volumes section below to use the host daemon.
+            # See volumes and security_opt section below to use the host daemon.
             # - SCRYPTED_DOCKER_AVAHI=true
 
             # NVIDIA (Part 1 of 4)
@@ -71,11 +71,16 @@ services:
             # Ensure Avahi is running on the host machine:
             # It can be installed with: sudo apt-get install avahi-daemon
             # This is not compatible with running avahi inside the container (see above).
+            # Also, uncomment the lines under security_opt
             # - /var/run/dbus:/var/run/dbus
             # - /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket
 
             # Default volume for the Scrypted database. Typically should not be changed.
             - ~/.scrypted/volume:/server/volume
+        # Uncomment the following lines to use Avahi daemon from the host
+        # Without this, AppArmor will block the container's attempt to talk to Avahi via dbus
+        # security_opt:
+        #     - apparmor:unconfined
         devices: [
             # uncomment the common systems devices to pass
             # them through to docker.

--- a/install/docker/install-scrypted-docker-compose.sh
+++ b/install/docker/install-scrypted-docker-compose.sh
@@ -61,6 +61,8 @@ then
     sudo apt-get -y install avahi-daemon
     sed -i 's/'#' - \/var\/run\/dbus/- \/var\/run\/dbus/g' $DOCKER_COMPOSE_YML
     sed -i 's/'#' - \/var\/run\/avahi-daemon/- \/var\/run\/avahi-daemon/g' $DOCKER_COMPOSE_YML
+    sed -i 's/'#' security_opt:/security_opt:/g' $DOCKER_COMPOSE_YML
+    sed -i 's/'#'     - apparmor:unconfined/    - apparmor:unconfined/g' $DOCKER_COMPOSE_YML
 fi
 
 echo "Setting permissions on $SCRYPTED_HOME"


### PR DESCRIPTION
While running the Avahi daemon on the host and scrypted in a docker container, I noticed that the homekit plugin would fail with the following exception:
<img width="899" alt="Screenshot 2024-05-27 at 11 20 18 PM" src="https://github.com/koush/scrypted/assets/3393447/05d25448-6dc8-4cdf-b2c9-879082ed367c">

Debugging the homebridge lib, I found out that it was caused by this error:
```
'An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call", sender="(null)" (inactive) interface="org.freedesktop.DBus" member="Hello" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus)'
```

I found this snippet in the homebridge docs (https://github.com/homebridge/homebridge/wiki/mDNS-Options#avahi-linux-and-docker)
> Unless you've disabled AppArmor on your Linux distro, or it's disabled by default, you'll also need to set a security_opt setting of apparmor:unconfined, otherwise AppArmor will block the container's attempt to talk to Avahi via dbus

After adding those lines to my own docker-compose file and restarting, it seemed to work.

This PR adds those lines to the docker-compose.yml and installation script, when the user wants to use host avahi