### PR TITLE
server: use `standard-telnetlib` for Python 3.13+

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scrypted/server",
-  "version": "0.123.68",
+  "version": "0.123.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scrypted/server",
-      "version": "0.123.68",
+      "version": "0.123.70",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -26,7 +26,7 @@
         "node-dijkstra": "^2.5.0",
         "node-forge": "^1.3.1",
         "node-gyp": "^10.2.0",
-        "py": "npm:@bjia56/portable-python@^0.1.94",
+        "py": "npm:@bjia56/portable-python@^0.1.112",
         "semver": "^7.6.3",
         "sharp": "^0.33.5",
         "source-map-support": "^0.5.21",
@@ -2763,9 +2763,9 @@
     },
     "node_modules/py": {
       "name": "@bjia56/portable-python",
-      "version": "0.1.94",
-      "resolved": "https://registry.npmjs.org/@bjia56/portable-python/-/portable-python-0.1.94.tgz",
-      "integrity": "sha512-dACd5jj4gJiv6Gyf2Ne4dwXR9DRn3s/S0sg6pe64JVhX/3jT18HBZ4oxgN+IFXJ2bjnYkp2LCtpOCEsYl3El0g==",
+      "version": "0.1.112",
+      "resolved": "https://registry.npmjs.org/@bjia56/portable-python/-/portable-python-0.1.112.tgz",
+      "integrity": "sha512-tYBv3ruCXXiJJncfBelO6GXgjCbopLM1WkB9vQywv5RTL60Ij+zHeq4fGSchuXdg8QQDVH6UkUaRmPfmqBYvSQ==",
       "dependencies": {
         "adm-zip": "^0.5.10"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "node-dijkstra": "^2.5.0",
     "node-forge": "^1.3.1",
     "node-gyp": "^10.2.0",
-    "py": "npm:@bjia56/portable-python@^0.1.94",
+    "py": "npm:@bjia56/portable-python@^0.1.112",
     "semver": "^7.6.3",
     "sharp": "^0.33.5",
     "source-map-support": "^0.5.21",

--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -41,6 +41,12 @@ SCRYPTED_REQUIREMENTS = """
 ptpython
 wheel
 """.strip()
+if sys.version_info.minor >= 13:
+    # telnetlib was removed in Python 3.13
+    SCRYPTED_REQUIREMENTS = f"""
+{SCRYPTED_REQUIREMENTS}
+standard-telnetlib
+""".strip()
 
 
 class SystemDeviceState(TypedDict):
@@ -797,7 +803,7 @@ class PluginRemote:
             )
 
             need_pip = False
-            # pip is needed if there's a requiremnts.txt file that has changed.
+            # pip is needed if there's a requirements.txt file that has changed.
             if str_requirements:
                 need_pip = need_requirements(requirements_basename, str_requirements)
             # pip is needed if the base scrypted requirements have changed.
@@ -933,7 +939,7 @@ class PluginRemote:
                             directGetRemote, rpc.RpcPeer.PROPERTY_PROXY_PEER
                         )
                         return await finishFork(forkPeer)
-                    
+
                     async def getClusterForkWrapped():
                         try:
                             return await getClusterFork()


### PR DESCRIPTION
Follow up to #1668 

Also bumps portable-python to version with Python 3.13 distributions