### PR TITLE
objectdetector: extend retention of detection inputs to 10s

### DIFF
--- a/plugins/objectdetector/src/main.ts
+++ b/plugins/objectdetector/src/main.ts
@@ -417,7 +417,7 @@ class ObjectDetectionMixin extends SettingsMixinDeviceBase<VideoCamera & Camera 
     const frameGenerator = this.model.decoder ? undefined : this.getFrameGenerator();
     for await (const detected of
       await sdk.connectRPCObject(
-        await this.objectDetection.generateObjectDetections( 
+        await this.objectDetection.generateObjectDetections(
           await this.createFrameGenerator(
             frameGenerator,
             options,
@@ -610,7 +610,7 @@ class ObjectDetectionMixin extends SettingsMixinDeviceBase<VideoCamera & Camera 
     this.detections.set(detectionId, detectionInput);
     setTimeout(() => {
       this.detections.delete(detectionId);
-    }, 2000);
+    }, 10000);
   }
 
   async getNativeObjectTypes(): Promise<ObjectDetectionTypes> {


### PR DESCRIPTION
From my testing, this duration is long enough for a mixin on the Notifier to fetch the original image when NVR sends the push notification.

I am not sure what the implications of keeping these frames for 5x the original duration would be, especially on memory. If this is a problem, an alternate solution may be for the mixin plugin to listen for ObjectDetector events and request/cache detection input frames immediately, then use its local cache when notifying. This would require some server work to implement listen() for Python plugins.