### PR TITLE
actions: add Linux arm64 runner to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-14, macos-13, windows-latest]
+        runner: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-latest]
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/