### PR TITLE
Add polling to reolink discovered devices

### DIFF
--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -11,10 +11,21 @@ import { AIState, Enc, ReolinkCameraClient } from './reolink-api';
 
 class ReolinkCameraSiren extends ScryptedDeviceBase implements OnOff {
     sirenTimeout: NodeJS.Timeout;
+    sirenCheckInterval: NodeJS.Timeout;
 
     constructor(public camera: ReolinkCamera, nativeId: string) {
         super(nativeId);
-        this.on = false;
+
+        this.sirenCheckInterval = setInterval(async () => {
+            if (!this.camera.sleeping) {
+                const api = this.camera.getClient();
+                const { enabled } = await api.getSiren();
+
+                if (enabled !== this.on) {
+                    this.on = enabled;
+                }
+            }
+        }, 2000);
     }
 
     async turnOff() {
@@ -51,9 +62,21 @@ class ReolinkCameraSiren extends ScryptedDeviceBase implements OnOff {
 }
 
 class ReolinkCameraFloodlight extends ScryptedDeviceBase implements OnOff, Brightness {
+    floodlightCheckInterval: NodeJS.Timeout;
+
     constructor(public camera: ReolinkCamera, nativeId: string) {
         super(nativeId);
-        this.on = false;
+
+        this.floodlightCheckInterval = setInterval(async () => {
+            if (!this.camera.sleeping) {
+                const api = this.camera.getClient();
+                const { enabled } = await api.getWhiteLedState();
+
+                if (enabled !== this.on) {
+                    this.on = enabled;
+                }
+            }
+        }, 2000);
     }
 
     async setBrightness(brightness: number): Promise<void> {
@@ -79,9 +102,21 @@ class ReolinkCameraFloodlight extends ScryptedDeviceBase implements OnOff, Brigh
 }
 
 class ReolinkCameraPirSensor extends ScryptedDeviceBase implements OnOff {
+    pirCheckInterval: NodeJS.Timeout;
+
     constructor(public camera: ReolinkCamera, nativeId: string) {
         super(nativeId);
-        this.on = false;
+
+        this.pirCheckInterval = setInterval(async () => {
+            if (!this.camera.sleeping) {
+                const api = this.camera.getClient();
+                const { enabled } = await api.getPirState();
+
+                if (enabled !== this.on) {
+                    this.on = enabled;
+                }
+            }
+        }, 2000);
     }
 
     async turnOff() {

--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -16,16 +16,16 @@ class ReolinkCameraSiren extends ScryptedDeviceBase implements OnOff {
     constructor(public camera: ReolinkCamera, nativeId: string) {
         super(nativeId);
 
-        this.sirenCheckInterval = setInterval(async () => {
-            if (!this.camera.sleeping) {
+        if (!this.camera.interfaces.includes(ScryptedInterface.Sleep)) {
+            this.sirenCheckInterval = setInterval(async () => {
                 const api = this.camera.getClient();
                 const { enabled } = await api.getSiren();
 
                 if (enabled !== this.on) {
                     this.on = enabled;
                 }
-            }
-        }, 2000);
+            }, 2000);
+        }
     }
 
     async turnOff() {
@@ -67,16 +67,16 @@ class ReolinkCameraFloodlight extends ScryptedDeviceBase implements OnOff, Brigh
     constructor(public camera: ReolinkCamera, nativeId: string) {
         super(nativeId);
 
-        this.floodlightCheckInterval = setInterval(async () => {
-            if (!this.camera.sleeping) {
+        if (!this.camera.interfaces.includes(ScryptedInterface.Sleep)) {
+            this.floodlightCheckInterval = setInterval(async () => {
                 const api = this.camera.getClient();
                 const { enabled } = await api.getWhiteLedState();
 
                 if (enabled !== this.on) {
                     this.on = enabled;
                 }
-            }
-        }, 2000);
+            }, 2000);
+        }
     }
 
     async setBrightness(brightness: number): Promise<void> {
@@ -107,16 +107,16 @@ class ReolinkCameraPirSensor extends ScryptedDeviceBase implements OnOff {
     constructor(public camera: ReolinkCamera, nativeId: string) {
         super(nativeId);
 
-        this.pirCheckInterval = setInterval(async () => {
-            if (!this.camera.sleeping) {
+        if (!this.camera.interfaces.includes(ScryptedInterface.Sleep)) {
+            this.pirCheckInterval = setInterval(async () => {
                 const api = this.camera.getClient();
                 const { enabled } = await api.getPirState();
 
                 if (enabled !== this.on) {
                     this.on = enabled;
                 }
-            }
-        }, 2000);
+            }, 2000);
+        }
     }
 
     async turnOff() {

--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -248,29 +248,35 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
         try {
             const api = this.getClient();
 
-            if (this.hasFloodlight() && this.floodlight) {
-                const { enabled } = await api.getWhiteLedState();
+            try {
+                if (this.hasFloodlight() && this.floodlight) {
+                    const { enabled } = await api.getWhiteLedState();
 
-                if (enabled !== this.floodlight.on) {
-                    this.floodlight.on = enabled;
+                    if (enabled !== this.floodlight.on) {
+                        this.floodlight.on = enabled;
+                    }
                 }
-            }
+            } catch { }
 
-            if (this.hasSiren() && this.siren) {
-                const { enabled } = await api.getSiren();
+            try {
+                if (this.hasSiren() && this.siren) {
+                    const { enabled } = await api.getSiren();
 
-                if (enabled !== this.siren.on) {
-                    this.siren.on = enabled;
+                    if (enabled !== this.siren.on) {
+                        this.siren.on = enabled;
+                    }
                 }
-            }
+            } catch { }
 
-            if (this.hasPirSensor() && this.pirSensor) {
-                const { enabled } = await api.getPirState();
+            try {
+                if (this.hasPirSensor() && this.pirSensor) {
+                    const { enabled } = await api.getPirState();
 
-                if (enabled !== this.pirSensor.on) {
-                    this.pirSensor.on = enabled;
+                    if (enabled !== this.pirSensor.on) {
+                        this.pirSensor.on = enabled;
+                    }
                 }
-            }
+            } catch { }
         } catch (e) {
             this.console.error('Error in pollDeviceStates', e);
         }

--- a/plugins/reolink/src/reolink-api.ts
+++ b/plugins/reolink/src/reolink-api.ts
@@ -476,6 +476,31 @@ export class ReolinkCameraClient {
         }
     }
 
+    async getSiren() {
+        const url = new URL(`http://${this.host}/api.cgi`);
+
+        const body = [{
+            cmd: 'GetAudioAlarmV20',
+            action: 0,
+            param: { channel: this.channelId }
+        }];
+
+        const response = await this.requestWithLogin({
+            url,
+            method: 'POST',
+            responseType: 'json',
+        }, this.createReadable(body));
+
+        const error = response.body?.[0]?.error;
+        if (error) {
+            this.console.error('error during call to getSiren', JSON.stringify(body), error);
+        }
+
+        return {
+            enabled: response.body?.[0]?.value?.Audio?.enable === 1
+        };
+    }
+
     async setSiren(on: boolean, duration?: number) {
         const url = new URL(`http://${this.host}/api.cgi`);
         const params = url.searchParams;
@@ -512,6 +537,31 @@ export class ReolinkCameraClient {
         return {
             value: (response.body?.[0]?.value || response.body?.value) as SirenResponse,
             data: response.body,
+        };
+    }
+
+    async getWhiteLedState() {
+        const url = new URL(`http://${this.host}/api.cgi`);
+
+        const body = [{
+            cmd: 'GetWhiteLed',
+            action: 0,
+            param: { channel: this.channelId }
+        }];
+
+        const response = await this.requestWithLogin({
+            url,
+            method: 'POST',
+            responseType: 'json',
+        }, this.createReadable(body));
+
+        const error = response.body?.[0]?.error;
+        if (error) {
+            this.console.error('error during call to getWhiteLedState', JSON.stringify(body), error);
+        }
+
+        return {
+            enabled: response.body?.[0]?.value?.WhiteLed?.state === 1
         };
     }
 
@@ -608,7 +658,7 @@ export class ReolinkCameraClient {
         };
     }
 
-    async getPirState(on?: boolean) {
+    async getPirState() {
         const url = new URL(`http://${this.host}/api.cgi`);
 
         const body = [{
@@ -625,10 +675,13 @@ export class ReolinkCameraClient {
 
         const error = response.body?.[0]?.error;
         if (error) {
-            this.console.error('error during call to setWhiteLedState', JSON.stringify(body), error);
+            this.console.error('error during call to getPirState', JSON.stringify(body), error);
         }
 
-        return response.body?.[0]?.value?.pirInfo;
+        return {
+            enabled: response.body?.[0]?.value?.pirInfo?.enable === 1,
+            state: response.body?.[0]?.value?.pirInfo
+        };
     }
 
     async setPirState(on: boolean) {
@@ -637,7 +690,7 @@ export class ReolinkCameraClient {
         const currentPir = await this.getPirState();
         const newState = on ? 1 : 0;
 
-        if (!currentPir || currentPir.enable === newState) {
+        if (!currentPir || currentPir.state?.enable === newState) {
             return;
         }
 


### PR DESCRIPTION
- Adds polling to discovered devices, to check current state. Avoid the call if camera is sleeping, since all these commands are meant to actually wake up battery cams
- Remove on property initialization of devices to false, this would actually triggers everytime reset of the actual devices on plugin restart 

There could be a different call for older cameras on the Siren device, I could not test it out. Would go for the V2 now and check if any issue will be reported on older devices. There should be just a property version to check