### PR TITLE
amcrest: handle HTTP/1.0 responses in event listener

### DIFF
--- a/plugins/amcrest/src/amcrest-api.ts
+++ b/plugins/amcrest/src/amcrest-api.ts
@@ -268,8 +268,8 @@ export class AmcrestCameraClient {
                     continue;
                 if (ignore === boundaryEnd)
                     continue;
-                // dahua bugs out and sends this.
-                if (ignore === 'HTTP/1.1 200 OK') {
+                // dahua bugs out and sends this (handle both HTTP/1.0 and HTTP/1.1).
+                if (ignore === 'HTTP/1.1 200 OK' || ignore === 'HTTP/1.0 200 OK') {
                     const message = await readAmcrestMessage(stream);
                     this.console.log('ignoring dahua http message', message);
                     message.unshift('');


### PR DESCRIPTION
## Problem
Some Dahua/Amcrest NVRs (e.g., AMDV7208M) respond with `HTTP/1.0 200 OK` instead of `HTTP/1.1 200 OK`. The event listener only checked for HTTP/1.1, causing it to fail with "expected boundary" errors when receiving HTTP/1.0 responses.

This resulted in:
- Event listener crashing immediately after connecting
- No motion detection events received
- `RpcPeer has been killed` errors in logs

## Solution
Added `HTTP/1.0 200 OK` as an accepted response in addition to `HTTP/1.1 200 OK`.

## Testing
- Verified curl from inside Scrypted container receives motion events correctly
- NVR confirmed to send HTTP/1.0 responses via `curl -v`

Fixes #1958

## Related Issues
- Similar to #1417 (Dahua motion events not working)
- Similar to #1475 (Motion detection stopped working)