### PR TITLE
feat(sdk): add support for notification channel in NotifierOptions

### DIFF
--- a/plugins/core/src/automation-actions.ts
+++ b/plugins/core/src/automation-actions.ts
@@ -81,6 +81,10 @@ addAction(ScryptedInterface.Notifier, {
         type: 'interface',
         deviceFilter: `deviceInterface === '${ScryptedInterface.VideoCamera}' || deviceInterface === '${ScryptedInterface.Camera}'`,
     },
+    notificationChannel: {
+        title: 'Channel (Android only)',
+        type: 'string',
+    },
 }, async function invoke(device: ScryptedDevice & Notifier, storageSettings) {
     let { notificationMediaUrl } = storageSettings;
     if (notificationMediaUrl && !notificationMediaUrl?.includes('://')) {
@@ -100,5 +104,6 @@ addAction(ScryptedInterface.Notifier, {
 
     return device.sendNotification(storageSettings.notificationTitle as string, {
         body: storageSettings.notificationBody as string,
+        channel: storageSettings.notificationChannel as string,
     }, notificationMediaUrl);
 });

--- a/plugins/core/src/automation-actions.ts
+++ b/plugins/core/src/automation-actions.ts
@@ -81,10 +81,6 @@ addAction(ScryptedInterface.Notifier, {
         type: 'interface',
         deviceFilter: `deviceInterface === '${ScryptedInterface.VideoCamera}' || deviceInterface === '${ScryptedInterface.Camera}'`,
     },
-    notificationChannel: {
-        title: 'Channel (Android only)',
-        type: 'string',
-    },
 }, async function invoke(device: ScryptedDevice & Notifier, storageSettings) {
     let { notificationMediaUrl } = storageSettings;
     if (notificationMediaUrl && !notificationMediaUrl?.includes('://')) {
@@ -104,6 +100,5 @@ addAction(ScryptedInterface.Notifier, {
 
     return device.sendNotification(storageSettings.notificationTitle as string, {
         body: storageSettings.notificationBody as string,
-        channel: storageSettings.notificationChannel as string,
     }, notificationMediaUrl);
 });

--- a/plugins/diagnostics/src/main.ts
+++ b/plugins/diagnostics/src/main.ts
@@ -128,6 +128,7 @@ class DiagnosticsPlugin extends ScryptedDeviceBase implements Settings {
             await device.sendNotification('Scrypted Diagnostics', {
                 body: 'Body',
                 subtitle: 'Subtitle',
+                channel: 'diagnostics',
             }, mo);
 
             this.warnStep(console, 'Check the device for the notification.');

--- a/plugins/diagnostics/src/main.ts
+++ b/plugins/diagnostics/src/main.ts
@@ -128,7 +128,9 @@ class DiagnosticsPlugin extends ScryptedDeviceBase implements Settings {
             await device.sendNotification('Scrypted Diagnostics', {
                 body: 'Body',
                 subtitle: 'Subtitle',
-                channel: 'diagnostics',
+                android: {
+                    channel: 'diagnostics',
+                }
             }, mo);
 
             this.warnStep(console, 'Check the device for the notification.');

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -649,6 +649,7 @@ class NotifierOptions(TypedDict):
     badge: str
     body: str
     bodyWithSubtitle: str
+    channel: str
     data: Any
     dir: NotificationDirection
     image: str

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -643,13 +643,16 @@ class MediaStreamOptions(TypedDict):
     tool: MediaStreamTool  # The tool was used to write the container or will be used to read teh container. Ie, scrypted, the ffmpeg tools, gstreamer.
     video: VideoStreamOptions
 
+class AndroidNotificationOptions(TypedDict):
+    channel: str
+
 class NotifierOptions(TypedDict):
 
     actions: list[NotificationAction]
+    android: AndroidNotificationOptions
     badge: str
     body: str
     bodyWithSubtitle: str
-    channel: str
     data: Any
     dir: NotificationDirection
     image: str

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -225,6 +225,7 @@ export interface NotifierOptions {
   badge?: string;
   bodyWithSubtitle?: string;
   body?: string;
+  channel?: string;
   data?: any;
   dir?: NotificationDirection;
   lang?: string;

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -225,7 +225,9 @@ export interface NotifierOptions {
   badge?: string;
   bodyWithSubtitle?: string;
   body?: string;
-  channel?: string;
+  android?: {
+    channel?: string;
+  }
   data?: any;
   dir?: NotificationDirection;
   lang?: string;


### PR DESCRIPTION
This change spins off from conversation at https://github.com/scryptedapp/homeassistant/pull/1 and allows consumers of the `Notifier` interface to specify a channel for notifications to be sent to. Android platforms can use this to send notifications to a specific channel, allowing the user to have fine-grained control over the audio and priority of the notifications they receive.

I'm not certain my `automation-actions.ts` edit is enough to make this work, I didn't readily see where these were consumed in the codebase.

Potential TODOs:

- Consumers of Notifier that might want to set a channel:
  * `manage.scrypted.app` - Should the frontend test notification set a channel of `testing` or should it stay with the general channel? https://github.com/koush/manage.scrypted.app/blob/168317f6790e7012560e7d2bb755c6fd03c0a308/src/components/interfaces/Notifier.vue#L97
  * `scryptedapp/notifier-zone-filter` - https://github.com/scryptedapp/notifier-zone-filter/blob/64d1d8130912ccab73c4e360db5cce757ccea1d6/src/main.py#L457 and https://github.com/scryptedapp/notifier-zone-filter/blob/64d1d8130912ccab73c4e360db5cce757ccea1d6/src/main.py#L460
  * `scryptedapp/securitysystem` - https://github.com/scryptedapp/securitysystem/blob/cd82bbde8a2414e738a035248e4646c3102e3221/src/main.ts#L129
  * Also, I'm not seeing where the results of the object detection are obtained in relation to conditional notifications, so that will still want to set a channel
- Implementations of Notifier that might be able to consume the channel:
  * Pushover? Edit: looks like pushover doesn't yet support this (https://support.pushover.net/i290-support-notification-channels-specific-to-application) - https://github.com/scryptedapp/pushover/blob/c1d28ca0feb2535d061e0b502e57fb707de3c17e/src/main.ts#L78
  * Home Assistant - PR - https://github.com/scryptedapp/homeassistant/pull/1