### PR TITLE
fix: show stream selection options when synthetic streams are configured

### DIFF
--- a/plugins/prebuffer-mixin/src/main.ts
+++ b/plugins/prebuffer-mixin/src/main.ts
@@ -351,7 +351,12 @@ class PrebufferSession {
 
       const currentParser = parser.isDefault ? STRING_DEFAULT : parser.parser;
 
-      const choices = this.canUseRtmpParser(this.advertisedMediaStreamOptions)
+      const choices = this.mixin.streamSettings.storageSettings.values.synthenticStreams.includes(this.streamId)
+        ? [
+          FFMPEG_PARSER_TCP,
+          FFMPEG_PARSER_UDP,
+        ]
+        : this.canUseRtmpParser(this.advertisedMediaStreamOptions)
         ? [
           STRING_DEFAULT,
           SCRYPTED_PARSER_TCP,
@@ -1405,6 +1410,7 @@ class PrebufferMixin extends SettingsMixinDeviceBase<VideoCamera> implements Vid
 
       session = new PrebufferSession(this, {
         id: synthetic,
+        container: 'rtsp',
       }, false, false);
       this.sessions.set(id, session);
       this.console.log('stream', synthetic, 'is synthetic and will be rebroadcast on demand.');

--- a/plugins/prebuffer-mixin/src/stream-settings.ts
+++ b/plugins/prebuffer-mixin/src/stream-settings.ts
@@ -227,7 +227,7 @@ export function createStreamSettings(device: MixinDeviceBase<VideoCamera>) {
                     hide: false,
                 };
 
-                if (msos?.length > 1) {
+                if (msos?.length > 1 || storageSettings.values.synthenticStreams.length > 0) {
                     return {
                         enabledStreams,
                         defaultStream: createStreamOptions(streamTypes.defaultStream, msos),


### PR DESCRIPTION
When only one physical stream exists, stream selection options (Remote Stream, Low Resolution Stream, etc.) are hidden even if synthetic streams are configured.
The condition `msos?.length > 1` does not account for synthetic streams.

Additionally, synthetic streams require FFmpeg for transcoding, but the RTSP parser selection was not displayed because `container` was not set on synthetic stream sessions. When it is displayed, users could select the Scrypted parser, which silently ignores FFmpeg output arguments. This fix also restricts RTSP parser choices to FFmpeg for synthetic streams.

Note that the underlying logic already handles synthetic streams correctly.
[`createStreamOptions`](https://github.com/koush/scrypted/blob/194acf15e8fec06028f79f70acae147dbc441192/plugins/prebuffer-mixin/src/stream-settings.ts#L191) includes them in the choices list, and [`getMediaStream`](https://github.com/koush/scrypted/blob/194acf15e8fec06028f79f70acae147dbc441192/plugins/prebuffer-mixin/src/stream-settings.ts#L167) resolves them properly. Only the UI visibility condition and parser restrictions were missing.

| before | after |
|--|--|
| <img width="1918" height="1552" alt="before" src="https://github.com/user-attachments/assets/3c46e2df-31d9-42a4-b8c9-22c27ddd5f0c" /> | <img width="1918" height="1846" alt="after" src="https://github.com/user-attachments/assets/b16329d2-b314-469a-82a6-afcf45616c2b" /> |
