### PR TITLE
reolink: fix deviceprovider for cameras with siren

### DIFF
--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -206,7 +206,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
         if (this.storageSettings.values.hasObjectDetector) {
             interfaces.push(ScryptedInterface.ObjectDetector);
         }
-        if (this.storageSettings.values.abilities?.Ability?.supportAudioAlarm?.ver && this.storageSettings.values.abilities?.Ability?.supportAudioAlarm?.ver !== 0) {
+        if (this.storageSettings.values.abilities?.value?.Ability?.supportAudioAlarm?.ver && this.storageSettings.values.abilities?.value?.Ability?.supportAudioAlarm?.ver !== 0) {
             interfaces.push(ScryptedInterface.DeviceProvider);
         }
         await this.provider.updateDevice(this.nativeId, name, interfaces, type);


### PR DESCRIPTION
Looks like I inadvertently caused a bug.  It's more than likely I had a cached response in my storage settings from intermediate code.

Anyway, my "production" instance of Scrypted synced up with the latest publish and I couldn't see the sirens after adding in my test camera.

This fixes it.

Apologies as I'm still learning my way around this codebase.