### PR TITLE
Allow sleeping cameras to have longer lived snapshots

### DIFF
--- a/plugins/snapshot/src/main.ts
+++ b/plugins/snapshot/src/main.ts
@@ -263,8 +263,11 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
             }
             try {
                 // consider waking the camera if 
-                if (!eventSnapshot && this.mixinDeviceInterfaces.includes(ScryptedInterface.Sleep) && realDevice.sleeping)
-                    throw new Error('Not waking sleeping camera for periodic snapshot.');
+                if (!eventSnapshot && this.mixinDeviceInterfaces.includes(ScryptedInterface.Sleep) && realDevice.sleeping) {
+                    this.console.log('Not waking sleeping camera for periodic snapshot.');
+                    return this.lastAvailablePicture;
+                }
+
                 return await this.mixinDevice.takePicture(takePictureOptions).then(mo => mediaManager.convertMediaObjectToBuffer(mo, 'image/jpeg'))
             }
             catch (e) {
@@ -278,9 +281,10 @@ class SnapshotMixin extends SettingsMixinDeviceBase<Camera> implements Camera {
     async takePictureRaw(options?: RequestPictureOptions): Promise<Buffer> {
         const eventSnapshot = options?.reason === 'event';
         const periodicSnapshot = options?.reason === 'periodic';
+        const hoursDuration = this.mixinDeviceInterfaces.includes(ScryptedInterface.Sleep) ? 5 : 1;
 
         // clear out snapshots that are too old.
-        if (this.currentPictureTime < Date.now() - 1 * 60 * 60 * 1000)
+        if (this.currentPictureTime < Date.now() - hoursDuration * 60 * 60 * 1000)
             this.currentPicture = undefined;
 
         // always grab/debounce a snapshot


### PR DESCRIPTION
Current implementation of snapshots for sleeping cameras would discard the latest acquired if requested with an event, this PR would try to let the snapshots for these longer and to not discard in case of events requests