### PR TITLE
Update install-scrypted-dependencies-win.ps1

### DIFF
--- a/install/local/install-scrypted-dependencies-win.ps1
+++ b/install/local/install-scrypted-dependencies-win.ps1
@@ -1,4 +1,13 @@
-#Requires -RunAsAdministrator
+# Check if the script is running as administrator
+$IsAdmin = [System.Security.Principal.WindowsPrincipal] [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$AdminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
+
+if (-not $IsAdmin.IsInRole($AdminRole)) {
+    # If not, relaunch the script with elevated privileges
+    $ScriptPath = $PSCommandPath
+    Start-Process powershell -ArgumentList "-File `"$ScriptPath`"" -Verb RunAs
+    exit
+}
 
 # Set-PSDebug -Trace 1
 


### PR DESCRIPTION
let the script relaunch itself with admin privileges.  Can be a pain when launching PowerShell as admin, you can't drag and drop the script into a PowerShell window.   This just makes it easier for people new to PowerShell.