### PR TITLE
server: guard plugin-repl against stale nativeId

### DIFF
--- a/server/src/plugin/plugin-repl.ts
+++ b/server/src/plugin/plugin-repl.ts
@@ -24,7 +24,9 @@ export async function createREPLServer(scrypted: ScryptedStatic, params: any, pl
                 break;
             const d = await systemManager.getDeviceById(entry.id);
             chain.push(filter);
-            filter = reversed.get(d!.providerId!);
+            if (!d?.providerId)
+                break;
+            filter = reversed.get(d.providerId);
         }
 
         chain.reverse();

--- a/server/src/plugin/plugin-repl.ts
+++ b/server/src/plugin/plugin-repl.ts
@@ -19,8 +19,10 @@ export async function createREPLServer(scrypted: ScryptedStatic, params: any, pl
         }
 
         while (filter) {
-            const { id } = nativeIds.get(filter);
-            const d = await systemManager.getDeviceById(id);
+            const entry = nativeIds.get(filter);
+            if (!entry)
+                break;
+            const d = await systemManager.getDeviceById(entry.id);
             chain.push(filter);
             filter = reversed.get(d!.providerId!);
         }


### PR DESCRIPTION
- The REPL socket handler in `server/src/plugin/plugin-repl.ts` destructures `nativeIds.get(filter)` without a nullish check.
- When `filter` is a stale nativeId (e.g. the UI rendered a REPL link for a device that was removed before the user clicked it), `nativeIds.get(...)` returns `undefined` and the destructure throws `TypeError: Cannot destructure property 'id' of 'nativeIds.get(...)' as it is undefined.` as an `unhandledRejection`.
- Surfaced under whichever plugin currently owns the REPL endpoint (observed under HomeKit, Snapshot, Diagnostics, and others — the bug is plugin-agnostic).
- Fix: look up the entry first, `break` out of the chain walk when the lookup misses, and use the deepest valid prefix already collected in `chain`.

The loop-iteration case is already safe because `reversed` is built from existing `nativeIds` entries; the only realistic miss is the stale-id passed in over the socket on the first iteration.