### PR TITLE
server: fix python connectRPCObject sha256

### DIFF
--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -404,7 +404,7 @@ class PluginRemote:
 
         def computeClusterObjectHash(o: ClusterObject) -> str:
             m = hashlib.sha256()
-            m.update(bytes(f"{o['id']}{o['port']}{o.get('sourcePort', '')}{o['proxyId']}{clusterSecret}", 'utf8'))
+            m.update(bytes(f"{o['id']}{o['port']}{o.get('sourcePort') or ''}{o['proxyId']}{clusterSecret}", 'utf8'))
             return base64.b64encode(m.digest()).decode('utf-8')
 
         def onProxySerialization(value: Any, proxyId: str, sourcePeerPort: int = None):


### PR DESCRIPTION
In the Python implementation, sourcePort is always present in the cluster object, but can be None. When the key is present, this value is always part of the Python hash calculation. On the JavaScript side, even when the key is present and set to null/undefined, it's excluded from the hash calculation. This change makes the Python calculation consistent with the JavaScript implementation.