### PR TITLE
reolink: save GetAiState to hasObjectDetector so object detector can work

### DIFF
--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -91,7 +91,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, Reboot, Intercom,
         }
 
         try {
-            const ai: AIState = this.storageSettings.values.hasObjectDetector[0]?.value;
+            const ai: AIState = this.storageSettings.values.hasObjectDetector?.value;
             const classes: string[] = [];
 
             for (const key of Object.keys(ai)) {
@@ -203,6 +203,8 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, Reboot, Intercom,
 
                     if (!classes.length)
                         return;
+
+                    this.storageSettings.values.hasObjectDetector = ai;
 
                     hasSucceeded = true;
                     const od: ObjectsDetected = {

--- a/plugins/reolink/src/reolink-api.ts
+++ b/plugins/reolink/src/reolink-api.ts
@@ -122,7 +122,7 @@ export class ReolinkCameraClient {
             responseType: 'json',
         });
         return {
-            value: response.body?.[0]?.value as AIState,
+            value: (response.body?.[0]?.value || response.body?.value) as AIState,
             data: response.body,
         };
     }


### PR DESCRIPTION
I purchased some CX410's the other day and noticed that the Video Analysis plugin wouldn't recognize the cameras as it does my POE Doorbell.

With this patch, I can create a new smart motion sensor for the camera, and the object detector drop down will show 'dog_cat', 'people', and 'vehicle' as expected.