### PR TITLE
hash-based paths for model downloads

### DIFF
--- a/plugins/openvino/src/predict/clip.py
+++ b/plugins/openvino/src/predict/clip.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 from typing import Tuple
 
 import scrypted_sdk
@@ -55,9 +56,11 @@ class ClipEmbedding(PredictPlugin, scrypted_sdk.TextEmbedding, scrypted_sdk.Imag
 
     def initModel(self):
         local_files: list[str] = []
+        plugin_suffix = self.pluginId.split('/')[1]
         for file in self.getFiles():
             remote_file = "https://huggingface.co/koushd/clip/resolve/main/" + file
-            localFile = self.downloadFile(remote_file, f"{self.id}/{file}")
+            url_hash = hashlib.sha256(remote_file.encode()).hexdigest()[:12]
+            localFile = self.downloadFile(remote_file, f"{plugin_suffix}/{url_hash}/{file}")
             local_files.append(localFile)
         return self.loadModel(local_files)
 

--- a/plugins/openvino/src/predict/custom_detect.py
+++ b/plugins/openvino/src/predict/custom_detect.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, List, Tuple
+import hashlib
 import json
 
 import numpy as np
@@ -50,9 +51,11 @@ class CustomDetection(PredictPlugin, scrypted_sdk.Settings):
         self.inputheight = config["input_shape"][3]
         files: list[str] = config["files"]
         local_files: list[str] = []
+        plugin_suffix = self.pluginId.split('/')[1]
         for file in files:
             remote_file = replace_last_path_component(config_url, file)
-            localFile = self.downloadFile(remote_file, f"{self.id}/{file}")
+            url_hash = hashlib.sha256(remote_file.encode()).hexdigest()[:12]
+            localFile = self.downloadFile(remote_file, f"{plugin_suffix}/{url_hash}/{file}")
             local_files.append(localFile)
 
         self.model = self.loadModel(local_files)


### PR DESCRIPTION
## Summary

- Replace `self.id` (runtime device ID) with hash-based paths for model downloads
- Path format: `{plugin_suffix}/{sha256(url)[:12]}/{filename}`
- Ensures consistent, reproducible, collision-free paths across plugin reinstalls

## Problem

The detection plugins used `self.id` (a Scrypted-assigned device ID) in file download paths. This ID is non-deterministic - it's assigned at runtime and changes if the plugin is reinstalled. This breaks reproducibility and wastes disk space on reinstalls.

## Solution

Use a deterministic path based on:
1. Plugin suffix extracted from `self.pluginId` (e.g., `openvino` from `@scrypted/openvino`)
2. First 12 chars of SHA256 hash of the download URL (collision-free, deterministic)

## Affected Plugins

All 6 detection plugins via symlinks: openvino, onnx, ncnn, tensorflow-lite, rknn, coreml