### PR TITLE
core: clear local url converter cache after 10m

### DIFF
--- a/plugins/core/src/converters.ts
+++ b/plugins/core/src/converters.ts
@@ -59,6 +59,7 @@ export class BufferHost extends ScryptedDeviceBase implements HttpRequestHandler
         const filename = uuid + (extension ? `.${extension}` : '');
 
         this.hosted.set(`/${filename}`, { data: buffer, fromMimeType, toMimeType });
+        setTimeout(() => this.hosted.delete(`/${filename}`), 10 * 1000); // free this resource after 10 seconds.
 
         return Buffer.from(`${endpoint}${filename}`);
     }

--- a/plugins/core/src/converters.ts
+++ b/plugins/core/src/converters.ts
@@ -59,7 +59,7 @@ export class BufferHost extends ScryptedDeviceBase implements HttpRequestHandler
         const filename = uuid + (extension ? `.${extension}` : '');
 
         this.hosted.set(`/${filename}`, { data: buffer, fromMimeType, toMimeType });
-        setTimeout(() => this.hosted.delete(`/${filename}`), 10 * 1000); // free this resource after 10 seconds.
+        setTimeout(() => this.hosted.delete(`/${filename}`), 10 * 60 * 1000); // free this resource after 10 min.
 
         return Buffer.from(`${endpoint}${filename}`);
     }


### PR DESCRIPTION
Stopgap fix for excessive memory usage when something repeatedly converts to a LocalUrl media type