### PR TITLE
Reolink - Fix name/model fetching if homehub

### DIFF
--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -181,8 +181,13 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
             }
             const api = this.getClient();
             const deviceInfo = await api.getDeviceInfo();
+            this.console.log('deviceInfo', JSON.stringify(deviceInfo));
             this.storageSettings.values.deviceInfo = deviceInfo;
-            await this.updateAbilities();
+            try {
+                await this.updateAbilities();
+            } catch (e) {
+                this.console.log('Fail fetching abilities', e);
+            }
             await this.updateDevice();
             if (this.hasSiren()) {
                 this.reportSirenDevice();
@@ -313,7 +318,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
         if (this.hasSiren())
             interfaces.push(ScryptedInterface.DeviceProvider);
 
-        await this.provider.updateDevice(this.nativeId, name, interfaces, type);
+        await this.provider.updateDevice(this.nativeId, this.name ?? name, interfaces, type);
     }
 
     async reboot() {
@@ -619,7 +624,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
         // 1: support main/extern/sub stream
         // 2: support main/sub stream
 
-        const live = this.storageSettings.values.abilities?.value?.Ability?.abilityChn?.[0].live?.ver;
+        const live = this.storageSettings.values.abilities?.value?.Ability?.abilityChn?.[this.getRtspChannel()].live?.ver;
         const [rtmpMain, rtmpExt, rtmpSub, rtspMain, rtspSub] = streams;
         streams.splice(0, streams.length);
 
@@ -628,7 +633,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
         // 1: main stream enc type is H265
 
         // anecdotally, encoders of type h265 do not have a working RTMP main stream.
-        const mainEncType = this.storageSettings.values.abilities?.value?.Ability?.abilityChn?.[0].mainEncType?.ver;
+        const mainEncType = this.storageSettings.values.abilities?.value?.Ability?.abilityChn?.[this.getRtspChannel()].mainEncType?.ver;
 
         if (live === 2) {
             if (mainEncType === 1) {

--- a/plugins/reolink/src/reolink-api.ts
+++ b/plugins/reolink/src/reolink-api.ts
@@ -198,19 +198,56 @@ export class ReolinkCameraClient {
     }
 
     async getDeviceInfo(): Promise<DevInfo> {
-        const url = new URL(`http://${this.host}/api.cgi`);
-        const params = url.searchParams;
+        let url = new URL(`http://${this.host}/api.cgi`);
+        let params = url.searchParams;
         params.set('cmd', 'GetDevInfo');
-        const response = await this.requestWithLogin({
+        let response = await this.requestWithLogin({
             url,
             responseType: 'json',
         });
-        const error = response.body?.[0]?.error;
+        let error = response.body?.[0]?.error;
         if (error) {
             this.console.error('error during call to getDeviceInfo', error);
             throw new Error('error during call to getDeviceInfo');
         }
-        return response.body?.[0]?.value?.DevInfo;
+
+        const deviceInfo: DevInfo = await response.body?.[0]?.value?.DevInfo;
+
+        // Will need to check if it's valid for NVR and NVR_WIFI
+        if(['HOMEHUB'].includes(deviceInfo.exactType)) {
+            // If the device is listed as homehub, fetch the channel specific information
+            url = new URL(`http://${this.host}/api.cgi`);
+            const body =  [
+                {cmd: "GetChnTypeInfo", action: 0, param: {channel: this.channelId}},
+                {cmd: "GetChannelstatus", action: 0, param: {}},
+            ]
+
+            response = await this.requestWithLogin({
+                url,
+                method: 'POST',
+                responseType: 'json'
+            }, this.createReadable(body));
+
+            const chnTypeInfo = response?.body?.find(elem => elem.cmd === 'GetChnTypeInfo');
+            const chnStatus = response?.body?.find(elem => elem.cmd === 'GetChannelstatus');
+
+            if(chnTypeInfo?.value) {
+                deviceInfo.firmVer = chnTypeInfo.value.firmVer;
+                deviceInfo.model = chnTypeInfo.value.typeInfo;
+                deviceInfo.pakSuffix = chnTypeInfo.value.pakSuffix;
+            }
+
+            if(chnStatus?.value) {
+                const specificChannelStatus = chnStatus.value?.status?.find(elem => elem.channel === this.channelId);
+
+                if(specificChannelStatus) {
+                    deviceInfo.name = specificChannelStatus.name;
+                }
+            }
+
+        }
+        
+        return deviceInfo;
     }
 
     async getPtzPresets(): Promise<PtzPreset[]> {


### PR DESCRIPTION
This PR fixes the naming used on reolink if the device is connected to an homehub (should be valid for each NVR, but I do not have one to test)

Currently the name of a reolink camera is automatically set to "Reolink camera" even though the api provides the right name