### PR TITLE
sdk, rebroadcast: don't automatically prebuffer synthetic streams

### DIFF
--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -1407,6 +1407,13 @@ class PrebufferMixin extends SettingsMixinDeviceBase<VideoCamera> implements Vid
         log.a(`${this.name} is a cloud camera. Prebuffering maintains a persistent stream and will not be enabled by default. You must enable the Prebuffer stream manually.`)
       }
     }
+    if (this.storage.getItem('warnedSynthetic') !== 'true') {
+      const synthetic = msos?.find(mso => mso.source === 'synthetic');
+      if (synthetic) {
+        this.storage.setItem('warnedSynthetic', 'true');
+        log.a(`${this.name} is a synthetic stream requiring substantial transcoding overhead. Prebuffering maintains a persistent stream and will not be enabled by default. You must enable the Prebuffer stream manually.`)
+      }
+    }
 
     if (!enabledIds.length)
       this.online = true;

--- a/plugins/prebuffer-mixin/src/stream-settings.ts
+++ b/plugins/prebuffer-mixin/src/stream-settings.ts
@@ -144,7 +144,7 @@ export function createStreamSettings(device: MixinDeviceBase<VideoCamera>) {
         const local = getMediaStream(storageSettings.keys.defaultStream, msos);
         const remoteRecording = getMediaStream(storageSettings.keys.remoteRecordingStream, msos);
 
-        if (!local?.stream || local.stream.source === 'cloud')
+        if (!local?.stream || local.stream.source === 'cloud' || local.stream.source === 'synthetic')
             return [];
 
         if (local.stream.id === remoteRecording.stream.id)

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -477,7 +477,7 @@ export interface AudioStreamOptions {
   sampleRate?: number;
 }
 
-export type MediaStreamSource = "local" | "cloud";
+export type MediaStreamSource = "local" | "cloud" | "synthetic";
 export type MediaStreamTool = 'ffmpeg' | 'scrypted' | 'gstreamer';
 
 /**


### PR DESCRIPTION
Adds a new stream source type `synthetic` which represents a stream source generated by software running on the Scrypted server. This is treated the same as cloud cameras, where it's not prebuffered by default unless manually enabled.