### PR TITLE
Preserve battery on snapshots

### DIFF
--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -1754,7 +1754,9 @@ export class RebroadcastPlugin extends AutoenableMixinProvider implements MixinP
       return;
     if (!interfaces.includes(ScryptedInterface.VideoCamera))
       return;
-    const ret = [ScryptedInterface.VideoCamera, ScryptedInterface.Settings, ScryptedInterface.Online, REBROADCAST_MIXIN_INTERFACE_TOKEN];
+    const ret = [ScryptedInterface.VideoCamera, ScryptedInterface.Settings, REBROADCAST_MIXIN_INTERFACE_TOKEN];
+    if (!interfaces.includes(ScryptedInterface.Online))
+      ret.push(ScryptedInterface.Online)
     return ret;
   }
 

--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -131,6 +131,8 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
             this.storageSettings.settings.snapshotsFromPrebuffer.hide = true;
 
             this.batteryCheckInterval = setInterval(async () => {
+                if (Date.now() - this.currentPictureTime < 60 * 1000)
+                    this.currentPicture = undefined;
                 this.takePictureRaw(this.currentPictureOptions, true);
             }, 15 * 1000);
         }


### PR DESCRIPTION
Rebroadcast plugin: don't implement Online interface if the extended device implements it already
Snapshot: if battery camera, don't execute any snapshot if the camera is not online. Regularly check for online status of the camera  to take a snapshot as soon as the camera gets online again. Never allow prebuffer