### PR TITLE
python: use create_task instead of run_coroutine_threadsafe

### DIFF
--- a/server/python/rpc_reader.py
+++ b/server/python/rpc_reader.py
@@ -206,7 +206,7 @@ class RpcConnectionTransport(RpcTransport):
         return self.writeMessage(bytes(buffer), reject)
 
 
-async def readLoop(loop, peer: rpc.RpcPeer, rpcTransport: RpcTransport):
+async def readLoop(peer: rpc.RpcPeer, rpcTransport: RpcTransport):
     deserializationContext = {"buffers": []}
 
     while True:
@@ -216,9 +216,7 @@ async def readLoop(loop, peer: rpc.RpcPeer, rpcTransport: RpcTransport):
             deserializationContext["buffers"].append(message)
             continue
 
-        asyncio.run_coroutine_threadsafe(
-            peer.handleMessage(message, deserializationContext), loop
-        )
+        asyncio.create_task(peer.handleMessage(message, deserializationContext))
 
         deserializationContext = {"buffers": []}
 
@@ -246,7 +244,7 @@ async def prepare_peer_readloop(loop: AbstractEventLoop, rpcTransport: RpcTransp
 
     async def peerReadLoop():
         try:
-            await readLoop(loop, peer, rpcTransport)
+            await readLoop(peer, rpcTransport)
         except:
             peer.kill()
             raise


### PR DESCRIPTION
## Summary

- Replace `asyncio.run_coroutine_threadsafe()` with `asyncio.create_task()` in the RPC read loop

## Problem

`run_coroutine_threadsafe` is designed for scheduling coroutines from a **different thread** onto the event loop. However, `readLoop` is already an async function running on the event loop, so using `run_coroutine_threadsafe` adds unnecessary thread-safe queue overhead for every RPC message.

## Solution

Use `create_task()` which is the native and more efficient way to spawn concurrent coroutines when already running on the event loop.

## Test plan

- [ ] Verify Python plugins continue to work correctly
- [ ] No functional change expected, only minor performance improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)