### PR TITLE
server: add unzipped path to python module lookup path

### DIFF
--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -798,9 +798,7 @@ class PluginRemote:
                 print("requirements.txt (up to date)")
                 print(str_requirements)
 
-            sys.path.insert(0, zipPath)
-            if not debug:
-                sys.path.insert(0, plugin_zip_paths.get("unzipped_path"))
+            sys.path.insert(0, plugin_zip_paths.get("unzipped_path"))
             sys.path.insert(0, pip_target)
 
         self.systemManager = SystemManager(self.api, self.systemState)

--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -799,6 +799,8 @@ class PluginRemote:
                 print(str_requirements)
 
             sys.path.insert(0, zipPath)
+            if not debug:
+                sys.path.insert(0, plugin_zip_paths.get("unzipped_path"))
             sys.path.insert(0, pip_target)
 
         self.systemManager = SystemManager(self.api, self.systemState)


### PR DESCRIPTION
So... I'm not sure how this ever worked.

The unzipped path wasn't added to the Python system path, so it was never explicitly available when looking up modules. It seems that pure-Python sources were unaffected, however loading binary extension modules bundled together inside the plugin (e.g. plugins compiled by [Nuitka ](https://github.com/Nuitka/Nuitka)) would never get found. This change adds the unzipped path but keeps existing behavior

This change will need some additional beta testing before release. I am able to load existing plugins just fine (OpenCV, Python Codecs, OpenVINO, btop, btop-camera).