### PR TITLE
Add to alexa an option to not auto-enable devices

### DIFF
--- a/plugins/alexa/package-lock.json
+++ b/plugins/alexa/package-lock.json
@@ -1,12 +1,11 @@
 {
    "name": "@scrypted/alexa",
-   "version": "0.3.3",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/alexa",
-         "version": "0.3.3",
+         "version": "0.3.4",
          "dependencies": {
             "axios": "^1.3.4",
             "uuid": "^9.0.0"

--- a/plugins/alexa/package.json
+++ b/plugins/alexa/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/alexa",
-   "version": "0.3.3",
+   "version": "0.3.4",
    "scripts": {
       "scrypted-setup-project": "scrypted-setup-project",
       "prescrypted-setup-project": "scrypted-package-json",

--- a/plugins/alexa/src/main.ts
+++ b/plugins/alexa/src/main.ts
@@ -53,6 +53,12 @@ class AlexaPlugin extends ScryptedDeviceBase implements HttpRequestHandler, Mixi
             title: "Pairing Key",
             description: "The pairing key used to validate requests from Alexa. Clear this key or delete the plugin to allow pairing with a different Alexa login.",
         },
+        disableAutoAdd: {
+            title: "Disable auto add",
+            description: "Disable automatic enablement of devices.",
+            type: 'boolean',
+            defaultValue: false,
+        },
     });
 
     accessToken: Promise<string>;
@@ -115,6 +121,10 @@ class AlexaPlugin extends ScryptedDeviceBase implements HttpRequestHandler, Mixi
 
         if (!supportedTypes.has(device.type))
             return DeviceMixinStatus.NotSupported;
+
+        if (this.storageSettings.values.disableAutoAdd) {
+            return DeviceMixinStatus.Skip;
+        }
 
         mixins.push(this.id);
 
@@ -671,7 +681,8 @@ class AlexaPlugin extends ScryptedDeviceBase implements HttpRequestHandler, Mixi
 enum DeviceMixinStatus {
     NotSupported = 0,
     Setup = 1,
-    AlreadySetup = 2
+    AlreadySetup = 2,
+    Skip = 3,
 }
 
 class HttpResponseLoggingImpl implements AlexaHttpResponse {


### PR DESCRIPTION
Not sure if this is only an issue for me, but it's very annoying to have devices autmatically pushed to alexa before any changes could be done on the devices
Please any hint would be appreciated if this is not the right way to make this thing configurable