### PR TITLE
Fix plugin NPM dependencies failing to install on Windows with path containing space

### DIFF
--- a/server/src/plugin/plugin-npm-dependencies.ts
+++ b/server/src/plugin/plugin-npm-dependencies.ts
@@ -9,8 +9,12 @@ import { ensurePluginVolume } from "./plugin-volume";
 
 export function defaultNpmExec(args: string[], options: child_process.SpawnOptions) {
     let npm = 'npm';
-    if (os.platform() === 'win32')
+    if (os.platform() === 'win32') {
         npm += '.cmd';
+        // wrap each argument in a quote to handle spaces in paths
+        // https://github.com/nodejs/node/issues/38490#issuecomment-927330248
+        args = args.map(arg => '"' + arg + '"');
+    }
     const cp = child_process.spawn(npm, args, options);
     return cp;
 }


### PR DESCRIPTION
Fixes https://discord.com/channels/882329362295316500/932852072024518726/1256029193842593913

Similar to https://github.com/koush/scrypted/pull/1471 but fixes plugin install calling `npm --prefix ... install` (which I wasn't aware of before) in a Windows path containing space which had an error

I reproed the issue and here was the log which led me to the issue

```
plugin start/fork failed Error: npm installation failed with exit code 1
    at installOptionalDependencies (C:\Users\john doe\.scrypted\node_modules\@scrypted\server\dist\plugin\plugin-npm-dependencies.js:78:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.onLoadZip (C:\Users\john doe\.scrypted\node_modules\@scrypted\server\dist\plugin\plugin-remote-worker.js:266:13)
    at async Object.loadZip (C:\Users\john doe\.scrypted\node_modules\@scrypted\server\dist\plugin\plugin-remote.js:588:28)
    at async RpcPeer.handleMessageInternal (C:\Users\john doe\.scrypted\node_modules\@scrypted\server\dist\rpc.js:602:37)
```