### PR TITLE
server: check if `SCRYPTED_PYTHON*_PATH` env points to valid path

### DIFF
--- a/server/src/plugin/runtime/python-worker.ts
+++ b/server/src/plugin/runtime/python-worker.ts
@@ -132,7 +132,7 @@ export class PythonRuntimeWorker extends ChildProcessWorker {
 
         const strippedPythonVersion = pluginPythonVersion.replace('.', '');
         const envPython = !process.env.SCRYPTED_PORTABLE_PYTHON && process.env[`SCRYPTED_PYTHON${strippedPythonVersion}_PATH`];
-        if (envPython) {
+        if (envPython && fs.existsSync(envPython)) {
             pythonPath = envPython;
             setup();
             this.peerin = this.worker.stdio[3] as Writable;


### PR DESCRIPTION
We had a Synology Docker user who upgraded to server 0.126.0 however Python plugins which specifically asked for Python 3.10 failed to load with ENOENT when looking for `/usr/bin/python3.10`. It turns out that `SCRYPTED_PYTHON310_PATH` was still defined (unknown if Synology transferred the env from the previous container) and prevented these plugins from starting. This adds a check to verify that the path pointed to by the env var exists before committing to selecting it as the runtime.