### PR TITLE
server: allow plugins to specify portable python build tags

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,7 +26,7 @@
         "node-dijkstra": "^2.5.0",
         "node-forge": "^1.3.1",
         "node-gyp": "^10.2.0",
-        "py": "npm:@bjia56/portable-python@^0.1.74",
+        "py": "npm:@bjia56/portable-python@^0.1.83",
         "semver": "^7.6.3",
         "sharp": "^0.33.5",
         "source-map-support": "^0.5.21",
@@ -2680,9 +2680,9 @@
     },
     "node_modules/py": {
       "name": "@bjia56/portable-python",
-      "version": "0.1.74",
-      "resolved": "https://registry.npmjs.org/@bjia56/portable-python/-/portable-python-0.1.74.tgz",
-      "integrity": "sha512-gg8t3/5d5c/anPb9NTvf68CSZXMXKJ/9ITycpCquMRP7A0YfHn4l493ifQY+d8/XCooSs9qWSisGufZaAb21UA==",
+      "version": "0.1.83",
+      "resolved": "https://registry.npmjs.org/@bjia56/portable-python/-/portable-python-0.1.83.tgz",
+      "integrity": "sha512-ga1Cmm+tEoVtgNNSK+5eAxnnJiYF8T8aGZUVFZbMxdmqdyJSwl8tkL0E+Hu/waLXnG8ulfYK4Hm0GRd+X+Rb2A==",
       "dependencies": {
         "adm-zip": "^0.5.10"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "node-dijkstra": "^2.5.0",
     "node-forge": "^1.3.1",
     "node-gyp": "^10.2.0",
-    "py": "npm:@bjia56/portable-python@^0.1.74",
+    "py": "npm:@bjia56/portable-python@^0.1.83",
     "semver": "^7.6.3",
     "sharp": "^0.33.5",
     "source-map-support": "^0.5.21",

--- a/server/src/plugin/runtime/python-worker.ts
+++ b/server/src/plugin/runtime/python-worker.ts
@@ -152,7 +152,7 @@ export class PythonRuntimeWorker extends ChildProcessWorker {
         const portableInstallPath = path.join(pyPath, pyVersion);
 
         const py = new PortablePython(pluginPythonVersion, portableInstallPath, portablePythonOptions);
-        if (fs.existsSync(py.executablePath)) {
+        if (fs.existsSync(py.executablePath) && !py.isTagOutdated()) {
             pythonPath = py.executablePath;
             finishSetup();
         }


### PR DESCRIPTION
Usage: 
![image](https://github.com/user-attachments/assets/35292cfc-0aa1-4720-ad6b-abd9942bf56c)

Also adds a check to kick the install if the build tag doesn't match, since the exe path will be the same if the Python version doesn't change.