### PR TITLE
Fix Windows install script NPM/Node version clash

### DIFF
--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -10,7 +10,7 @@ sc.exe stop scrypted.exe
 iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Install node.js
-choco upgrade -y nodejs-lts --version=20.11.1
+choco upgrade -y nodejs-lts --version=20.18.0
 
 # Install VC Redist, which is necessary for portable python
 choco install -y vcredist140

--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -25,7 +25,7 @@ $SCRYPTED_WINDOWS_PYTHON_VERSION="-3.9"
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
 
 # Workaround Windows Node no longer creating %APPDATA%\npm which causes npx to fail
-# Fixed in newer versions of NPM but not the one bundled with 20.11.1
+# Fixed in newer versions of NPM but not the one bundled with Node 20
 # https://github.com/nodejs/node/issues/53538
 npm i -g npm
 


### PR DESCRIPTION
Testing the Windows install script again, the latest version of `npm` is no longer compatible with Node version `20.11.1` which is what's installed by Chocolatey. 

It spits out an error when running `npm i -g npm`

```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm ERR! notsup Actual:   {"npm":"10.2.4","node":"v20.11.1"}
```

because the NPM engine requires at least 20.17.0 https://github.com/npm/cli/blob/f7da341322c2f860156e8144b208583596504479/package.json#L258

Update the Windows install script Node version to `20.18.0` which is the latest Node LTS and is also supported by NPM.

