### PR TITLE
hikvision: add ERI-K104-P4 to the list of NVRs that doesn't support channel cap checks

### DIFF
--- a/plugins/hikvision/src/hikvision-camera-api.ts
+++ b/plugins/hikvision/src/hikvision-camera-api.ts
@@ -116,11 +116,15 @@ export class HikvisionCameraAPI implements HikvisionAPI {
     }
 
     async checkIsOldModel() {
-        // The old Hikvision DS-7608NI-E2 doesn't support channel capability checks, and the requests cause errors
+        // The old Hikvision NVRs don't support channel capability checks, and the requests cause errors
+        const oldModels = [
+            /DS-76098NI-E2/,
+            /ERI-K104-P4/
+        ];
         const model = await this.checkDeviceModel();
         if (!model)
             return;
-        return !!model?.match(/DS-7608NI-E2/);
+        return !!oldModels.find(oldModel => model?.match(oldModel));
     }
 
     async checkStreamSetup(channel: string, isOld: boolean): Promise<HikvisionCameraStreamSetup> {


### PR DESCRIPTION
I have an ERI-K104-P4 NVR - which is only a couple of years old, but doesn't support these channel capability checks.  This lets Scrypted fallback to H264/AAC similar to the DS-76098NI-E2.

Works great now with a 4 channel set up.