### PR TITLE
Fixed an issue for some devices. They send screen width as not even value

### DIFF
--- a/plugins/webrtc/package.json
+++ b/plugins/webrtc/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/webrtc",
-   "version": "0.2.77",
+   "version": "0.2.78",
    "scripts": {
       "scrypted-setup-project": "scrypted-setup-project",
       "prescrypted-setup-project": "scrypted-package-json",

--- a/plugins/webrtc/src/ffmpeg-to-wrtc.ts
+++ b/plugins/webrtc/src/ffmpeg-to-wrtc.ts
@@ -458,7 +458,11 @@ export function parseOptions(options: RTCSignalingOptions) {
     if (options?.userAgent?.includes('Firefox/'))
         sessionSupportsH264High = true;
 
-    const transcodeWidth = Math.max(640, Math.min(options?.screen?.width || 960, 1280));
+    // Some devices return a `screen width` value that is not a multiple of 2, which is not allowed for the h264 codec.
+    // Convert to a smaller even value.
+    const screenWidthForTranscodeH264 = Math.trunc((options?.screen?.width || 960) / 2) * 2;
+
+    const transcodeWidth = Math.max(640, Math.min(screenWidthForTranscodeH264, 1280));
     const devicePixelRatio = options?.screen?.devicePixelRatio || 1;
     const width = (options?.screen?.width * devicePixelRatio) || undefined;
     const height = (options?.screen?.height * devicePixelRatio) || undefined;


### PR DESCRIPTION
When trying to connect from Home Assistant (camera card) from a Realme tablet , the following log comes to the WebRTC plugin:

```
linux x64 #202311151304 SMP PREEMPT_DYNAMIC Thu Nov 16 08:20:12 UTC 2023
server version: 0.137.0
plugin version: @scrypted/webrtc 0.2.77
full
########################
4/26/2025, 9:59:18 AM
########################

................

[Домофон] Client Stream Profile {
  transcodeBaseline: true,
  sessionSupportsH264High: true,
  maximumCompatibilityMode: false,
  userAgent: 'Mozilla/5.0 (Linux; Android 11; RMP2106 Build/RP1A.201005.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/135.0.7049.111 Safari/537.36 Home Assistant/2025.4.3-15918 (Android 11; RMP2106)',
  capabilities: {
    audio: { codecs: [Array], headerExtensions: [Array] },
    video: { codecs: [Array], headerExtensions: [Array] }
  },
  screen: { devicePixelRatio: 1.3312500715255737, width: 1007, height: 601 }
}
[Домофон] video codec/container not matched, transcoding: undefined {"url":"rtsp://127.0.0.1:39331/8a421ce14bb0c848/89","urls":["rtsp://10.210.210.150:39331/8a421ce14bb0c848/89"],"container":"rtsp","inputArguments":["-analyzeduration","0","-probesize","500000","-reorder_queue_size","0","-rtsp_transport","tcp","-f","rtsp","-i","rtsp://127.0.0.1:39331/8a421ce14bb0c848/89"],"mediaStreamOptions":{"id":"channel0","name":"Stream 1","url":"rtsp://10.210.211.211:554/ISAPI/Streaming/channels/101/?transportmode=unicast","container":"rtsp","video":{"width":1920,"height":1080,"codec":"h264","h264Info":{"fuab":false,"stapb":false,"mtap16":false,"mtap32":false,"sei":false,"reserved0":false,"reserved30":false,"reserved31":false}},"audio":{"codec":"pcm_mulaw","sampleRate":8000},"tool":"scrypted","sdp":"v=0\r\no=- 1745561608236629 1745561608236629 IN IP4 10.210.211.211\r\ns=Media Presentation\r\ne=NONE\r\nb=AS:5100\r\nt=0 0\r\na=control:rtsp://10.210.211.211:554/ISAPI/Streaming/channels/101/?transportmode=unicast\r\nm=video 0 RTP/AVP 96\r\nb=AS:5000\r\na=control:rtsp://10.210.211.211:554/ISAPI/Streaming/channels/101/trackID=1?transportmode=unicast\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 profile-level-id=420029; packetization-mode=1; sprop-parameter-sets=\r\nm=audio 0 RTP/AVP 0\r\nb=AS:50\r\na=control:rtsp://10.210.211.211:554/ISAPI/Streaming/channels/101/trackID=2?transportmode=unicast\r\na=rtpmap:0 PCMU/8000\r\na=Media_header:MEDIAINFO=494D4B48010100000400010010710110401F0000000;\r\na=appversion:1.0","prebuffer":1963,"prebufferBytes":245012}}
[Домофон] -hide_banner -analyzeduration 0 -probesize 500000 -reorder_queue_size 0 -rtsp_transport tcp -f rtsp -i rtsp:[REDACTED] -b:v 1000000 -bufsize 2000000 -maxrate 1000000 -r 15 -filter_complex scale='min(1007,iw)':-2 -profile:v baseline -preset ultrafast -g 60 -c:v libx264 -bf 0 -dn -sn -an -f rtp rtp://127.0.0.1:47141?pkt_size=1200 -acodec copy -dn -sn -vn -f rtp rtp://127.0.0.1:60006? -sdp_file pipe:4
[Домофон] [rtsp @ 0x561be4d7b200] Missing PPS in sprop-parameter-sets, ignoring

................

[Домофон] [libx264 @ 0x561be4f02a80] width not divisible by 2 (1007x566)
[vost#0:0/libx264 @ 0x561be4f026c0] Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height.
Error while filtering: Generic error in an external library

[Домофон] [out#0/rtp @ 0x561be4d855c0] Nothing was written into output file, because at least one of its streams received no packets.
[out#1/rtp @ 0x561be4f04000] Nothing was written into output file, because at least one of its streams received no packets.
frame=    0 fps=0.0 q=0.0 Lsize=       0kB time=N/A bitrate=N/A speed=N/A    

[Домофон] video/audio detected, discarding further input
[Домофон] ffmpeg exited
```

That is, the tablet reported that it has a resolution of `1007x566`, which led to an error in the x264 codec: `[libx264 @ 0x561be4f02a80] width not divisible by 2 (1007x566)`

This PR offers a "simple" solution.

I tested it in Realme Pad, it works.