### PR TITLE
Force token on getAbility if the get call fails

### DIFF
--- a/plugins/reolink/package-lock.json
+++ b/plugins/reolink/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/reolink",
-   "version": "0.0.96",
+   "version": "0.0.98",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/reolink",
-         "version": "0.0.96",
+         "version": "0.0.98",
          "license": "Apache",
          "dependencies": {
             "@scrypted/common": "file:../../common",

--- a/plugins/reolink/package.json
+++ b/plugins/reolink/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/reolink",
-   "version": "0.0.97",
+   "version": "0.0.98",
    "description": "Reolink Plugin for Scrypted",
    "author": "Scrypted",
    "license": "Apache",

--- a/plugins/reolink/src/probe.ts
+++ b/plugins/reolink/src/probe.ts
@@ -46,6 +46,43 @@ async function getDeviceInfo(host: string, username: string, password: string): 
     return response.body?.[0]?.value?.DevInfo;
 }
 
+export async function getToken(host: string, username: string, password: string) {
+    const url = new URL(`http://${host}/api.cgi`);
+    const params = url.searchParams;
+    params.set('cmd', 'Login');
+
+    const response = await httpFetch({
+        url,
+        method: 'POST',
+        responseType: 'json',
+        rejectUnauthorized: false,
+        body: [
+            {
+                cmd: 'Login',
+                action: 0,
+                param: {
+                    User: {
+                        userName: username,
+                        password: password
+                    }
+                }
+            },
+        ],
+    });
+
+    const token = response.body?.[0]?.value?.Token?.name || response.body?.value?.Token?.name;
+    if (!token)
+        throw new Error('unable to login');
+    const { body } = response;
+    const leaseTimeSeconds: number = body?.[0]?.value?.Token.leaseTime || body?.value?.Token.leaseTime;
+    return {
+        parameters: {
+            token,
+        },
+        leaseTimeSeconds,
+    }
+}
+
 export async function getLoginParameters(host: string, username: string, password: string) {
     try {
         await getDeviceInfo(host, username, password);
@@ -61,40 +98,7 @@ export async function getLoginParameters(host: string, username: string, passwor
     }
 
     try {
-        const url = new URL(`http://${host}/api.cgi`);
-        const params = url.searchParams;
-        params.set('cmd', 'Login');
-    
-        const response = await httpFetch({
-            url,
-            method: 'POST',
-            responseType: 'json',
-            rejectUnauthorized: false,
-            body: [
-                {
-                    cmd: 'Login',
-                    action: 0,
-                    param: {
-                        User: {
-                            userName: username,
-                            password: password
-                        }
-                    }
-                },
-            ],
-        });
-    
-        const token = response.body?.[0]?.value?.Token?.name || response.body?.value?.Token?.name;
-        if (!token)
-            throw new Error('unable to login');
-        const { body } = response;
-        const leaseTimeSeconds: number = body?.[0]?.value?.Token.leaseTime || body?.value?.Token.leaseTime;
-        return {
-            parameters: {
-                token,
-            },
-            leaseTimeSeconds,
-        }
+        return await getToken(host, username, password);
     }
     catch (e) {
         // if the token exchange fails, fall back to basic auth

--- a/plugins/reolink/src/reolink-api.ts
+++ b/plugins/reolink/src/reolink-api.ts
@@ -96,7 +96,7 @@ export class ReolinkCameraClient {
             this.console.log(`token expired at ${this.tokenLease}, renewing...`);
 
             const { leaseTimeSeconds, parameters: { token } } = await getToken(this.host, this.username, this.password);
-            this.tokenData = { leaseTime: leaseTimeSeconds, token };
+            this.tokenData = { leaseTime: Date.now() + 1000 * leaseTimeSeconds, token };
         }
 
         const url = options.url as URL;


### PR DESCRIPTION
More recent Reolink devices fail on using some call using the GET endpoint + username/password comination as authentication. This PR extract the api to get the token in a separated token data, to not collide with the other methods, and is used by an alternative getAbility method as documented in the official Reolink API documentation