### PR TITLE
wyze: add include/exclude camera filter setting

### DIFF
--- a/plugins/wyze/src/main.py
+++ b/plugins/wyze/src/main.py
@@ -1113,11 +1113,22 @@ class WyzePlugin(scrypted_sdk.ScryptedDeviceBase, DeviceProvider):
         self.authInfo = auth_info
         self.account = wyzecam.get_user_info(auth_info)
         cameras = wyzecam.get_camera_list(auth_info)
-        # await self.pollEvents()
-        manifest: scrypted_sdk.DeviceManifest = {"devices": []}
+
+        # Store all discovered cameras before filtering so getSettings can populate choices
         for camera in cameras:
             self.cameras[camera.p2p_id] = camera
 
+        # Apply include/exclude filter
+        filter_mode = self.safeParseJsonStorage("cameraFilterMode") or "Disabled"
+        filter_list = self.safeParseJsonStorage("cameraFilter") or []
+        if filter_mode == "Include Only" and filter_list:
+            cameras = [c for c in cameras if c.nickname in filter_list]
+        elif filter_mode == "Exclude" and filter_list:
+            cameras = [c for c in cameras if c.nickname not in filter_list]
+
+        # await self.pollEvents()
+        manifest: scrypted_sdk.DeviceManifest = {"devices": []}
+        for camera in cameras:
             interfaces: List[ScryptedInterface] = [
                 ScryptedInterface.Settings.value,
                 ScryptedInterface.VideoCamera.value,
@@ -1185,6 +1196,26 @@ class WyzePlugin(scrypted_sdk.ScryptedDeviceBase, DeviceProvider):
                 "type": "password",
                 "description": "The API Key retrieved from the Wyze portal.",
                 "value": self.safeParseJsonStorage("apiKey"),
+            }
+        )
+        ret.append(
+            {
+                "key": "cameraFilterMode",
+                "title": "Camera Filter Mode",
+                "description": "Choose whether to include or exclude specific cameras. Save credentials first to populate the camera list.",
+                "choices": ["Disabled", "Include Only", "Exclude"],
+                "value": self.safeParseJsonStorage("cameraFilterMode") or "Disabled",
+            }
+        )
+        camera_choices = sorted([cam.nickname for cam in self.cameras.values()])
+        ret.append(
+            {
+                "key": "cameraFilter",
+                "title": "Camera Filter",
+                "description": "Select cameras to include or exclude based on the filter mode above.",
+                "multiple": True,
+                "choices": camera_choices,
+                "value": self.safeParseJsonStorage("cameraFilter") or [],
             }
         )
         return ret


### PR DESCRIPTION
Adds two new plugin-level settings to the Wyze plugin:

- Camera Filter Mode: dropdown with options Disabled / Include Only / Exclude
- Camera Filter: multi-select list populated dynamically from all discovered cameras, allowing the user to pick which cameras to include or exclude

When filter mode is "Include Only", only cameras whose nicknames appear in the filter list are registered with Scrypted. When "Exclude", all cameras except those in the list are registered. "Disabled" (default) preserves existing behaviour — all cameras are registered.

All discovered cameras are stored in self.cameras before filtering so the multi-select choices are always fully populated in the settings UI, even when a filter is active.