### PR TITLE
Update Windows install script workaround npm issue

### DIFF
--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -26,6 +26,8 @@ $SCRYPTED_WINDOWS_PYTHON_VERSION="-3.9"
 # Refresh environment variables for py and npx to work
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
 
+node -v
+
 # Workaround Windows Node no longer creating %APPDATA%\npm which causes npx to fail
 # Fixed in newer versions of NPM but not the one bundled with 20.11.1
 # https://github.com/nodejs/node/issues/53538
@@ -102,7 +104,7 @@ svc.on("install", () => {
    setTimeout(() => {
      console.log("Starting service");
      svc.start();
-   }, 5000);
+   }, 10000);
 });
 svc.on("start", () => {
   console.log("Service started");

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -1,3 +1,5 @@
+#Requires -RunAsAdministrator
+
 # Set-PSDebug -Trace 1
 
 # stop existing service if any

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -37,6 +37,8 @@ py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install --upgrade pip
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install debugpy typing_extensions typing opencv-python
 
 $SCRYPTED_INSTALL_VERSION=[System.Environment]::GetEnvironmentVariable("SCRYPTED_INSTALL_VERSION","User")
+Write-Output $SCRYPTED_INSTALL_VERSION
+
 if ($SCRYPTED_INSTALL_VERSION -eq $null) {
   npx -y scrypted@latest install-server
 } else {
@@ -66,6 +68,8 @@ child_process.spawn('$NPX_PATH_ESCAPED', ['-y', 'scrypted', 'serve'], {
     shell: true,
 });
 "@
+
+Write-Output $SERVICE_JS
 
 $SERVICE_JS_PATH = $SCRYPTED_HOME + '\service.js'
 $SERVICE_JS_ESCAPED_PATH = $SERVICE_JS_PATH.replace('\', '\\')
@@ -114,6 +118,8 @@ svc.on("error", (err) => {
 });
 svc.install();
 "@
+
+Write-Output $INSTALL_SERVICE_JS
 
 $INSTALL_SERVICE_JS_PATH = $SCRYPTED_HOME + '\install-service.js'
 $INSTALL_SERVICE_JS | Out-File -Encoding ASCII -FilePath $INSTALL_SERVICE_JS_PATH

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -53,6 +53,9 @@ npm install --prefix $SCRYPTED_HOME @koush/node-windows --save
 $NPX_PATH = (Get-Command npx).Path
 # The path needs double quotes to handle spaces in the directory path
 $NPX_PATH_ESCAPED = '"' + $NPX_PATH.replace('\', '\\') + '"'
+# On newer versions of NPM, the NPX might be a .ps1 file which doesn't work with child_process.spawn
+# Change to .cmd
+$NPX_PATH_ESCAPED = $NPX_PATH_ESCAPED.replace('.ps1', '.cmd')
 
 $SERVICE_JS = @"
 const fs = require('fs');

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -24,8 +24,6 @@ $SCRYPTED_WINDOWS_PYTHON_VERSION="-3.9"
 # Refresh environment variables for py and npx to work
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
 
-node -v
-
 # Workaround Windows Node no longer creating %APPDATA%\npm which causes npx to fail
 # Fixed in newer versions of NPM but not the one bundled with 20.11.1
 # https://github.com/nodejs/node/issues/53538

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -105,6 +105,9 @@ svc.on("install", () => {
 svc.on("start", () => {
   console.log("Service started");
 });
+svc.on("error", (err) => {
+  console.log("Service error", err);
+});
 svc.install();
 "@
 
@@ -119,15 +122,4 @@ Write-Output "Note that it is https and that you'll be asked to approve/ignore t
 
 Start-Sleep -Seconds 30
 
-Write-Output "scrypted.out.log"
-Get-Content "$SCRYPTED_HOME\daemon\scrypted.out.log" | Write-Output
-
-Write-Output "scrypted.wrapper.log"
-Get-Content "$SCRYPTED_HOME\daemon\scrypted.wrapper.log" | Write-Output
-
-Write-Output "scrypted.err.log"
-Get-Content "$SCRYPTED_HOME\daemon\scrypted.err.log" | Write-Output
-
-Write-Output $NPX_PATH
-
-& $NPX_PATH -y scrypted serve
+Get-EventLog -LogName Application -Newest 20 | Select-Object -Property *

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -117,7 +117,7 @@ del $INSTALL_SERVICE_JS_PATH
 Write-Output "Scrypted is now running at: https://localhost:10443/"
 Write-Output "Note that it is https and that you'll be asked to approve/ignore the website certificate."
 
-Start-Sleep -Seconds 10
+Start-Sleep -Seconds 30
 
 Write-Output "scrypted.out.log"
 Get-Content "$SCRYPTED_HOME\daemon\scrypted.out.log" | Write-Output
@@ -130,4 +130,4 @@ Get-Content "$SCRYPTED_HOME\daemon\scrypted.err.log" | Write-Output
 
 Write-Output $NPX_PATH
 
-& $NPX_PATH_ESCAPED -y scrypted serve
+& $NPX_PATH -y scrypted serve

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -1,5 +1,3 @@
-#Requires -RunAsAdministrator
-
 # Set-PSDebug -Trace 1
 
 # stop existing service if any

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -1,7 +1,5 @@
 #Requires -RunAsAdministrator
 
-node -v
-
 # Set-PSDebug -Trace 1
 
 # stop existing service if any
@@ -37,7 +35,6 @@ py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install --upgrade pip
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install debugpy typing_extensions typing opencv-python
 
 $SCRYPTED_INSTALL_VERSION=[System.Environment]::GetEnvironmentVariable("SCRYPTED_INSTALL_VERSION","User")
-Write-Output $SCRYPTED_INSTALL_VERSION
 
 if ($SCRYPTED_INSTALL_VERSION -eq $null) {
   npx -y scrypted@latest install-server
@@ -53,8 +50,7 @@ npm install --prefix $SCRYPTED_HOME @koush/node-windows --save
 $NPX_PATH = (Get-Command npx).Path
 # The path needs double quotes to handle spaces in the directory path
 $NPX_PATH_ESCAPED = '"' + $NPX_PATH.replace('\', '\\') + '"'
-# On newer versions of NPM, the NPX might be a .ps1 file which doesn't work with child_process.spawn
-# Change to .cmd
+# On newer versions of NPM, the NPX might be a .ps1 file which doesn't work with child_process.spawn, change to .cmd
 $NPX_PATH_ESCAPED = $NPX_PATH_ESCAPED.replace('.ps1', '.cmd')
 
 $SERVICE_JS = @"
@@ -71,8 +67,6 @@ child_process.spawn('$NPX_PATH_ESCAPED', ['-y', 'scrypted', 'serve'], {
     shell: true,
 });
 "@
-
-Write-Output $SERVICE_JS
 
 $SERVICE_JS_PATH = $SCRYPTED_HOME + '\service.js'
 $SERVICE_JS_ESCAPED_PATH = $SERVICE_JS_PATH.replace('\', '\\')
@@ -111,7 +105,7 @@ svc.on("install", () => {
    setTimeout(() => {
      console.log("Starting service");
      svc.start();
-   }, 10000);
+   }, 5000);
 });
 svc.on("start", () => {
   console.log("Service started");
@@ -121,8 +115,6 @@ svc.on("error", (err) => {
 });
 svc.install();
 "@
-
-Write-Output $INSTALL_SERVICE_JS
 
 $INSTALL_SERVICE_JS_PATH = $SCRYPTED_HOME + '\install-service.js'
 $INSTALL_SERVICE_JS | Out-File -Encoding ASCII -FilePath $INSTALL_SERVICE_JS_PATH

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -65,7 +65,7 @@ child_process.spawn('$NPX_PATH_ESCAPED', ['-y', 'scrypted', 'serve'], {
     stdio: 'inherit',
     // allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
     shell: true,
-}).error((err) => {
+}).on('error', (err) => {
     console.error('Error spawning child process', err);
 });
 "@

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -1,5 +1,7 @@
 #Requires -RunAsAdministrator
 
+node -v
+
 # Set-PSDebug -Trace 1
 
 # stop existing service if any
@@ -119,7 +121,3 @@ del $INSTALL_SERVICE_JS_PATH
 
 Write-Output "Scrypted is now running at: https://localhost:10443/"
 Write-Output "Note that it is https and that you'll be asked to approve/ignore the website certificate."
-
-Start-Sleep -Seconds 30
-
-Get-EventLog -LogName Application -Newest 20 | Select-Object -Property *

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -24,6 +24,11 @@ $SCRYPTED_WINDOWS_PYTHON_VERSION="-3.9"
 # Refresh environment variables for py and npx to work
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
 
+# Workaround Windows Node no longer creating %APPDATA%\npm which causes npx to fail
+# Fixed in newer versions of NPM but not the one bundled with 20.11.1
+# https://github.com/nodejs/node/issues/53538
+npm i -g npm
+
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install --upgrade pip
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install debugpy typing_extensions typing opencv-python
 

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -1,3 +1,5 @@
+#Requires -RunAsAdministrator
+
 # Set-PSDebug -Trace 1
 
 # stop existing service if any
@@ -22,6 +24,10 @@ $SCRYPTED_WINDOWS_PYTHON_VERSION="-3.9"
 # Refresh environment variables for py and npx to work
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
 
+# Workaround Windows Node no longer creating %APPDATA%\npm which causes npx to fail
+# Fixed in newer versions of NPM but not the one bundled with 20.11.1
+# https://github.com/nodejs/node/issues/53538
+npm i -g npm
 
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install --upgrade pip
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install debugpy typing_extensions typing opencv-python

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -65,6 +65,8 @@ child_process.spawn('$NPX_PATH_ESCAPED', ['-y', 'scrypted', 'serve'], {
     stdio: 'inherit',
     // allow spawning .cmd https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
     shell: true,
+}).error((err) => {
+    console.error('Error spawning child process', err);
 });
 "@
 

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -127,3 +127,7 @@ Get-Content "$SCRYPTED_HOME\daemon\scrypted.wrapper.log" | Write-Output
 
 Write-Output "scrypted.err.log"
 Get-Content "$SCRYPTED_HOME\daemon\scrypted.err.log" | Write-Output
+
+Write-Output $NPX_PATH
+
+& $NPX_PATH_ESCAPED -y scrypted serve

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -116,3 +116,14 @@ del $INSTALL_SERVICE_JS_PATH
 
 Write-Output "Scrypted is now running at: https://localhost:10443/"
 Write-Output "Note that it is https and that you'll be asked to approve/ignore the website certificate."
+
+Start-Sleep -Seconds 10
+
+Write-Output "scrypted.out.log"
+Get-Content "$SCRYPTED_HOME\daemon\scrypted.out.log" | Write-Output
+
+Write-Output "scrypted.wrapper.log"
+Get-Content "$SCRYPTED_HOME\daemon\scrypted.wrapper.log" | Write-Output
+
+Write-Output "scrypted.err.log"
+Get-Content "$SCRYPTED_HOME\daemon\scrypted.err.log" | Write-Output

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -24,11 +24,6 @@ $SCRYPTED_WINDOWS_PYTHON_VERSION="-3.9"
 # Refresh environment variables for py and npx to work
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
 
-# Workaround Windows Node no longer creating %APPDATA%\npm which causes npx to fail
-# Fixed in newer versions of NPM but not the one bundled with 20.11.1
-# https://github.com/nodejs/node/issues/53538
-npm i -g npm
-
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install --upgrade pip
 py $SCRYPTED_WINDOWS_PYTHON_VERSION -m pip install debugpy typing_extensions typing opencv-python
 


### PR DESCRIPTION
I was just testing the Windows install script recently and noticed that it would actually fail on the `npx` commands

After some digging it's due to Node.js removing creating the `%APPDATA%\npm` folder in the MSI installer https://github.com/nodejs/node/commit/0ae8bf8dbc3d5db9a604c7be66aa22893e109fa0 which then causes the `npx` command to fail https://github.com/nodejs/node/issues/53538

This was fixed in `npm` https://github.com/npm/cli/pull/7640 but it's not included with the npm installed in Node 20.11.1 specified in the install script

This `npm i -g npm` is a workaround https://github.com/nodejs/node/issues/53538#issuecomment-2223853437

Also added `#Requires -RunAsAdministrator` so the script will error if it's not run under admin