### PR TITLE
core: exit terminal's subprocess on generator end

### DIFF
--- a/plugins/core/src/terminal-service.ts
+++ b/plugins/core/src/terminal-service.ts
@@ -278,6 +278,8 @@ export class TerminalService extends ScryptedDeviceBase implements StreamService
             }
             catch (e) {
                 this.console.log(e);
+            }
+            finally {
                 cp?.kill();
             }
         })();


### PR DESCRIPTION
When navigating away from a TTY page, it appears that the async generator exits without raising any exceptions. This can cause core to keep the subprocess (and RPC objects) active even when the xtermjs window no longer exists. The fix is to always clean up the subprocess.