### PR TITLE
webrtc: convert RTCSignalingChannel to FFmpegInput + consolidate all converters

### DIFF
--- a/plugins/webrtc/package-lock.json
+++ b/plugins/webrtc/package-lock.json
@@ -83,7 +83,7 @@
       },
       "../../sdk": {
          "name": "@scrypted/sdk",
-         "version": "0.3.50",
+         "version": "0.3.52",
          "license": "ISC",
          "dependencies": {
             "@babel/preset-typescript": "^7.24.7",

--- a/plugins/webrtc/package.json
+++ b/plugins/webrtc/package.json
@@ -25,7 +25,7 @@
       "interfaces": [
          "EngineIOHandler",
          "Settings",
-         "BufferConverter",
+         "MediaConverter",
          "MixinProvider",
          "DeviceProvider"
       ]

--- a/plugins/webrtc/src/ffmpeg-to-wrtc.ts
+++ b/plugins/webrtc/src/ffmpeg-to-wrtc.ts
@@ -17,6 +17,7 @@ import { getAudioCodec, getFFmpegRtpAudioOutputArguments } from "./webrtc-requir
 import { WeriftSignalingSession } from "./werift-signaling-session";
 
 export const RTC_BRIDGE_NATIVE_ID = 'rtc-bridge';
+export const RTC_FFMPEG_BRIDGE_NATIVE_ID = 'ffmpeg-bridge';
 
 function getDebugModeH264EncoderArgs() {
     return [

--- a/plugins/webrtc/src/ffmpeg-to-wrtc.ts
+++ b/plugins/webrtc/src/ffmpeg-to-wrtc.ts
@@ -17,7 +17,6 @@ import { getAudioCodec, getFFmpegRtpAudioOutputArguments } from "./webrtc-requir
 import { WeriftSignalingSession } from "./werift-signaling-session";
 
 export const RTC_BRIDGE_NATIVE_ID = 'rtc-bridge';
-export const RTC_FFMPEG_BRIDGE_NATIVE_ID = 'ffmpeg-bridge';
 
 function getDebugModeH264EncoderArgs() {
     return [

--- a/plugins/webrtc/src/ffmpeg-to-wrtc.ts
+++ b/plugins/webrtc/src/ffmpeg-to-wrtc.ts
@@ -16,8 +16,6 @@ import { RtpCodecCopy, RtpTrack, RtpTracks, startRtpForwarderProcess } from "./r
 import { getAudioCodec, getFFmpegRtpAudioOutputArguments } from "./webrtc-required-codecs";
 import { WeriftSignalingSession } from "./werift-signaling-session";
 
-export const RTC_BRIDGE_NATIVE_ID = 'rtc-bridge';
-
 function getDebugModeH264EncoderArgs() {
     return [
         '-profile:v', 'baseline',

--- a/plugins/webrtc/src/main.ts
+++ b/plugins/webrtc/src/main.ts
@@ -13,7 +13,7 @@ import ip from 'ip';
 import net from 'net';
 import os from 'os';
 import { DataChannelDebouncer } from './datachannel-debouncer';
-import { RTC_BRIDGE_NATIVE_ID, WebRTCConnectionManagement, createRTCPeerConnectionSink, createTrackForwarder } from "./ffmpeg-to-wrtc";
+import { WebRTCConnectionManagement, createRTCPeerConnectionSink, createTrackForwarder } from "./ffmpeg-to-wrtc";
 import { stunServers, turnServers, weriftStunServers, weriftTurnServers } from './ice-servers';
 import { waitClosed } from './peerconnection-util';
 import { WebRTCCamera } from "./webrtc-camera";

--- a/plugins/webrtc/src/main.ts
+++ b/plugins/webrtc/src/main.ts
@@ -192,7 +192,7 @@ class WebRTCMixin extends SettingsMixinDeviceBase<RTCSignalingClient & VideoCame
     }
 }
 
-export class WebRTCPlugin extends AutoenableMixinProvider implements DeviceCreator, DeviceProvider, BufferConverter, MixinProvider, Settings {
+export class WebRTCPlugin extends AutoenableMixinProvider implements DeviceCreator, DeviceProvider, MediaConverter, MixinProvider, Settings {
     storageSettings = new StorageSettings(this, {
         iceInterfaceAddresses: {
             title: 'ICE Interface Addresses',
@@ -256,25 +256,19 @@ export class WebRTCPlugin extends AutoenableMixinProvider implements DeviceCreat
             multiple: true,
         }
     });
-    bridge: WebRTCBridge;
     activeConnections = 0;
 
     constructor() {
         super();
         this.unshiftMixin = true;
 
-        this.fromMimeType = '*/*';
-        this.toMimeType = ScryptedMimeTypes.RTCSignalingChannel;
+        this.converters = [
+            ["*/*", ScryptedMimeTypes.RTCSignalingChannel],
+            [ScryptedMimeTypes.RTCSignalingSession, ScryptedMimeTypes.RTCConnectionManagement],
+            [ScryptedMimeTypes.RTCSignalingChannel, ScryptedMimeTypes.FFmpegInput],
+        ]
 
-        deviceManager.onDeviceDiscovered({
-            name: 'RTC Connection Bridge',
-            type: ScryptedDeviceType.API,
-            nativeId: RTC_BRIDGE_NATIVE_ID,
-            interfaces: [
-                ScryptedInterface.MediaConverter,
-            ],
-        })
-            .then(() => this.bridge = new WebRTCBridge(this, RTC_BRIDGE_NATIVE_ID));
+        deviceManager.onDevicesChanged({ devices: [] });
     }
 
     getSettings(): Promise<Setting[]> {
@@ -285,7 +279,7 @@ export class WebRTCPlugin extends AutoenableMixinProvider implements DeviceCreat
         return this.storageSettings.putSetting(key, value);
     }
 
-    async convert(data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<RTCSignalingChannel> {
+    async convertToSignalingChannel(data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<RTCSignalingChannel> {
         const plugin = this;
 
         const console = deviceManager.getMixinConsole(options?.sourceId, this.nativeId);
@@ -327,6 +321,98 @@ export class WebRTCPlugin extends AutoenableMixinProvider implements DeviceCreat
         }
         else {
             throw new Error(`@scrypted/webrtc is unable to convert ${fromMimeType} to ${ScryptedMimeTypes.RTCSignalingChannel}`);
+        }
+    }
+
+    async convertToRTCConnectionManagement(result: ReturnType<typeof zygote>, cleanup: Deferred<string>, data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<any> {
+        const weriftConfiguration = await this.getWeriftConfiguration();
+        const session = data as RTCSignalingSession;
+        const maximumCompatibilityMode = !!this.storageSettings.values.maximumCompatibilityMode;
+        const clientOptions = await legacyGetSignalingSessionOptions(session);
+
+        let connection: WebRTCConnectionManagement;
+        try {
+            const { createConnection } = await result.result;
+            connection = await createConnection({}, undefined, session,
+                maximumCompatibilityMode,
+                clientOptions,
+                {
+                    configuration: this.getRTCConfiguration(),
+                    weriftConfiguration,
+                    ipv4Ban: this.storageSettings.values.ipv4Ban,
+                }
+            );
+        }
+        catch (e) {
+            result.worker.terminate();
+            throw e;
+        }
+        handleCleanupConnection(cleanup, connection, result);
+        await connection.negotiateRTCSignalingSession();
+        await connection.waitConnected();
+
+        return connection;
+    }
+
+    async convertToFFmpegInput(result: ReturnType<typeof zygote>, cleanup: Deferred<string>, data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<any> {
+        const channel = data as RTCSignalingChannel;
+        try {
+            const { createRTCPeerConnectionSource } = await result.result;
+            const rtcSource = await createRTCPeerConnectionSource({
+                __json_copy_serialize_children: true,
+                nativeId: undefined,
+                mixinId: undefined,
+                mediaStreamOptions: {
+                    id: 'webrtc',
+                    name: 'WebRTC',
+                    source: 'cloud',
+                },
+                startRTCSignalingSession: (session) => channel.startRTCSignalingSession(session),
+                maximumCompatibilityMode: this.storageSettings.values.maximumCompatibilityMode,
+            });
+
+            const mediaStreamUrl = rtcSource.mediaObject;
+            return await mediaManager.convertMediaObject(mediaStreamUrl, ScryptedMimeTypes.FFmpegInput);
+        } catch (e) {
+            result.worker.terminate();
+            throw e;
+        }
+    }
+
+    async convertMedia(data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<any> {
+        const getFork = (cleanup: Deferred<string>) => {
+            const result = zygote();
+            this.activeConnections++;
+            result.worker.on('exit', () => {
+                this.activeConnections--;
+                cleanup.resolve('worker exited (convert)');
+            });
+            return result;
+        }
+
+        let converter: () => Promise<any>;
+        let cleanup = new Deferred<string>();
+        if (fromMimeType === ScryptedMimeTypes.RTCSignalingSession && toMimeType === ScryptedMimeTypes.RTCConnectionManagement) {
+            const result = getFork(cleanup);
+            converter = () => this.convertToRTCConnectionManagement(result, cleanup, data, fromMimeType, toMimeType, options);
+        }
+        else if (fromMimeType === ScryptedMimeTypes.RTCSignalingChannel && toMimeType === ScryptedMimeTypes.FFmpegInput) {
+            const result = getFork(cleanup);
+            converter = () => this.convertToFFmpegInput(result, cleanup, data, fromMimeType, toMimeType, options);
+        }
+        else if (toMimeType === ScryptedMimeTypes.RTCSignalingChannel) {
+            converter = () => this.convertToSignalingChannel(data, fromMimeType, toMimeType, options);
+        }
+        else {
+            throw new Error(`@scrypted/webrtc is unable to convert ${fromMimeType} to ${toMimeType}`);
+        }
+
+        try {
+            return await timeoutPromise(2 * 60 * 1000, converter());
+        }
+        catch (e) {
+            cleanup.resolve(e.toString());
+            throw e;
         }
     }
 
@@ -418,8 +504,6 @@ export class WebRTCPlugin extends AutoenableMixinProvider implements DeviceCreat
     }
 
     async getDevice(nativeId: string) {
-        if (nativeId === RTC_BRIDGE_NATIVE_ID)
-            return this.bridge;
         return new WebRTCCamera(this, nativeId);
     }
 
@@ -711,101 +795,6 @@ export async function fork() {
             }
 
             return connection;
-        }
-    }
-}
-
-class WebRTCBridge extends ScryptedDeviceBase implements MediaConverter {
-    constructor(public plugin: WebRTCPlugin, nativeId: string) {
-        super(nativeId);
-
-        this.converters = [
-            [ScryptedMimeTypes.RTCSignalingSession, ScryptedMimeTypes.RTCConnectionManagement],
-            [ScryptedMimeTypes.RTCSignalingChannel, ScryptedMimeTypes.FFmpegInput],
-        ]
-    }
-
-    async convertToRTCConnectionManagement(result: ReturnType<typeof zygote>, cleanup: Deferred<string>, data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<any> {
-        const weriftConfiguration = await this.plugin.getWeriftConfiguration();
-        const session = data as RTCSignalingSession;
-        const maximumCompatibilityMode = !!this.plugin.storageSettings.values.maximumCompatibilityMode;
-        const clientOptions = await legacyGetSignalingSessionOptions(session);
-
-        let connection: WebRTCConnectionManagement;
-        try {
-            const { createConnection } = await result.result;
-            connection = await createConnection({}, undefined, session,
-                maximumCompatibilityMode,
-                clientOptions,
-                {
-                    configuration: this.plugin.getRTCConfiguration(),
-                    weriftConfiguration,
-                    ipv4Ban: this.plugin.storageSettings.values.ipv4Ban,
-                }
-            );
-        }
-        catch (e) {
-            result.worker.terminate();
-            throw e;
-        }
-        handleCleanupConnection(cleanup, connection, result);
-        await connection.negotiateRTCSignalingSession();
-        await connection.waitConnected();
-
-        return connection;
-    }
-
-    async convertToFFmpegInput(result: ReturnType<typeof zygote>, cleanup: Deferred<string>, data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<any> {
-        const channel = data as RTCSignalingChannel;
-        try {
-            const { createRTCPeerConnectionSource } = await result.result;
-            const rtcSource = await createRTCPeerConnectionSource({
-                __json_copy_serialize_children: true,
-                nativeId: undefined,
-                mixinId: undefined,
-                mediaStreamOptions: {
-                    id: 'webrtc',
-                    name: 'WebRTC',
-                    source: 'cloud',
-                },
-                startRTCSignalingSession: (session) => channel.startRTCSignalingSession(session),
-                maximumCompatibilityMode: this.plugin.storageSettings.values.maximumCompatibilityMode,
-            });
-
-            const mediaStreamUrl = rtcSource.mediaObject;
-            return await mediaManager.convertMediaObject(mediaStreamUrl, ScryptedMimeTypes.FFmpegInput);
-        } catch (e) {
-            result.worker.terminate();
-            throw e;
-        }
-    }
-
-    async convertMedia(data: any, fromMimeType: string, toMimeType: string, options?: MediaObjectOptions): Promise<any> {
-        const result = zygote();
-        this.plugin.activeConnections++;
-        const cleanup = new Deferred<string>();
-        result.worker.on('exit', () => {
-            this.plugin.activeConnections--;
-            cleanup.resolve('worker exited (convert)');
-        });
-
-        let converter: () => Promise<any>;
-        if (fromMimeType === ScryptedMimeTypes.RTCSignalingSession && toMimeType === ScryptedMimeTypes.RTCConnectionManagement) {
-            converter = () => this.convertToRTCConnectionManagement(result, cleanup, data, fromMimeType, toMimeType, options);
-        }
-        else if (fromMimeType === ScryptedMimeTypes.RTCSignalingChannel && toMimeType === ScryptedMimeTypes.FFmpegInput) {
-            converter = () => this.convertToFFmpegInput(result, cleanup, data, fromMimeType, toMimeType, options);
-        }
-        else {
-            throw new Error(`@scrypted/webrtc is unable to convert ${fromMimeType} to ${toMimeType}`);
-        }
-
-        try {
-            return await timeoutPromise(2 * 60 * 1000, converter());
-        }
-        catch (e) {
-            cleanup.resolve(e.toString());
-            throw e;
         }
     }
 }


### PR DESCRIPTION
I was able to test this by converting a WebRTC mixin device (since that implements RTCSignalingChannel) to FFmpegInput, then ffprobe-ing the returned RTSP.