### PR TITLE
Fallback pip to latin

### DIFF
--- a/server/python/plugin_pip.py
+++ b/server/python/plugin_pip.py
@@ -101,7 +101,10 @@ def install_with_pip(
         line = p.stdout.readline()
         if not line:
             break
-        line = line.decode("utf8").rstrip("\r\n")
+        try:
+            line = line.decode("utf8").rstrip("\r\n")
+        except UnicodeDecodeError:
+            line = line.decode("latin-1").rstrip("\r\n")  # Fallback to Latin
         print(line)
     result = p.wait()
     print("pip install result %s" % result)


### PR DESCRIPTION
Had an issue running Scrypted in Windows under a PT-BR install. The default user on this case is created as "Usuário" and pip was complaining about not finding the home dir. 
With this fix I'm able to run it in Windows.