### PR TITLE
Improve snapshot handling for battery cams

### DIFF
--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -405,7 +405,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
             catch (e) {
                 this.console.log('Error in getting battery info', e);
             }
-        }, 1000 * 60 * 30);
+        }, 1000 * 15);
     }
 
     async reboot() {

--- a/plugins/reolink/src/reolink-api.ts
+++ b/plugins/reolink/src/reolink-api.ts
@@ -495,4 +495,29 @@ export class ReolinkCameraClient {
             sleep: channelStatusEntry?.sleep === 1,
         }
     }
+
+    async getWhiteLed() {
+        const url = new URL(`http://${this.host}/api.cgi`);
+
+        const body = [
+            {
+                cmd: "GetWhiteLed",
+                action: 0,
+                param: { channel: this.channelId }
+            }
+        ];
+
+        const response = await this.requestWithLogin({
+            url,
+            responseType: 'json',
+            method: 'POST',
+        }, this.createReadable(body));
+
+        const error = response.body?.find(elem => elem.error)?.error;
+        if (error) {
+            this.console.error('error during call to getWhiteLed', error);
+        }
+
+        return response.body[0];
+    }
 }


### PR DESCRIPTION
Snapshots on Reolink battery cameras drains the battery. Only current solution is to use a dummy url in the snapshot plugin
These changes will limit the snapshots taken from the camera, avoiding to waking it up eccessively
The snap will be allowed only when the camera wakes up for other purposes, or every n seconds defined in the new setting added