### PR TITLE
Use optional chaining for allowBatteryPrebuffer

### DIFF
--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -1358,7 +1358,7 @@ class PrebufferMixin extends SettingsMixinDeviceBase<VideoCamera> implements Vid
       }
       const name = mso?.name;
       const enabled = enabledIds.includes(id);
-      session = new PrebufferSession(this, mso, enabled, mso.allowBatteryPrebuffer);
+      session = new PrebufferSession(this, mso, enabled, mso?.allowBatteryPrebuffer ?? false);
       this.sessions.set(id, session);
 
       if (!enabled) {


### PR DESCRIPTION
Fixed the following issue
[Video Analysis Plugin]: Video Analysis ended with error RPCResultError [TypeError]: Cannot read properties of undefined (reading 'allowBatteryPrebuffer')
[Video Analysis Plugin]:     at V.options [as ensurePrebufferSessions] (/Users/alex/.scrypted/volume/plugins/@scrypted/prebuffer-mixin/zip/src/main.ts:1361:62)
[Video Analysis Plugin]:     at V.getVideoStream (/Users/alex/.scrypted/volume/plugins/@scrypted/prebuffer-mixin/zip/src/main.ts:1252:24)
[Video Analysis Plugin]:     at RpcPeer.handleMessageInternal (/Users/alex/.scrypted/node_modules/@scrypted/server/src/rpc.ts:766:37)
[Video Analysis Plugin]: thread:main
[Video Analysis Plugin]: @scrypted/prebuffer-mixin:host
[Video Analysis Plugin]: host:@scrypted/objectdetector {
[Video Analysis Plugin]:   cause: undefined
[Video Analysis Plugin]: }