### PR TITLE
server: aggressively catch child process pipe errors

### DIFF
--- a/server/src/plugin/runtime/child-process-worker.ts
+++ b/server/src/plugin/runtime/child-process-worker.ts
@@ -21,7 +21,7 @@ export abstract class ChildProcessWorker extends EventEmitter implements Runtime
         this.worker.on('error', e => this.emit('error', e));
         // aggressively catch errors
         // ECONNRESET can be raised when the child process is killed
-        for (const stdio of this.worker.stdio) {
+        for (const stdio of this.worker.stdio || []) {
             if (stdio)
                 stdio.on('error', e => this.emit('error', e));
         }

--- a/server/src/plugin/runtime/child-process-worker.ts
+++ b/server/src/plugin/runtime/child-process-worker.ts
@@ -19,6 +19,12 @@ export abstract class ChildProcessWorker extends EventEmitter implements Runtime
         this.worker.on('disconnect', () => this.emit('error', new Error('disconnect')));
         this.worker.on('exit', (code, signal) => this.emit('exit', code, signal));
         this.worker.on('error', e => this.emit('error', e));
+        // aggressively catch errors
+        // ECONNRESET can be raised when the child process is killed
+        for (const stdio of this.worker.stdio) {
+            if (stdio)
+                stdio.on('error', e => this.emit('error', e));
+        }
     }
 
     get pid() {

--- a/server/src/plugin/runtime/python-worker.ts
+++ b/server/src/plugin/runtime/python-worker.ts
@@ -111,6 +111,13 @@ export class PythonRuntimeWorker extends ChildProcessWorker {
 
             this.worker.stdout.pipe(this.stdout);
             this.worker.stderr.pipe(this.stderr);
+
+            // aggressively catch errors
+            const onErr = (e: Error) => this.emit('error', e);
+            this.worker.stdout.on('error', onErr);
+            this.worker.stderr.on('error', onErr);
+            this.worker.stdio[3].on('error', onErr);
+            this.worker.stdio[4].on('error', onErr);
         };
 
         let pluginPythonVersion: string = options.packageJson.scrypted.pythonVersion?.[os.platform()]?.[os.arch()] || options.packageJson.scrypted.pythonVersion?.default;

--- a/server/src/plugin/runtime/python-worker.ts
+++ b/server/src/plugin/runtime/python-worker.ts
@@ -113,6 +113,7 @@ export class PythonRuntimeWorker extends ChildProcessWorker {
             this.worker.stderr.pipe(this.stderr);
 
             // aggressively catch errors
+            // ECONNRESET can be raised when the child process is killed
             const onErr = (e: Error) => this.emit('error', e);
             this.worker.stdout.on('error', onErr);
             this.worker.stderr.on('error', onErr);

--- a/server/src/plugin/runtime/python-worker.ts
+++ b/server/src/plugin/runtime/python-worker.ts
@@ -111,14 +111,6 @@ export class PythonRuntimeWorker extends ChildProcessWorker {
 
             this.worker.stdout.pipe(this.stdout);
             this.worker.stderr.pipe(this.stderr);
-
-            // aggressively catch errors
-            // ECONNRESET can be raised when the child process is killed
-            const onErr = (e: Error) => this.emit('error', e);
-            this.worker.stdout.on('error', onErr);
-            this.worker.stderr.on('error', onErr);
-            this.worker.stdio[3].on('error', onErr);
-            this.worker.stdio[4].on('error', onErr);
         };
 
         let pluginPythonVersion: string = options.packageJson.scrypted.pythonVersion?.[os.platform()]?.[os.arch()] || options.packageJson.scrypted.pythonVersion?.default;


### PR DESCRIPTION
In the case where a plugin requests a non-standard Python version that must be installed via portable-python, the extra pipes are used via PassThroughs and errors are not properly caught. This results in a high probability of a server crash when the plugin is killed and restarted.