### PR TITLE
server: bind single address if cluster address is 127.0.0.1

### DIFF
--- a/server/src/cluster/cluster-setup.ts
+++ b/server/src/cluster/cluster-setup.ts
@@ -463,7 +463,7 @@ export function getScryptedClusterMode(): ['server' | 'client', string, number] 
 
 export async function clusterListenZero(callback: (socket: net.Socket) => void) {
     const SCRYPTED_CLUSTER_ADDRESS = process.env.SCRYPTED_CLUSTER_ADDRESS;
-    if (!SCRYPTED_CLUSTER_ADDRESS) {
+    if (!SCRYPTED_CLUSTER_ADDRESS || SCRYPTED_CLUSTER_ADDRESS === '127.0.0.1') {
         const server = new net.Server(callback);
         const port = await listenZero(server, '127.0.0.1');
         return {


### PR DESCRIPTION
Specifying 127.0.0.1 as the server cluster address (such as in the case of a multi-Docker container cluster test setup) fails since it will try binding to the local address twice.