### PR TITLE
homekit: remove listeners from video/audioReturn sockets

### DIFF
--- a/plugins/homekit/src/types/camera/camera-streaming.ts
+++ b/plugins/homekit/src/types/camera/camera-streaming.ts
@@ -101,6 +101,8 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
             audioReturn.setSendBufferSize(1024 * 1024);
 
             killPromise.finally(() => {
+                videoReturn.removeAllListeners('message');
+                audioReturn.removeAllListeners('message');
                 closeQuiet(videoReturn);
                 closeQuiet(audioReturn);
             });


### PR DESCRIPTION
I'm finding HomeKit playback starts stuttering after a couple of weeks of uptime.  Let's see if this helps.