### PR TITLE
actions: replace local install test with setup-scrypted action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
         id: parse_server
         shell: bash
         run: |
-          VERSION=$(cat ./server/package.json | jq -r '.version')
+          VERSION=$(cat ./server/package-lock.json | jq -r '.version')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Will test @scrypted/server@$VERSION"
 
       - name: Install scrypted server
         uses: scryptedapp/setup-scrypted@v0.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-14, macos-14-large, windows-latest]
+        runner: [ubuntu-latest, macos-14, macos-13, windows-latest]
     
     steps:
       - name: Install scrypted server
-        uses: scryptedapp/setup-scrypted@v0
+        uses: scryptedapp/setup-scrypted@v0.0.2
         with:
           branch: ${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,18 @@ jobs:
         runner: [ubuntu-latest, macos-14, macos-13, windows-latest]
     
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Parse latest server release
+        id: parse_server
+        shell: bash
+        run: |
+          VERSION=$(cat ./server/package.json | jq -r '.version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Install scrypted server
         uses: scryptedapp/setup-scrypted@v0.0.2
         with:
           branch: ${{ github.sha }}
+          version: ${{ steps.parse_server.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,52 +9,16 @@ on:
   workflow_dispatch:
   
 jobs:
-  test_linux_local:
-    name: Test Linux local installation
-    runs-on: ubuntu-latest
+  test_local:
+    name: Test local installation on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-14, macos-14-large, windows-latest]
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - name: Run install script
-        run: |
-          cat ./install/local/install-scrypted-dependencies-linux.sh | sudo SERVICE_USER=$USER bash
-          
-      - name: Test server is running
-        run: |
-          systemctl status scrypted.service
-          curl -k --retry 20 --retry-all-errors --retry-max-time 600 https://localhost:10443/
-          
-  test_mac_local:
-    name: Test Mac local installation
-    runs-on: macos-latest
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - name: Run install script
-        run: |
-          mkdir -p ~/.scrypted
-          bash ./install/local/install-scrypted-dependencies-mac.sh
-          
-      - name: Test server is running
-        run: |
-          curl -k --retry 20 --retry-all-errors --retry-max-time 600 https://localhost:10443/
-          
-  test_windows_local:
-    name: Test Windows local installation
-    runs-on: windows-latest
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - name: Run install script
-        run: |
-          .\install\local\install-scrypted-dependencies-win.ps1
-          
-      - name: Test server is running
-        run: |
-          curl -k --retry 20 --retry-all-errors --retry-max-time 600 https://localhost:10443/
+      - name: Install scrypted server
+        uses: scryptedapp/setup-scrypted@v0
+        with:
+          branch: ${{ github.sha }}


### PR DESCRIPTION
This should let the test properly target the install scripts and the scrypted server version contained within the commit SHA that triggered the test.

Tests run on MacOS 13 and 14 to capture both x64 and arm64, respectively.