### PR TITLE
tapo: provide settings to override tapo camera's ip

### DIFF
--- a/plugins/tapo/package.json
+++ b/plugins/tapo/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/tapo",
-   "version": "0.0.19",
+   "version": "0.0.20",
    "description": "Tapo Camera Plugin for Scrypted",
    "scripts": {
       "scrypted-setup-project": "scrypted-setup-project",

--- a/plugins/tapo/src/main.ts
+++ b/plugins/tapo/src/main.ts
@@ -11,6 +11,12 @@ class TapoIntercomMixin extends SettingsMixinDeviceBase<VideoCamera & Settings> 
             title: 'Cloud Password',
             description: 'The Tapo Cloud account password. This is not the same as the ONVIF/RTSP local password.',
             type: 'password',
+        },
+        cameraIP: {
+            title: 'Camera IP Address',
+            description: 'The actual IP address of your Tapo camera, Defaults to the one Scrypted provides.',
+            type: 'string',
+            placeholder: 'e.g., 192.168.1.100',
         }
     });
     client: Promise<TapoAPI>;
@@ -19,7 +25,9 @@ class TapoIntercomMixin extends SettingsMixinDeviceBase<VideoCamera & Settings> 
         const ffmpegInput = await sdk.mediaManager.convertMediaObjectToJSON<FFmpegInput>(media, ScryptedMimeTypes.FFmpegInput);
 
         const settings = await this.mixinDevice.getSettings();
-        const ip = settings.find(s => s.key === 'ip')?.value?.toString();
+        const ipFromSetting = this.storageSettings.values.cameraIP;
+        const ipFromCamera = settings.find(s => s.key === 'ip')?.value?.toString();
+        const ip = ipFromSetting || ipFromCamera;
         await this.stopIntercom();
 
         if (!this.storageSettings.values.cloudPassword) {


### PR DESCRIPTION
# Motivation
I purchased a Tapo C120 camera, but after connecting it to Scrypted and trying various parameter combinations, the video still stutters. However, if I first connect it to Go2RTC and then integrate it into Scrypted using RTSP, it streams smoothly, though this approach sacrifices two-way audio functionality.

# Prompts
Since @scrypted/tapo’s two-way audio implementation actually relies on a less strict vulnerability in the Tapo camera, I suggest adding an option in the @scrypted/tapo plugin’s settings to specify the camera’s IP address. This way, even if a camera is connected through Go2RTC, the @scrypted/tapo plugin could still ensure connection to the actual Tapo camera IP. Given that the Go2RTC server IP and the Tapo camera IP are obviously different, in this scenario, @scrypted/tapo should not default to using Go2RTC’s virtual camera IP.