### PR TITLE
reolink: add ONVIF objection detection for cameras that can support it

### DIFF
--- a/plugins/reolink/package-lock.json
+++ b/plugins/reolink/package-lock.json
@@ -6,7 +6,7 @@
    "packages": {
       "": {
          "name": "@scrypted/reolink",
-         "version": "0.0.66",
+         "version": "0.0.67",
          "license": "Apache",
          "dependencies": {
             "@scrypted/common": "file:../../common",
@@ -14,6 +14,7 @@
             "onvif": "file:../onvif/onvif"
          },
          "devDependencies": {
+            "@scrypted/sdk": "file:../../sdk",
             "@types/node": "^18.16.18"
          }
       },
@@ -24,23 +25,23 @@
          "dependencies": {
             "@scrypted/sdk": "file:../sdk",
             "@scrypted/server": "file:../server",
-            "http-auth-utils": "^3.0.2",
-            "node-fetch-commonjs": "^3.1.1",
+            "http-auth-utils": "^5.0.1",
             "typescript": "^5.3.3"
          },
          "devDependencies": {
-            "@types/node": "^20.10.8",
+            "@types/node": "^20.11.0",
             "ts-node": "^10.9.2"
          }
       },
       "../../sdk": {
          "name": "@scrypted/sdk",
-         "version": "0.3.4",
+         "version": "0.3.31",
+         "dev": true,
          "license": "ISC",
          "dependencies": {
             "@babel/preset-typescript": "^7.18.6",
             "adm-zip": "^0.4.13",
-            "axios": "^0.21.4",
+            "axios": "^1.6.5",
             "babel-loader": "^9.1.0",
             "babel-plugin-const-enum": "^1.1.0",
             "esbuild": "^0.15.9",

--- a/plugins/reolink/package.json
+++ b/plugins/reolink/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/reolink",
-   "version": "0.0.66",
+   "version": "0.0.67",
    "description": "Reolink Plugin for Scrypted",
    "author": "Scrypted",
    "license": "Apache",
@@ -40,6 +40,7 @@
       "onvif": "file:../onvif/onvif"
    },
    "devDependencies": {
-      "@types/node": "^18.16.18"
+      "@types/node": "^18.16.18",
+      "@scrypted/sdk": "file:../../sdk"
    }
 }


### PR DESCRIPTION
A few changes here:

1. the doorbell checkbox is removed from the UI.  We can auto-detect it using the `type` field from `GetDevInfo`.
2. ~`hasObjectDetector` is changed to a boolean and inferred by a call to `GetAiState` when the camera is created~
3. a new ONVIF dropdown in the UI - the user can choose whether to use ONVIF detection or polling the camera's `GetAiState`
4. ONVIF events are mapped to the values that come back from GetAiState, which are in turn picked up by the video analysis plugin
5. Bump the plugin version


Thanks!