### PR TITLE
Add utility attributes to get camera data

### DIFF
--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -164,7 +164,6 @@ class ScryptedInterface(str, Enum):
     ObjectDetection = "ObjectDetection"
     ObjectDetectionGenerator = "ObjectDetectionGenerator"
     ObjectDetectionPreview = "ObjectDetectionPreview"
-    ObjectDetectionZones = "ObjectDetectionZones"
     ObjectDetector = "ObjectDetector"
     ObjectTracker = "ObjectTracker"
     OccupancySensor = "OccupancySensor"
@@ -1718,11 +1717,6 @@ class StreamService:
     """Generic bidirectional stream connection."""
 
     async def connectStream(self, input: AsyncGenerator[Any, None] = None, options: Any = None) -> AsyncGenerator[Any, None]:
-        pass
-
-class ObjectDetectionZones:
-
-    async def getZones(self) -> Any:
         pass
 
 
@@ -3575,13 +3569,6 @@ ScryptedInterfaceDescriptors = {
   "ScryptedSettings": {
     "name": "ScryptedSettings",
     "methods": [],
-    "properties": []
-  },
-  "ObjectDetectionZones": {
-    "name": "ObjectDetectionZones",
-    "methods": [
-      "getZones"
-    ],
     "properties": []
   }
 }

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -164,7 +164,9 @@ class ScryptedInterface(str, Enum):
     ObjectDetection = "ObjectDetection"
     ObjectDetectionGenerator = "ObjectDetectionGenerator"
     ObjectDetectionPreview = "ObjectDetectionPreview"
+    ObjectDetectionZones = "ObjectDetectionZones"
     ObjectDetector = "ObjectDetector"
+    NativebjectDetector = "NativebjectDetector"
     ObjectTracker = "ObjectTracker"
     OccupancySensor = "OccupancySensor"
     Online = "Online"
@@ -825,6 +827,7 @@ class ObjectsDetected(TypedDict):
     inputDimensions: tuple[float, float]
     resources: VideoResource
     timestamp: float
+    sourceId: str # The id of the generation source. Can be a camera id or a plugin id 
 
 class PanTiltZoomCapabilities(TypedDict):
 
@@ -1467,6 +1470,11 @@ class ObjectDetector:
     async def getObjectTypes(self) -> ObjectDetectionTypes:
         pass
 
+class NativebjectDetector:
+
+    async def getNativeObjectTypes(self) -> ObjectDetectionTypes:
+        pass
+
 
 class ObjectTracker:
     """Given object detections with bounding boxes, return a similar list with tracker ids."""
@@ -1717,6 +1725,11 @@ class StreamService:
     """Generic bidirectional stream connection."""
 
     async def connectStream(self, input: AsyncGenerator[Any, None] = None, options: Any = None) -> AsyncGenerator[Any, None]:
+        pass
+
+class ObjectDetectionZones:
+
+    async def getZones(self) -> Any:
         pass
 
 
@@ -3431,6 +3444,13 @@ ScryptedInterfaceDescriptors = {
     ],
     "properties": []
   },
+  "NativebjectDetector": {
+    "name": "NativebjectDetector",
+    "methods": [
+      "getNativeObjectTypes"
+    ],
+    "properties": []
+  },
   "ObjectDetection": {
     "name": "ObjectDetection",
     "methods": [
@@ -3569,6 +3589,13 @@ ScryptedInterfaceDescriptors = {
   "ScryptedSettings": {
     "name": "ScryptedSettings",
     "methods": [],
+    "properties": []
+  },
+  "ObjectDetectionZones": {
+    "name": "ObjectDetectionZones",
+    "methods": [
+      "getZones"
+    ],
     "properties": []
   }
 }

--- a/sdk/types/scrypted_python/scrypted_sdk/types.py
+++ b/sdk/types/scrypted_python/scrypted_sdk/types.py
@@ -166,7 +166,6 @@ class ScryptedInterface(str, Enum):
     ObjectDetectionPreview = "ObjectDetectionPreview"
     ObjectDetectionZones = "ObjectDetectionZones"
     ObjectDetector = "ObjectDetector"
-    NativebjectDetector = "NativebjectDetector"
     ObjectTracker = "ObjectTracker"
     OccupancySensor = "OccupancySensor"
     Online = "Online"
@@ -1469,12 +1468,6 @@ class ObjectDetector:
 
     async def getObjectTypes(self) -> ObjectDetectionTypes:
         pass
-
-class NativebjectDetector:
-
-    async def getNativeObjectTypes(self) -> ObjectDetectionTypes:
-        pass
-
 
 class ObjectTracker:
     """Given object detections with bounding boxes, return a similar list with tracker ids."""
@@ -3441,13 +3434,6 @@ ScryptedInterfaceDescriptors = {
     "methods": [
       "getDetectionInput",
       "getObjectTypes"
-    ],
-    "properties": []
-  },
-  "NativebjectDetector": {
-    "name": "NativebjectDetector",
-    "methods": [
-      "getNativeObjectTypes"
     ],
     "properties": []
   },

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1608,10 +1608,6 @@ export interface SecuritySystem {
   disarmSecuritySystem(): Promise<void>;
 }
 
-export interface ObjectDetectionZones {
-  getZones(): Promise<ObjectDetectionZone[]>;
-}
-
 export interface ObjectDetectionHistory {
   firstSeen: number;
   lastSeen: number;
@@ -2401,7 +2397,6 @@ export enum ScryptedInterface {
   VideoCamera = "VideoCamera",
   VideoCameraMask = "VideoCameraMask",
   VideoTextOverlays = "VideoTextOverlays",
-  ObjectDetectionZones = "ObjectDetectionZones",
   VideoRecorder = "VideoRecorder",
   VideoRecorderManagement = "VideoRecorderManagement",
   PanTiltZoom = "PanTiltZoom",

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1708,9 +1708,6 @@ export interface ObjectDetector {
   getDetectionInput(detectionId: string, eventId?: any): Promise<MediaObject>;
   getObjectTypes(): Promise<ObjectDetectionTypes>;
 }
-export interface NativebjectDetector {
-  getNativeObjectTypes(): Promise<ObjectDetectionTypes>;
-}
 export interface ObjectDetectionGeneratorSession {
   zones?: ObjectDetectionZone[];
   settings?: { [key: string]: any };
@@ -2461,7 +2458,6 @@ export enum ScryptedInterface {
   ClusterForkInterface = "ClusterForkInterface",
   ObjectTracker = "ObjectTracker",
   ObjectDetector = "ObjectDetector",
-  NativebjectDetector = "NativebjectDetector",
   ObjectDetection = "ObjectDetection",
   ObjectDetectionPreview = "ObjectDetectionPreview",
   ObjectDetectionGenerator = "ObjectDetectionGenerator",

--- a/sdk/types/src/types.input.ts
+++ b/sdk/types/src/types.input.ts
@@ -1608,6 +1608,10 @@ export interface SecuritySystem {
   disarmSecuritySystem(): Promise<void>;
 }
 
+export interface ObjectDetectionZones {
+  getZones(): Promise<ObjectDetectionZone[]>;
+}
+
 export interface ObjectDetectionHistory {
   firstSeen: number;
   lastSeen: number;
@@ -1673,6 +1677,11 @@ export interface ObjectsDetected {
   inputDimensions?: [number, number],
   timestamp: number;
   resources?: VideoResource;
+  /**
+   * The id of the generation source.
+   * Can be a camera id or a plugin id 
+   */
+  sourceId?: string;
 }
 export type ObjectDetectionClass = 'motion' | 'face' | 'person' | string;
 export interface ObjectDetectionTypes {
@@ -1698,6 +1707,9 @@ export interface ObjectDetector {
    */
   getDetectionInput(detectionId: string, eventId?: any): Promise<MediaObject>;
   getObjectTypes(): Promise<ObjectDetectionTypes>;
+}
+export interface NativebjectDetector {
+  getNativeObjectTypes(): Promise<ObjectDetectionTypes>;
 }
 export interface ObjectDetectionGeneratorSession {
   zones?: ObjectDetectionZone[];
@@ -2392,6 +2404,7 @@ export enum ScryptedInterface {
   VideoCamera = "VideoCamera",
   VideoCameraMask = "VideoCameraMask",
   VideoTextOverlays = "VideoTextOverlays",
+  ObjectDetectionZones = "ObjectDetectionZones",
   VideoRecorder = "VideoRecorder",
   VideoRecorderManagement = "VideoRecorderManagement",
   PanTiltZoom = "PanTiltZoom",
@@ -2448,6 +2461,7 @@ export enum ScryptedInterface {
   ClusterForkInterface = "ClusterForkInterface",
   ObjectTracker = "ObjectTracker",
   ObjectDetector = "ObjectDetector",
+  NativebjectDetector = "NativebjectDetector",
   ObjectDetection = "ObjectDetection",
   ObjectDetectionPreview = "ObjectDetectionPreview",
   ObjectDetectionGenerator = "ObjectDetectionGenerator",


### PR DESCRIPTION
- Add a property sourceId to ObjectsDetected to help identify from where the object detections come from on consumer plugins