### PR TITLE
server: update portable-python

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -29,7 +29,7 @@
         "node-dijkstra": "^2.5.0",
         "node-forge": "^1.3.1",
         "node-gyp": "^10.2.0",
-        "py": "npm:@bjia56/portable-python@^0.1.54",
+        "py": "npm:@bjia56/portable-python@^0.1.74",
         "router": "^1.3.8",
         "semver": "^7.6.3",
         "sharp": "^0.33.4",
@@ -2969,9 +2969,9 @@
     },
     "node_modules/py": {
       "name": "@bjia56/portable-python",
-      "version": "0.1.54",
-      "resolved": "https://registry.npmjs.org/@bjia56/portable-python/-/portable-python-0.1.54.tgz",
-      "integrity": "sha512-cvE+K+NEsFEa0H5iMn5RWEE5FdAxxmhNqFRafRcqd1kbGdB5kb5MZs2LC1amurB3BD/2pb9ZS/1iABwaNjgT5A==",
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@bjia56/portable-python/-/portable-python-0.1.74.tgz",
+      "integrity": "sha512-gg8t3/5d5c/anPb9NTvf68CSZXMXKJ/9ITycpCquMRP7A0YfHn4l493ifQY+d8/XCooSs9qWSisGufZaAb21UA==",
       "dependencies": {
         "adm-zip": "^0.5.10"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
     "node-dijkstra": "^2.5.0",
     "node-forge": "^1.3.1",
     "node-gyp": "^10.2.0",
-    "py": "npm:@bjia56/portable-python@^0.1.54",
+    "py": "npm:@bjia56/portable-python@^0.1.74",
     "router": "^1.3.8",
     "semver": "^7.6.3",
     "sharp": "^0.33.4",


### PR DESCRIPTION
Needed to rebuild server after #1542 

No functional changes for python 3.10 other than removing tkinter UI libs, bumping Zig compiler, and updating certifi certificates to the latest. Python directory structure has changed, adding `-headless` to the path.