### PR TITLE
core: terminalservice fork across cluster

### DIFF
--- a/plugins/core/src/main.ts
+++ b/plugins/core/src/main.ts
@@ -13,7 +13,7 @@ import { MediaCore } from './media-core';
 import { checkLegacyLxc, checkLxc } from './platform/lxc';
 import { ConsoleServiceNativeId, PluginSocketService, ReplServiceNativeId } from './plugin-socket-service';
 import { ScriptCore, ScriptCoreNativeId, newScript } from './script-core';
-import { TerminalService, TerminalServiceNativeId } from './terminal-service';
+import { TerminalService, TerminalServiceNativeId, connectTTYStream } from './terminal-service';
 import { UsersCore, UsersNativeId } from './user';
 import { ClusterCore, ClusterCoreNativeId } from './cluster';
 
@@ -331,5 +331,6 @@ export async function fork() {
     return {
         tsCompile,
         newScript,
+        connectTTYStream,
     }
 }

--- a/plugins/core/src/main.ts
+++ b/plugins/core/src/main.ts
@@ -242,7 +242,7 @@ class ScryptedCore extends ScryptedDeviceBase implements HttpRequestHandler, Dev
         if (nativeId === UsersNativeId)
             return this.users ||= new UsersCore();
         if (nativeId === TerminalServiceNativeId)
-            return this.terminalService ||= new TerminalService();
+            return this.terminalService ||= new TerminalService(TerminalServiceNativeId, false);
         if (nativeId === ReplServiceNativeId)
             return this.replService ||= new PluginSocketService(ReplServiceNativeId, 'repl');
         if (nativeId === ConsoleServiceNativeId)

--- a/plugins/core/src/main.ts
+++ b/plugins/core/src/main.ts
@@ -13,7 +13,7 @@ import { MediaCore } from './media-core';
 import { checkLegacyLxc, checkLxc } from './platform/lxc';
 import { ConsoleServiceNativeId, PluginSocketService, ReplServiceNativeId } from './plugin-socket-service';
 import { ScriptCore, ScriptCoreNativeId, newScript } from './script-core';
-import { TerminalService, TerminalServiceNativeId, connectTTYStream } from './terminal-service';
+import { TerminalService, TerminalServiceNativeId, newTerminalService } from './terminal-service';
 import { UsersCore, UsersNativeId } from './user';
 import { ClusterCore, ClusterCoreNativeId } from './cluster';
 
@@ -140,7 +140,7 @@ class ScryptedCore extends ScryptedDeviceBase implements HttpRequestHandler, Dev
                 {
                     name: 'Terminal Service',
                     nativeId: TerminalServiceNativeId,
-                    interfaces: [ScryptedInterface.StreamService, ScryptedInterface.TTY],
+                    interfaces: [ScryptedInterface.StreamService, ScryptedInterface.TTY, ScryptedInterface.ClusterForkInterface],
                     type: ScryptedDeviceType.Builtin,
                 },
             );
@@ -331,6 +331,6 @@ export async function fork() {
     return {
         tsCompile,
         newScript,
-        connectTTYStream,
+        newTerminalService,
     }
 }

--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -148,6 +148,7 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
         if (options?.clusterWorkerId) {
             const clusterWorkerId = options.clusterWorkerId;
             delete options.clusterWorkerId;
+            options.isClusterFork = true;
 
             const fork = sdk.fork<{
                 connectTTYStream: typeof connectTTYStream,
@@ -159,6 +160,12 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
         let cp: InteractiveTerminal | NoninteractiveTerminal = null;
         const queue = createAsyncQueue<Buffer>();
         const extraPaths = await this.getExtraPaths();
+
+        queue.endPromise.then(() => {
+            if (options?.isClusterFork) {
+                process.exit();
+            }
+        });
 
         function registerChildListeners() {
             cp.onExit(() => queue.end());

--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -287,5 +287,5 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
 }
 
 export async function newTerminalService(): Promise<TerminalService> {
-    return new TerminalService(null, true);
+    return new TerminalService(TerminalServiceNativeId, true);
 }

--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -153,8 +153,13 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
             const fork = sdk.fork<{
                 connectTTYStream: typeof connectTTYStream,
             }>({ clusterWorkerId });
-            const result = await fork.result;
-            return result.connectTTYStream(input, options);
+            try {
+                const result = await fork.result;
+                return result.connectTTYStream(input, options);
+            } catch (e) {
+                fork.worker.terminate();
+                throw e;
+            }
         }
 
         let cp: InteractiveTerminal | NoninteractiveTerminal = null;

--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -112,7 +112,7 @@ class NoninteractiveTerminal {
 
 
 export class TerminalService extends ScryptedDeviceBase implements StreamService<Buffer | string, Buffer> {
-    constructor(nativeId?: ScryptedNativeId) {
+    constructor(nativeId?: ScryptedNativeId, private isClusterFork: boolean = false) {
         super(nativeId);
     }
 
@@ -148,7 +148,6 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
         if (options?.clusterWorkerId) {
             const clusterWorkerId = options.clusterWorkerId;
             delete options.clusterWorkerId;
-            options.isClusterFork = true;
 
             const fork = sdk.fork<{
                 connectTTYStream: typeof connectTTYStream,
@@ -167,7 +166,7 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
         const extraPaths = await this.getExtraPaths();
 
         queue.endPromise.then(() => {
-            if (options?.isClusterFork) {
+            if (this.isClusterFork) {
                 process.exit();
             }
         });
@@ -258,6 +257,6 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
 }
 
 export async function connectTTYStream(input: AsyncGenerator<Buffer | string, void>, options?: any): Promise<AsyncGenerator<Buffer, void>> {
-    const terminalService = new TerminalService();
+    const terminalService = new TerminalService(null, true);
     return terminalService.connectStream(input, options);
 }


### PR DESCRIPTION
Enable `terminalservice` to fork across cluster nodes. This allows TTY plugins to tell `terminalservice` which node to launch its PTY.