### PR TITLE
sdk: add TTYSettings

### DIFF
--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -183,9 +183,9 @@ class ScryptedInterface(str, Enum):
     StartStop = "StartStop"
     StreamService = "StreamService"
     TTY = "TTY"
+    TTYSettings = "TTYSettings"
     TamperSensor = "TamperSensor"
     TemperatureSetting = "TemperatureSetting"
-    TerminalSettings = "TerminalSettings"
     Thermometer = "Thermometer"
     UltravioletSensor = "UltravioletSensor"
     VOCSensor = "VOCSensor"
@@ -1478,6 +1478,13 @@ class TTY:
 
     pass
 
+class TTYSettings:
+    """TTYSettings allows TTY backends to query plugins for modifications to the (non-)interactive terminal environment."""
+
+    async def getTTYSettings(self) -> Any:
+        pass
+
+
 class TamperSensor:
 
     tampered: TamperState
@@ -1487,13 +1494,6 @@ class TemperatureSetting:
 
     temperatureSetting: TemperatureSettingStatus
     async def setTemperature(self, command: TemperatureCommand) -> None:
-        pass
-
-
-class TerminalSettings:
-    """TerminalSettings allows TerminalService to query plugins for modifications to the (non-)interactive terminal environment."""
-
-    def getPaths(self) -> list[str]:
         pass
 
 
@@ -1936,7 +1936,7 @@ class ScryptedInterfaceMethods(str, Enum):
     getScryptedUserAccessControl = "getScryptedUserAccessControl"
     generateVideoFrames = "generateVideoFrames"
     connectStream = "connectStream"
-    getPaths = "getPaths"
+    getTTYSettings = "getTTYSettings"
 
 class DeviceState:
 
@@ -3151,10 +3151,10 @@ ScryptedInterfaceDescriptors = {
     "methods": [],
     "properties": []
   },
-  "TerminalSettings": {
-    "name": "TerminalSettings",
+  "TTYSettings": {
+    "name": "TTYSettings",
     "methods": [
-      "getPaths"
+      "getTTYSettings"
     ],
     "properties": []
   },

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -185,6 +185,7 @@ class ScryptedInterface(str, Enum):
     TTY = "TTY"
     TamperSensor = "TamperSensor"
     TemperatureSetting = "TemperatureSetting"
+    TerminalSettings = "TerminalSettings"
     Thermometer = "Thermometer"
     UltravioletSensor = "UltravioletSensor"
     VOCSensor = "VOCSensor"
@@ -1489,6 +1490,13 @@ class TemperatureSetting:
         pass
 
 
+class TerminalSettings:
+    """TerminalSettings allows TerminalService to query plugins for modifications to the (non-)interactive terminal environment."""
+
+    def getPaths(self) -> list[str]:
+        pass
+
+
 class Thermometer:
 
     temperature: float  # Get the ambient temperature in Celsius.
@@ -1928,6 +1936,7 @@ class ScryptedInterfaceMethods(str, Enum):
     getScryptedUserAccessControl = "getScryptedUserAccessControl"
     generateVideoFrames = "generateVideoFrames"
     connectStream = "connectStream"
+    getPaths = "getPaths"
 
 class DeviceState:
 
@@ -3140,6 +3149,13 @@ ScryptedInterfaceDescriptors = {
   "TTY": {
     "name": "TTY",
     "methods": [],
+    "properties": []
+  },
+  "TerminalSettings": {
+    "name": "TerminalSettings",
+    "methods": [
+      "getPaths"
+    ],
     "properties": []
   },
   "ScryptedSystemDevice": {

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1537,6 +1537,16 @@ export interface StreamService<Input, Output=Input> {
 export interface TTY {
 }
 /**
+ * TerminalSettings allows TerminalService to query plugins for modifications
+ * to the (non-)interactive terminal environment.
+ */
+export interface TerminalSettings {
+  /**
+   * List of extra PATHs to add to the terminal environment
+   */
+  getPaths(): string[];
+}
+/**
  * Logger is exposed via log.* to allow writing to the Scrypted log.
  */
 export interface Logger {
@@ -2152,6 +2162,7 @@ export enum ScryptedInterface {
   VideoFrameGenerator = 'VideoFrameGenerator',
   StreamService = 'StreamService',
   TTY = 'TTY',
+  TerminalSettings = 'TerminalSettings',
 
   ScryptedSystemDevice = "ScryptedSystemDevice",
   ScryptedDeviceCreator = "ScryptedDeviceCreator",

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1537,14 +1537,13 @@ export interface StreamService<Input, Output=Input> {
 export interface TTY {
 }
 /**
- * TerminalSettings allows TerminalService to query plugins for modifications
+ * TTYSettings allows TTY backends to query plugins for modifications
  * to the (non-)interactive terminal environment.
  */
-export interface TerminalSettings {
-  /**
-   * List of extra PATHs to add to the terminal environment
-   */
-  getPaths(): string[];
+export interface TTYSettings {
+  getTTYSettings(): Promise<{
+    paths?: string[];
+  }>;
 }
 /**
  * Logger is exposed via log.* to allow writing to the Scrypted log.
@@ -2162,7 +2161,7 @@ export enum ScryptedInterface {
   VideoFrameGenerator = 'VideoFrameGenerator',
   StreamService = 'StreamService',
   TTY = 'TTY',
-  TerminalSettings = 'TerminalSettings',
+  TTYSettings = 'TTYSettings',
 
   ScryptedSystemDevice = "ScryptedSystemDevice",
   ScryptedDeviceCreator = "ScryptedDeviceCreator",


### PR DESCRIPTION
Intended to be used by btop plugin to add the path where btop is installed to the interactive terminal.