### PR TITLE
reolink: use Login json api to get around URL escaping limitations with some firmware

### DIFF
--- a/plugins/reolink/src/reolink-api.ts
+++ b/plugins/reolink/src/reolink-api.ts
@@ -4,7 +4,6 @@ import https, { RequestOptions } from 'https';
 import { PassThrough, Readable } from 'stream';
 import { HttpFetchOptions, HttpFetchResponseType } from '../../../server/src/fetch/http-fetch';
 
-import { getMotionState, reolinkHttpsAgent } from './probe';
 import { PanTiltZoomCommand } from "@scrypted/sdk";
 import { sleep } from "@scrypted/common/src/sleep";
 
@@ -65,6 +64,8 @@ export type SirenResponse = {
 
 export class ReolinkCameraClient {
     credential: AuthFetchCredentialState;
+    token: string;
+    tokenLease: number = Date.now();
 
     constructor(public host: string, public username: string, public password: string, public channelId: number, public console: Console) {
         this.credential = {
@@ -73,11 +74,9 @@ export class ReolinkCameraClient {
         };
     }
 
-    async request(urlOrOptions: string | URL | HttpFetchOptions<Readable>, body?: Readable) {
+    private async request(options: HttpFetchOptions<Readable>, body?: Readable) {
         const response = await authHttpFetch({
-            ...typeof urlOrOptions !== 'string' && !(urlOrOptions instanceof URL) ? urlOrOptions : {
-                url: urlOrOptions,
-            },
+            ...options,
             rejectUnauthorized: false,
             credential: this.credential,
             body,
@@ -85,14 +84,61 @@ export class ReolinkCameraClient {
         return response;
     }
 
+    async login() {
+        if (this.tokenLease > Date.now()) {
+            return;
+        }
+
+        this.console.log(`token expired at ${this.tokenLease}, renewing...`);
+
+        const url = new URL(`http://${this.host}/api.cgi`);
+        const params = url.searchParams;
+        params.set('cmd', 'Login');
+
+        const createReadable = (data: any) => {
+            const pt = new PassThrough();
+            pt.write(Buffer.from(JSON.stringify(data)));
+            pt.end();
+            return pt;
+        }
+
+        const response = await this.request({
+            url,
+            method: 'POST',
+            responseType: 'json',
+        }, createReadable([
+            {
+                cmd: 'Login',
+                action: 0,
+                param: {
+                    User: {
+                        userName: this.username,
+                        password: this.password
+                    }
+                }
+            },
+        ]));
+        this.token = response.body?.[0]?.value?.Token?.name || response.body?.value?.Token?.name;
+        if (!this.token) {
+            throw new Error('unable to login');
+        }
+        this.tokenLease = Date.now() + 1000 * (response.body?.[0]?.value?.Token.leaseTime || response.body?.value?.Token.leaseTime);
+    }
+
+    async requestWithLogin(options: HttpFetchOptions<Readable>, body?: Readable) {
+        await this.login();
+        const url = options.url as URL;
+        const params = url.searchParams;
+        params.set('token', this.token);
+        return this.request(options, body);
+    }
+
     async reboot() {
         const url = new URL(`http://${this.host}/api.cgi`);
         const params = url.searchParams;
         params.set('cmd', 'Reboot');
-        params.set('user', this.username);
-        params.set('password', this.password);
-        const response = await this.request({
-            url: url.toString(),
+        const response = await this.requestWithLogin({
+            url,
             responseType: 'json',
         });
         return {
@@ -111,7 +157,18 @@ export class ReolinkCameraClient {
     //     }
     //  ]
     async getMotionState() {
-        return getMotionState(this.credential, this.username, this.password, this.host, this.channelId);
+        const url = new URL(`http://${this.host}/api.cgi`);
+        const params = url.searchParams;
+        params.set('cmd', 'GetMdState');
+        params.set('channel', this.channelId.toString());
+        const response = await this.requestWithLogin({
+            url,
+            responseType: 'json',
+        });
+        return {
+            value: !!response.body?.[0]?.value?.state,
+            data: response.body,
+        };
     }
 
     async getAiState() {
@@ -119,9 +176,7 @@ export class ReolinkCameraClient {
         const params = url.searchParams;
         params.set('cmd', 'GetAiState');
         params.set('channel', this.channelId.toString());
-        params.set('user', this.username);
-        params.set('password', this.password);
-        const response = await this.request({
+        const response = await this.requestWithLogin({
             url,
             responseType: 'json',
         });
@@ -136,9 +191,7 @@ export class ReolinkCameraClient {
         const params = url.searchParams;
         params.set('cmd', 'GetAbility');
         params.set('channel', this.channelId.toString());
-        params.set('user', this.username);
-        params.set('password', this.password);
-        const response = await this.request({
+        const response = await this.requestWithLogin({
             url,
             responseType: 'json',
         });
@@ -154,10 +207,8 @@ export class ReolinkCameraClient {
         params.set('cmd', 'Snap');
         params.set('channel', this.channelId.toString());
         params.set('rs', Date.now().toString());
-        params.set('user', this.username);
-        params.set('password', this.password);
 
-        const response = await this.request({
+        const response = await this.requestWithLogin({
             url,
             timeout,
         });
@@ -171,9 +222,7 @@ export class ReolinkCameraClient {
         params.set('cmd', 'GetEnc');
         // is channel used on this call?
         params.set('channel', this.channelId.toString());
-        params.set('user', this.username);
-        params.set('password', this.password);
-        const response = await this.request({
+        const response = await this.requestWithLogin({
             url,
             responseType: 'json',
         });
@@ -185,9 +234,7 @@ export class ReolinkCameraClient {
         const url = new URL(`http://${this.host}/api.cgi`);
         const params = url.searchParams;
         params.set('cmd', 'GetDevInfo');
-        params.set('user', this.username);
-        params.set('password', this.password);
-        const response = await this.request({
+        const response = await this.requestWithLogin({
             url,
             responseType: 'json',
         });
@@ -195,12 +242,10 @@ export class ReolinkCameraClient {
         return response.body?.[0]?.value?.DevInfo;
     }
 
-    async ptzOp(op: string) {
+    private async ptzOp(op: string) {
         const url = new URL(`http://${this.host}/api.cgi`);
         const params = url.searchParams;
         params.set('cmd', 'PtzCtrl');
-        params.set('user', this.username);
-        params.set('password', this.password);
 
         const createReadable = (data: any) => {
             const pt = new PassThrough();
@@ -209,7 +254,7 @@ export class ReolinkCameraClient {
             return pt;
         }
 
-        const c1 = this.request({
+        const c1 = this.requestWithLogin({
             url,
             method: 'POST',
             responseType: 'text',
@@ -227,7 +272,7 @@ export class ReolinkCameraClient {
 
         await sleep(500);
 
-        const c2 = this.request({
+        const c2 = this.requestWithLogin({
             url,
             method: 'POST',
         }, createReadable([
@@ -273,8 +318,6 @@ export class ReolinkCameraClient {
         const url = new URL(`http://${this.host}/api.cgi`);
         const params = url.searchParams;
         params.set('cmd', 'AudioAlarmPlay');
-        params.set('user', this.username);
-        params.set('password', this.password);
         const createReadable = (data: any) => {
             const pt = new PassThrough();
             pt.write(Buffer.from(JSON.stringify(data)));
@@ -296,7 +339,7 @@ export class ReolinkCameraClient {
             };
         }
 
-        const response = await this.request({
+        const response = await this.requestWithLogin({
             url,
             method: 'POST',
             responseType: 'json',


### PR DESCRIPTION
I noticed that I was unable to login to some of my cameras with Scrypted because my passwords have hyphens and spaces in them.  In fact, the latest firmware available for my RLN36 NVR and CX410s requires the passwords to have passwords with mixed alpha-numeric and various symbols as can be seen from this screenshot:

<img width="745" alt="Screenshot 2024-06-26 at 22 06 11" src="https://github.com/koush/scrypted/assets/355585/951b69a1-63b7-4e0c-9796-bf6b669a839a">

Here we'll switch over to using the Login API which has a JSON payload for the password.  Each of the functions will check if the token has expired, and if so, we will re-perform the login to get a new token.