### PR TITLE
fix(homekit): bump to latest @homebridge/hap-nodejs and @homebridge/ciao to catch the loopback sender packet leak

### DIFF
--- a/plugins/homekit/.gitmodules
+++ b/plugins/homekit/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "HAP-NodeJS"]
-	path = HAP-NodeJS
-	url = git@github.com:koush/HAP-NodeJS.git

--- a/plugins/homekit/package-lock.json
+++ b/plugins/homekit/package-lock.json
@@ -8,9 +8,9 @@
          "name": "@scrypted/homekit",
          "version": "1.2.65",
          "dependencies": {
+            "@homebridge/hap-nodejs": "^2.1.3",
             "@koush/werift-src": "file:../../external/werift",
             "check-disk-space": "^3.4.0",
-            "hap-nodejs": "^1.1.0",
             "lodash": "^4.17.21",
             "mkdirp": "^3.0.1",
             "qrcode-svg": "^1.1.0"
@@ -32,14 +32,17 @@
          "license": "ISC",
          "dependencies": {
             "@scrypted/sdk": "file:../sdk",
-            "@scrypted/types": "^0.5.27",
             "http-auth-utils": "^5.0.1",
             "typescript": "^5.5.3"
          },
          "devDependencies": {
-            "@types/node": "^20.11.0",
+            "@types/node": "^20.19.11",
             "monaco-editor": "^0.50.0",
-            "ts-node": "^10.9.2"
+            "ts-node": "^10.9.2",
+            "tslib": "^2.8.1"
+         },
+         "peerDependencies": {
+            "@scrypted/types": "^0.5.55"
          }
       },
       "../../external/werift": {
@@ -122,45 +125,49 @@
       },
       "../../sdk": {
          "name": "@scrypted/sdk",
-         "version": "0.5.38",
+         "version": "0.5.59",
          "dev": true,
          "license": "ISC",
          "dependencies": {
             "@babel/preset-typescript": "^7.27.1",
-            "@rollup/plugin-commonjs": "^28.0.5",
+            "@rollup/plugin-commonjs": "^28.0.9",
             "@rollup/plugin-json": "^6.1.0",
             "@rollup/plugin-node-resolve": "^16.0.1",
-            "@rollup/plugin-typescript": "^12.1.2",
+            "@rollup/plugin-terser": "^0.4.4",
+            "@rollup/plugin-typescript": "^12.3.0",
             "@rollup/plugin-virtual": "^3.0.2",
+            "@scrypted/auth-fetch": "^1.0.5",
             "adm-zip": "^0.5.16",
-            "axios": "^1.10.0",
             "babel-loader": "^10.0.0",
             "babel-plugin-const-enum": "^1.2.0",
             "ncp": "^2.0.0",
-            "openai": "^5.3.0",
+            "openai": "^6.1.0",
             "raw-loader": "^4.0.2",
             "rimraf": "^6.0.1",
-            "rollup": "^4.43.0",
+            "rollup": "^4.52.5",
             "tmp": "^0.2.3",
-            "ts-loader": "^9.5.2",
+            "ts-loader": "^9.5.4",
             "tslib": "^2.8.1",
-            "typescript": "^5.8.3",
+            "typescript": "^5.9.3",
             "webpack": "^5.99.9",
             "webpack-bundle-analyzer": "^4.10.2"
          },
          "bin": {
-            "scrypted-changelog": "bin/scrypted-changelog.js",
-            "scrypted-debug": "bin/scrypted-debug.js",
-            "scrypted-deploy": "bin/scrypted-deploy.js",
-            "scrypted-deploy-debug": "bin/scrypted-deploy-debug.js",
-            "scrypted-package-json": "bin/scrypted-package-json.js",
-            "scrypted-setup-project": "bin/scrypted-setup-project.js",
-            "scrypted-webpack": "bin/scrypted-webpack.js"
+            "scrypted-changelog": "bin/cli.js",
+            "scrypted-debug": "bin/cli.js",
+            "scrypted-deploy": "bin/cli.js",
+            "scrypted-deploy-debug": "bin/cli.js",
+            "scrypted-package-json": "bin/cli.js",
+            "scrypted-setup-project": "bin/cli.js",
+            "scrypted-webpack": "bin/cli.js"
          },
          "devDependencies": {
-            "@types/node": "^24.0.1",
+            "@types/adm-zip": "^0.5.8",
+            "@types/ncp": "^2.0.8",
+            "@types/node": "^24.9.2",
+            "@types/tmp": "^0.2.6",
             "ts-node": "^10.9.2",
-            "typedoc": "^0.28.5"
+            "typedoc": "^0.28.14"
          }
       },
       "../HAP-NodeJS": {
@@ -206,16 +213,52 @@
             "node": ">=10.17.0"
          }
       },
-      "node_modules/@homebridge/dbus-native": {
-         "version": "0.6.0",
-         "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.6.0.tgz",
-         "integrity": "sha512-xObqQeYHTXmt6wsfj10+krTo4xbzR9BgUfX2aQ+edDC9nc4ojfzLScfXCh3zluAm6UCowKw+AFfXn6WLWUOPkg==",
+      "node_modules/@homebridge/ciao": {
+         "version": "1.3.7",
+         "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.7.tgz",
+         "integrity": "sha512-ncvcXQe4vrqBLNqnVjQjke5NpNin6SO9bStfBZ4jgZk/xIjD9GMcH8vp8XKd7hw5akIzwITMiDMysIKvE5rHBw==",
+         "license": "MIT",
          "dependencies": {
-            "@homebridge/long": "^5.2.1",
-            "@homebridge/put": "^0.0.8",
+            "debug": "^4.4.3",
+            "fast-deep-equal": "^3.1.3",
+            "source-map-support": "^0.5.21",
+            "tslib": "^2.8.1"
+         },
+         "bin": {
+            "ciao-bcs": "lib/bonjour-conformance-testing.js"
+         }
+      },
+      "node_modules/@homebridge/hap-nodejs": {
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.3.tgz",
+         "integrity": "sha512-8TGtfgV4bY6VexoaoANxEaV2N0fLHO6I3aD65Bj4q6hGbwmXrkok4b9rxPjkOZOj77I8fhVQ2ofkeNrGBgdXVw==",
+         "license": "Apache-2.0",
+         "dependencies": {
+            "@homebridge/ciao": "^1.3.7",
+            "@homebridge/dbus-native": "^0.7.4",
+            "bonjour-hap": "^3.10.1",
+            "debug": "^4.4.3",
+            "fast-srp-hap": "^2.0.4",
+            "futoin-hkdf": "^1.5.3",
+            "node-persist": "^0.0.12",
+            "source-map-support": "^0.5.21",
+            "tslib": "^2.8.1",
+            "tweetnacl": "^1.0.3"
+         },
+         "engines": {
+            "node": "^22 || ^24"
+         }
+      },
+      "node_modules/@homebridge/hap-nodejs/node_modules/@homebridge/dbus-native": {
+         "version": "0.7.4",
+         "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.4.tgz",
+         "integrity": "sha512-DtX16c/NNT/NJBFgy8qu74z/SZuAaS0GJahKIrS9ZZOYUHDtZYr1B4ZdjQlr+1NT7ZcCk6e84O4lAieiJq0Hsw==",
+         "license": "MIT",
+         "dependencies": {
             "event-stream": "^4.0.1",
-            "hexy": "^0.3.5",
-            "minimist": "^1.2.6",
+            "hexy": "^0.4.0",
+            "long": "^5.3.2",
+            "minimist": "^1.2.8",
             "safe-buffer": "^5.1.2",
             "xml2js": "^0.6.2"
          },
@@ -223,17 +266,16 @@
             "dbus2js": "bin/dbus2js.js"
          }
       },
-      "node_modules/@homebridge/long": {
-         "version": "5.2.1",
-         "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
-         "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA=="
-      },
-      "node_modules/@homebridge/put": {
-         "version": "0.0.8",
-         "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
-         "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA==",
+      "node_modules/@homebridge/hap-nodejs/node_modules/hexy": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+         "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
+         "license": "MIT",
+         "bin": {
+            "hexy": "bin/hexy_cmd.js"
+         },
          "engines": {
-            "node": ">=0.3.0"
+            "node": ">=14.0.0"
          }
       },
       "node_modules/@koush/werift-src": {
@@ -296,67 +338,21 @@
          "integrity": "sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg==",
          "dev": true
       },
-      "node_modules/array-buffer-byte-length": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-         "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "node_modules/bonjour-hap": {
+         "version": "3.10.1",
+         "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.1.tgz",
+         "integrity": "sha512-StmRRG5LzJirg/1olvm2cWPJ/HeqrxyRa4cl2L6al0JoWJsH000uBM67R0RfBM3QAjcJrVjpMT3wDyg/v09osQ==",
+         "license": "MIT",
          "dependencies": {
-            "call-bind": "^1.0.5",
-            "is-array-buffer": "^3.0.4"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/available-typed-arrays": {
-         "version": "1.0.6",
-         "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
-         "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
+            "fast-deep-equal": "^3.1.3",
+            "multicast-dns": "^7.2.5",
+            "multicast-dns-service-types": "^1.1.0"
          }
       },
       "node_modules/buffer-from": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
          "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-      },
-      "node_modules/call-bind": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-         "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-         "dependencies": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.4",
-            "set-function-length": "^1.2.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/call-bind-apply-helpers": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-         "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-         "license": "MIT",
-         "dependencies": {
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
       },
       "node_modules/check-disk-space": {
          "version": "3.4.0",
@@ -367,11 +363,12 @@
          }
       },
       "node_modules/debug": {
-         "version": "4.3.5",
-         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-         "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+         "version": "4.4.3",
+         "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+         "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+         "license": "MIT",
          "dependencies": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
          },
          "engines": {
             "node": ">=6.0"
@@ -380,69 +377,6 @@
             "supports-color": {
                "optional": true
             }
-         }
-      },
-      "node_modules/deep-equal": {
-         "version": "2.2.3",
-         "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-         "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-         "dependencies": {
-            "array-buffer-byte-length": "^1.0.0",
-            "call-bind": "^1.0.5",
-            "es-get-iterator": "^1.1.3",
-            "get-intrinsic": "^1.2.2",
-            "is-arguments": "^1.1.1",
-            "is-array-buffer": "^3.0.2",
-            "is-date-object": "^1.0.5",
-            "is-regex": "^1.1.4",
-            "is-shared-array-buffer": "^1.0.2",
-            "isarray": "^2.0.5",
-            "object-is": "^1.1.5",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.4",
-            "regexp.prototype.flags": "^1.5.1",
-            "side-channel": "^1.0.4",
-            "which-boxed-primitive": "^1.0.2",
-            "which-collection": "^1.0.1",
-            "which-typed-array": "^1.1.13"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/define-data-property": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-         "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-         "dependencies": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/define-properties": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-         "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-         "dependencies": {
-            "define-data-property": "^1.0.1",
-            "has-property-descriptors": "^1.0.0",
-            "object-keys": "^1.1.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/dns-packet": {
@@ -456,72 +390,10 @@
             "node": ">=6"
          }
       },
-      "node_modules/dunder-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-         "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-         "license": "MIT",
-         "dependencies": {
-            "call-bind-apply-helpers": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.2.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
       "node_modules/duplexer": {
          "version": "0.1.2",
          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
          "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-      },
-      "node_modules/es-define-property": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-         "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/es-errors": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-         "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/es-get-iterator": {
-         "version": "1.1.3",
-         "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-         "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.3",
-            "has-symbols": "^1.0.3",
-            "is-arguments": "^1.1.1",
-            "is-map": "^2.0.2",
-            "is-set": "^2.0.2",
-            "is-string": "^1.0.7",
-            "isarray": "^2.0.5",
-            "stop-iteration-iterator": "^1.0.0"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/es-object-atoms": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-         "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-         "license": "MIT",
-         "dependencies": {
-            "es-errors": "^1.3.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
       },
       "node_modules/event-stream": {
          "version": "4.0.1",
@@ -550,453 +422,35 @@
             "node": ">=10.17.0"
          }
       },
-      "node_modules/for-each": {
-         "version": "0.3.3",
-         "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-         "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-         "dependencies": {
-            "is-callable": "^1.1.3"
-         }
-      },
       "node_modules/from": {
          "version": "0.1.7",
          "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
          "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
       },
-      "node_modules/function-bind": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/functions-have-names": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-         "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/get-intrinsic": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-         "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-         "license": "MIT",
-         "dependencies": {
-            "call-bind-apply-helpers": "^1.0.2",
-            "es-define-property": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "es-object-atoms": "^1.1.1",
-            "function-bind": "^1.1.2",
-            "get-proto": "^1.0.1",
-            "gopd": "^1.2.0",
-            "has-symbols": "^1.1.0",
-            "hasown": "^2.0.2",
-            "math-intrinsics": "^1.1.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/get-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-         "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-         "license": "MIT",
-         "dependencies": {
-            "dunder-proto": "^1.0.1",
-            "es-object-atoms": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/gopd": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-         "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/hap-nodejs": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-1.1.0.tgz",
-         "integrity": "sha512-FVJotfbsUzBY7ydiz9cWDmlmyAHswh0AcLwGJ9T+SuRAVhZYsnoHRpom0si1mWzwXA2k0RqFOn52nssf0AlrGQ==",
-         "dependencies": {
-            "@homebridge/ciao": "^1.3.0",
-            "@homebridge/dbus-native": "^0.6.0",
-            "bonjour-hap": "^3.8.0",
-            "debug": "^4.3.5",
-            "fast-srp-hap": "^2.0.4",
-            "futoin-hkdf": "^1.5.3",
-            "node-persist": "^0.0.12",
-            "source-map-support": "^0.5.21",
-            "tslib": "^2.6.3",
-            "tweetnacl": "^1.0.3"
-         },
-         "engines": {
-            "node": "^18 || ^20"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/@homebridge/ciao": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.0.tgz",
-         "integrity": "sha512-PRbY5FiukY13gIDwiAAZng598gMyI61GL9VU19G2CB4D3vNwh8vESgI9TkjeecCDethTqJmNiruYvdunfQkt7w==",
-         "dependencies": {
-            "debug": "^4.3.5",
-            "fast-deep-equal": "^3.1.3",
-            "source-map-support": "^0.5.21",
-            "tslib": "^2.6.3"
-         },
-         "bin": {
-            "ciao-bcs": "lib/bonjour-conformance-testing.js"
-         },
-         "engines": {
-            "node": "^18 || ^20"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/array-flatten": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-         "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-      },
-      "node_modules/hap-nodejs/node_modules/bonjour-hap": {
-         "version": "3.8.0",
-         "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.8.0.tgz",
-         "integrity": "sha512-l/Ptvrt/pjN2pCgiVyyA0EkE0uVoXXYZ4DW4xhL4kDVBaw0w54/3Jhdhzn5EyT1Z8YhNXiNhSX0uW6xz2zSxqQ==",
-         "dependencies": {
-            "array-flatten": "^3.0.0",
-            "deep-equal": "^2.2.3",
-            "multicast-dns": "^7.2.5",
-            "multicast-dns-service-types": "^1.1.0"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/futoin-hkdf": {
+      "node_modules/futoin-hkdf": {
          "version": "1.5.3",
          "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
          "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==",
+         "license": "Apache-2.0",
          "engines": {
             "node": ">=8"
          }
-      },
-      "node_modules/hap-nodejs/node_modules/mkdirp": {
-         "version": "0.5.6",
-         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-         "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-         "dependencies": {
-            "minimist": "^1.2.6"
-         },
-         "bin": {
-            "mkdirp": "bin/cmd.js"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/node-persist": {
-         "version": "0.0.12",
-         "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
-         "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
-         "dependencies": {
-            "mkdirp": "~0.5.1",
-            "q": "~1.1.1"
-         }
-      },
-      "node_modules/has-bigints": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-         "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-property-descriptors": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-         "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-         "dependencies": {
-            "es-define-property": "^1.0.0"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-symbols": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-         "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-tostringtag": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-         "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-         "dependencies": {
-            "has-symbols": "^1.0.3"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/hasown": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-         "dependencies": {
-            "function-bind": "^1.1.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/hexy": {
-         "version": "0.3.5",
-         "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
-         "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw==",
-         "bin": {
-            "hexy": "bin/hexy_cmd.js"
-         },
-         "engines": {
-            "node": ">=10.4"
-         }
-      },
-      "node_modules/internal-slot": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-         "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-         "dependencies": {
-            "es-errors": "^1.3.0",
-            "hasown": "^2.0.0",
-            "side-channel": "^1.0.4"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/is-arguments": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-         "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-array-buffer": {
-         "version": "3.0.4",
-         "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-         "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.2.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-bigint": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-         "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-         "dependencies": {
-            "has-bigints": "^1.0.1"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-boolean-object": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-         "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-callable": {
-         "version": "1.2.7",
-         "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-         "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-date-object": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-         "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-         "dependencies": {
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-map": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-         "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-number-object": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-         "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-         "dependencies": {
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-regex": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-         "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-set": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-         "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-shared-array-buffer": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-         "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-         "dependencies": {
-            "call-bind": "^1.0.2"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-string": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-         "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-         "dependencies": {
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-symbol": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-         "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-         "dependencies": {
-            "has-symbols": "^1.0.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-weakmap": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-         "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-weakset": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-         "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.1"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/isarray": {
-         "version": "2.0.5",
-         "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-         "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
       },
       "node_modules/lodash": {
          "version": "4.17.21",
          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
       },
+      "node_modules/long": {
+         "version": "5.3.2",
+         "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+         "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+         "license": "Apache-2.0"
+      },
       "node_modules/map-stream": {
          "version": "0.0.7",
          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
          "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
-      },
-      "node_modules/math-intrinsics": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-         "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         }
       },
       "node_modules/minimist": {
          "version": "1.2.8",
@@ -1021,9 +475,10 @@
          }
       },
       "node_modules/ms": {
-         "version": "2.1.2",
-         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-         "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+         "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+         "license": "MIT"
       },
       "node_modules/multicast-dns": {
          "version": "7.2.5",
@@ -1042,52 +497,26 @@
          "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
          "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ=="
       },
-      "node_modules/object-inspect": {
-         "version": "1.13.1",
-         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-         "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/object-is": {
-         "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-         "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "node_modules/node-persist": {
+         "version": "0.0.12",
+         "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
+         "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
+         "license": "MIT",
          "dependencies": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
+            "mkdirp": "~0.5.1",
+            "q": "~1.1.1"
          }
       },
-      "node_modules/object-keys": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-         "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/object.assign": {
-         "version": "4.1.5",
-         "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-         "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "node_modules/node-persist/node_modules/mkdirp": {
+         "version": "0.5.6",
+         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+         "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+         "license": "MIT",
          "dependencies": {
-            "call-bind": "^1.0.5",
-            "define-properties": "^1.2.1",
-            "has-symbols": "^1.0.3",
-            "object-keys": "^1.1.1"
+            "minimist": "^1.2.6"
          },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
+         "bin": {
+            "mkdirp": "bin/cmd.js"
          }
       },
       "node_modules/pause-stream": {
@@ -1115,23 +544,6 @@
             "qrcode-svg": "bin/qrcode-svg.js"
          }
       },
-      "node_modules/regexp.prototype.flags": {
-         "version": "1.5.2",
-         "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-         "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-         "dependencies": {
-            "call-bind": "^1.0.6",
-            "define-properties": "^1.2.1",
-            "es-errors": "^1.3.0",
-            "set-function-name": "^2.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/safe-buffer": {
          "version": "5.2.1",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1155,52 +567,6 @@
          "version": "1.4.1",
          "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
          "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
-      },
-      "node_modules/set-function-length": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-         "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
-         "dependencies": {
-            "define-data-property": "^1.1.2",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.3",
-            "gopd": "^1.0.1",
-            "has-property-descriptors": "^1.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/set-function-name": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-         "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-         "dependencies": {
-            "define-data-property": "^1.0.1",
-            "functions-have-names": "^1.2.3",
-            "has-property-descriptors": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/side-channel": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-         "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
-         "dependencies": {
-            "call-bind": "^1.0.6",
-            "es-errors": "^1.3.0",
-            "get-intrinsic": "^1.2.4",
-            "object-inspect": "^1.13.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
       },
       "node_modules/source-map": {
          "version": "0.6.1",
@@ -1230,17 +596,6 @@
             "node": "*"
          }
       },
-      "node_modules/stop-iteration-iterator": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-         "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-         "dependencies": {
-            "internal-slot": "^1.0.4"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
       "node_modules/stream-combiner": {
          "version": "0.2.2",
          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -1261,9 +616,10 @@
          "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
       },
       "node_modules/tslib": {
-         "version": "2.6.3",
-         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-         "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+         "version": "2.8.1",
+         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+         "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+         "license": "0BSD"
       },
       "node_modules/tweetnacl": {
          "version": "1.0.3",
@@ -1276,53 +632,6 @@
          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
          "dev": true,
          "license": "MIT"
-      },
-      "node_modules/which-boxed-primitive": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-         "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-         "dependencies": {
-            "is-bigint": "^1.0.1",
-            "is-boolean-object": "^1.1.0",
-            "is-number-object": "^1.0.4",
-            "is-string": "^1.0.5",
-            "is-symbol": "^1.0.3"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/which-collection": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-         "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-         "dependencies": {
-            "is-map": "^2.0.1",
-            "is-set": "^2.0.1",
-            "is-weakmap": "^2.0.1",
-            "is-weakset": "^2.0.1"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/which-typed-array": {
-         "version": "1.1.14",
-         "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-         "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
-         "dependencies": {
-            "available-typed-arrays": "^1.0.6",
-            "call-bind": "^1.0.5",
-            "for-each": "^0.3.3",
-            "gopd": "^1.0.1",
-            "has-tostringtag": "^1.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
       },
       "node_modules/xml2js": {
          "version": "0.6.2",
@@ -1346,29 +655,53 @@
       }
    },
    "dependencies": {
-      "@homebridge/dbus-native": {
-         "version": "0.6.0",
-         "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.6.0.tgz",
-         "integrity": "sha512-xObqQeYHTXmt6wsfj10+krTo4xbzR9BgUfX2aQ+edDC9nc4ojfzLScfXCh3zluAm6UCowKw+AFfXn6WLWUOPkg==",
+      "@homebridge/ciao": {
+         "version": "1.3.7",
+         "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.7.tgz",
+         "integrity": "sha512-ncvcXQe4vrqBLNqnVjQjke5NpNin6SO9bStfBZ4jgZk/xIjD9GMcH8vp8XKd7hw5akIzwITMiDMysIKvE5rHBw==",
          "requires": {
-            "@homebridge/long": "^5.2.1",
-            "@homebridge/put": "^0.0.8",
-            "event-stream": "^4.0.1",
-            "hexy": "^0.3.5",
-            "minimist": "^1.2.6",
-            "safe-buffer": "^5.1.2",
-            "xml2js": "^0.6.2"
+            "debug": "^4.4.3",
+            "fast-deep-equal": "^3.1.3",
+            "source-map-support": "^0.5.21",
+            "tslib": "^2.8.1"
          }
       },
-      "@homebridge/long": {
-         "version": "5.2.1",
-         "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
-         "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA=="
-      },
-      "@homebridge/put": {
-         "version": "0.0.8",
-         "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
-         "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA=="
+      "@homebridge/hap-nodejs": {
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.1.3.tgz",
+         "integrity": "sha512-8TGtfgV4bY6VexoaoANxEaV2N0fLHO6I3aD65Bj4q6hGbwmXrkok4b9rxPjkOZOj77I8fhVQ2ofkeNrGBgdXVw==",
+         "requires": {
+            "@homebridge/ciao": "^1.3.7",
+            "@homebridge/dbus-native": "^0.7.4",
+            "bonjour-hap": "^3.10.1",
+            "debug": "^4.4.3",
+            "fast-srp-hap": "^2.0.4",
+            "futoin-hkdf": "^1.5.3",
+            "node-persist": "^0.0.12",
+            "source-map-support": "^0.5.21",
+            "tslib": "^2.8.1",
+            "tweetnacl": "^1.0.3"
+         },
+         "dependencies": {
+            "@homebridge/dbus-native": {
+               "version": "0.7.4",
+               "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.4.tgz",
+               "integrity": "sha512-DtX16c/NNT/NJBFgy8qu74z/SZuAaS0GJahKIrS9ZZOYUHDtZYr1B4ZdjQlr+1NT7ZcCk6e84O4lAieiJq0Hsw==",
+               "requires": {
+                  "event-stream": "^4.0.1",
+                  "hexy": "^0.4.0",
+                  "long": "^5.3.2",
+                  "minimist": "^1.2.8",
+                  "safe-buffer": "^5.1.2",
+                  "xml2js": "^0.6.2"
+               }
+            },
+            "hexy": {
+               "version": "0.4.0",
+               "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+               "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg=="
+            }
+         }
       },
       "@koush/werift-src": {
          "version": "file:../../external/werift",
@@ -1396,11 +729,11 @@
          "version": "file:../../common",
          "requires": {
             "@scrypted/sdk": "file:../sdk",
-            "@scrypted/types": "^0.5.27",
-            "@types/node": "^20.11.0",
+            "@types/node": "^20.19.11",
             "http-auth-utils": "^5.0.1",
             "monaco-editor": "^0.50.0",
             "ts-node": "^10.9.2",
+            "tslib": "^2.8.1",
             "typescript": "^5.5.3"
          }
       },
@@ -1408,27 +741,31 @@
          "version": "file:../../sdk",
          "requires": {
             "@babel/preset-typescript": "^7.27.1",
-            "@rollup/plugin-commonjs": "^28.0.5",
+            "@rollup/plugin-commonjs": "^28.0.9",
             "@rollup/plugin-json": "^6.1.0",
             "@rollup/plugin-node-resolve": "^16.0.1",
-            "@rollup/plugin-typescript": "^12.1.2",
+            "@rollup/plugin-terser": "^0.4.4",
+            "@rollup/plugin-typescript": "^12.3.0",
             "@rollup/plugin-virtual": "^3.0.2",
-            "@types/node": "^24.0.1",
+            "@scrypted/auth-fetch": "^1.0.5",
+            "@types/adm-zip": "^0.5.8",
+            "@types/ncp": "^2.0.8",
+            "@types/node": "^24.9.2",
+            "@types/tmp": "^0.2.6",
             "adm-zip": "^0.5.16",
-            "axios": "^1.10.0",
             "babel-loader": "^10.0.0",
             "babel-plugin-const-enum": "^1.2.0",
             "ncp": "^2.0.0",
-            "openai": "^5.3.0",
+            "openai": "^6.1.0",
             "raw-loader": "^4.0.2",
             "rimraf": "^6.0.1",
-            "rollup": "^4.43.0",
+            "rollup": "^4.52.5",
             "tmp": "^0.2.3",
-            "ts-loader": "^9.5.2",
+            "ts-loader": "^9.5.4",
             "ts-node": "^10.9.2",
             "tslib": "^2.8.1",
-            "typedoc": "^0.28.5",
-            "typescript": "^5.8.3",
+            "typedoc": "^0.28.14",
+            "typescript": "^5.9.3",
             "webpack": "^5.99.9",
             "webpack-bundle-analyzer": "^4.10.2"
          }
@@ -1475,45 +812,20 @@
          "integrity": "sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg==",
          "dev": true
       },
-      "array-buffer-byte-length": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-         "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "bonjour-hap": {
+         "version": "3.10.1",
+         "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.1.tgz",
+         "integrity": "sha512-StmRRG5LzJirg/1olvm2cWPJ/HeqrxyRa4cl2L6al0JoWJsH000uBM67R0RfBM3QAjcJrVjpMT3wDyg/v09osQ==",
          "requires": {
-            "call-bind": "^1.0.5",
-            "is-array-buffer": "^3.0.4"
+            "fast-deep-equal": "^3.1.3",
+            "multicast-dns": "^7.2.5",
+            "multicast-dns-service-types": "^1.1.0"
          }
-      },
-      "available-typed-arrays": {
-         "version": "1.0.6",
-         "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
-         "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg=="
       },
       "buffer-from": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
          "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-      },
-      "call-bind": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-         "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-         "requires": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.4",
-            "set-function-length": "^1.2.1"
-         }
-      },
-      "call-bind-apply-helpers": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-         "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-         "requires": {
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2"
-         }
       },
       "check-disk-space": {
          "version": "3.4.0",
@@ -1521,56 +833,11 @@
          "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw=="
       },
       "debug": {
-         "version": "4.3.5",
-         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-         "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+         "version": "4.4.3",
+         "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+         "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
          "requires": {
-            "ms": "2.1.2"
-         }
-      },
-      "deep-equal": {
-         "version": "2.2.3",
-         "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-         "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-         "requires": {
-            "array-buffer-byte-length": "^1.0.0",
-            "call-bind": "^1.0.5",
-            "es-get-iterator": "^1.1.3",
-            "get-intrinsic": "^1.2.2",
-            "is-arguments": "^1.1.1",
-            "is-array-buffer": "^3.0.2",
-            "is-date-object": "^1.0.5",
-            "is-regex": "^1.1.4",
-            "is-shared-array-buffer": "^1.0.2",
-            "isarray": "^2.0.5",
-            "object-is": "^1.1.5",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.4",
-            "regexp.prototype.flags": "^1.5.1",
-            "side-channel": "^1.0.4",
-            "which-boxed-primitive": "^1.0.2",
-            "which-collection": "^1.0.1",
-            "which-typed-array": "^1.1.13"
-         }
-      },
-      "define-data-property": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-         "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-         "requires": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.0.1"
-         }
-      },
-      "define-properties": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-         "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-         "requires": {
-            "define-data-property": "^1.0.1",
-            "has-property-descriptors": "^1.0.0",
-            "object-keys": "^1.1.1"
+            "ms": "^2.1.3"
          }
       },
       "dns-packet": {
@@ -1581,54 +848,10 @@
             "@leichtgewicht/ip-codec": "^2.0.1"
          }
       },
-      "dunder-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-         "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-         "requires": {
-            "call-bind-apply-helpers": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.2.0"
-         }
-      },
       "duplexer": {
          "version": "0.1.2",
          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
          "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-      },
-      "es-define-property": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-         "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-      },
-      "es-errors": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-         "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-      },
-      "es-get-iterator": {
-         "version": "1.1.3",
-         "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-         "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.3",
-            "has-symbols": "^1.0.3",
-            "is-arguments": "^1.1.1",
-            "is-map": "^2.0.2",
-            "is-set": "^2.0.2",
-            "is-string": "^1.0.7",
-            "isarray": "^2.0.5",
-            "stop-iteration-iterator": "^1.0.0"
-         }
-      },
-      "es-object-atoms": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-         "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-         "requires": {
-            "es-errors": "^1.3.0"
-         }
       },
       "event-stream": {
          "version": "4.0.1",
@@ -1654,309 +877,30 @@
          "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
          "integrity": "sha512-lHRYYaaIbMrhZtsdGTwPN82UbqD9Bv8QfOlKs+Dz6YRnByZifOh93EYmf2iEWFtkOEIqR2IK8cFD0UN5wLIWBQ=="
       },
-      "for-each": {
-         "version": "0.3.3",
-         "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-         "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-         "requires": {
-            "is-callable": "^1.1.3"
-         }
-      },
       "from": {
          "version": "0.1.7",
          "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
          "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
       },
-      "function-bind": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-      },
-      "functions-have-names": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-         "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
-      },
-      "get-intrinsic": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-         "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-         "requires": {
-            "call-bind-apply-helpers": "^1.0.2",
-            "es-define-property": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "es-object-atoms": "^1.1.1",
-            "function-bind": "^1.1.2",
-            "get-proto": "^1.0.1",
-            "gopd": "^1.2.0",
-            "has-symbols": "^1.1.0",
-            "hasown": "^2.0.2",
-            "math-intrinsics": "^1.1.0"
-         }
-      },
-      "get-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-         "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-         "requires": {
-            "dunder-proto": "^1.0.1",
-            "es-object-atoms": "^1.0.0"
-         }
-      },
-      "gopd": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-         "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-      },
-      "hap-nodejs": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-1.1.0.tgz",
-         "integrity": "sha512-FVJotfbsUzBY7ydiz9cWDmlmyAHswh0AcLwGJ9T+SuRAVhZYsnoHRpom0si1mWzwXA2k0RqFOn52nssf0AlrGQ==",
-         "requires": {
-            "@homebridge/ciao": "^1.3.0",
-            "@homebridge/dbus-native": "^0.6.0",
-            "bonjour-hap": "^3.8.0",
-            "debug": "^4.3.5",
-            "fast-srp-hap": "^2.0.4",
-            "futoin-hkdf": "^1.5.3",
-            "node-persist": "^0.0.12",
-            "source-map-support": "^0.5.21",
-            "tslib": "^2.6.3",
-            "tweetnacl": "^1.0.3"
-         },
-         "dependencies": {
-            "@homebridge/ciao": {
-               "version": "1.3.0",
-               "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.0.tgz",
-               "integrity": "sha512-PRbY5FiukY13gIDwiAAZng598gMyI61GL9VU19G2CB4D3vNwh8vESgI9TkjeecCDethTqJmNiruYvdunfQkt7w==",
-               "requires": {
-                  "debug": "^4.3.5",
-                  "fast-deep-equal": "^3.1.3",
-                  "source-map-support": "^0.5.21",
-                  "tslib": "^2.6.3"
-               }
-            },
-            "array-flatten": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-               "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-            },
-            "bonjour-hap": {
-               "version": "3.8.0",
-               "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.8.0.tgz",
-               "integrity": "sha512-l/Ptvrt/pjN2pCgiVyyA0EkE0uVoXXYZ4DW4xhL4kDVBaw0w54/3Jhdhzn5EyT1Z8YhNXiNhSX0uW6xz2zSxqQ==",
-               "requires": {
-                  "array-flatten": "^3.0.0",
-                  "deep-equal": "^2.2.3",
-                  "multicast-dns": "^7.2.5",
-                  "multicast-dns-service-types": "^1.1.0"
-               }
-            },
-            "futoin-hkdf": {
-               "version": "1.5.3",
-               "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
-               "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ=="
-            },
-            "mkdirp": {
-               "version": "0.5.6",
-               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-               "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-               "requires": {
-                  "minimist": "^1.2.6"
-               }
-            },
-            "node-persist": {
-               "version": "0.0.12",
-               "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
-               "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
-               "requires": {
-                  "mkdirp": "~0.5.1",
-                  "q": "~1.1.1"
-               }
-            }
-         }
-      },
-      "has-bigints": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-         "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
-      },
-      "has-property-descriptors": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-         "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-         "requires": {
-            "es-define-property": "^1.0.0"
-         }
-      },
-      "has-symbols": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-         "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-      },
-      "has-tostringtag": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-         "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-         "requires": {
-            "has-symbols": "^1.0.3"
-         }
-      },
-      "hasown": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-         "requires": {
-            "function-bind": "^1.1.2"
-         }
-      },
-      "hexy": {
-         "version": "0.3.5",
-         "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
-         "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw=="
-      },
-      "internal-slot": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-         "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-         "requires": {
-            "es-errors": "^1.3.0",
-            "hasown": "^2.0.0",
-            "side-channel": "^1.0.4"
-         }
-      },
-      "is-arguments": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-         "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-array-buffer": {
-         "version": "3.0.4",
-         "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-         "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.2.1"
-         }
-      },
-      "is-bigint": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-         "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-         "requires": {
-            "has-bigints": "^1.0.1"
-         }
-      },
-      "is-boolean-object": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-         "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-callable": {
-         "version": "1.2.7",
-         "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-         "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-      },
-      "is-date-object": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-         "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-         "requires": {
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-map": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-         "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-      },
-      "is-number-object": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-         "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-         "requires": {
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-regex": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-         "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-set": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-         "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-      },
-      "is-shared-array-buffer": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-         "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-         "requires": {
-            "call-bind": "^1.0.2"
-         }
-      },
-      "is-string": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-         "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-         "requires": {
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-symbol": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-         "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-         "requires": {
-            "has-symbols": "^1.0.2"
-         }
-      },
-      "is-weakmap": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-         "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-      },
-      "is-weakset": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-         "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.1"
-         }
-      },
-      "isarray": {
-         "version": "2.0.5",
-         "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-         "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "futoin-hkdf": {
+         "version": "1.5.3",
+         "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
+         "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ=="
       },
       "lodash": {
          "version": "4.17.21",
          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
       },
+      "long": {
+         "version": "5.3.2",
+         "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+         "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+      },
       "map-stream": {
          "version": "0.0.7",
          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
          "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
-      },
-      "math-intrinsics": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-         "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
       },
       "minimist": {
          "version": "1.2.8",
@@ -1969,9 +913,9 @@
          "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
       },
       "ms": {
-         "version": "2.1.2",
-         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-         "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+         "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
       },
       "multicast-dns": {
          "version": "7.2.5",
@@ -1987,34 +931,23 @@
          "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
          "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ=="
       },
-      "object-inspect": {
-         "version": "1.13.1",
-         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-         "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
-      },
-      "object-is": {
-         "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-         "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "node-persist": {
+         "version": "0.0.12",
+         "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
+         "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-         }
-      },
-      "object-keys": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-         "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-      },
-      "object.assign": {
-         "version": "4.1.5",
-         "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-         "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-         "requires": {
-            "call-bind": "^1.0.5",
-            "define-properties": "^1.2.1",
-            "has-symbols": "^1.0.3",
-            "object-keys": "^1.1.1"
+            "mkdirp": "~0.5.1",
+            "q": "~1.1.1"
+         },
+         "dependencies": {
+            "mkdirp": {
+               "version": "0.5.6",
+               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+               "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+               "requires": {
+                  "minimist": "^1.2.6"
+               }
+            }
          }
       },
       "pause-stream": {
@@ -2035,17 +968,6 @@
          "resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
          "integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw=="
       },
-      "regexp.prototype.flags": {
-         "version": "1.5.2",
-         "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-         "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-         "requires": {
-            "call-bind": "^1.0.6",
-            "define-properties": "^1.2.1",
-            "es-errors": "^1.3.0",
-            "set-function-name": "^2.0.1"
-         }
-      },
       "safe-buffer": {
          "version": "5.2.1",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2055,40 +977,6 @@
          "version": "1.4.1",
          "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
          "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
-      },
-      "set-function-length": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-         "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
-         "requires": {
-            "define-data-property": "^1.1.2",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.3",
-            "gopd": "^1.0.1",
-            "has-property-descriptors": "^1.0.1"
-         }
-      },
-      "set-function-name": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-         "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-         "requires": {
-            "define-data-property": "^1.0.1",
-            "functions-have-names": "^1.2.3",
-            "has-property-descriptors": "^1.0.0"
-         }
-      },
-      "side-channel": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-         "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
-         "requires": {
-            "call-bind": "^1.0.6",
-            "es-errors": "^1.3.0",
-            "get-intrinsic": "^1.2.4",
-            "object-inspect": "^1.13.1"
-         }
       },
       "source-map": {
          "version": "0.6.1",
@@ -2112,14 +1000,6 @@
             "through": "2"
          }
       },
-      "stop-iteration-iterator": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-         "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-         "requires": {
-            "internal-slot": "^1.0.4"
-         }
-      },
       "stream-combiner": {
          "version": "0.2.2",
          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
@@ -2140,9 +1020,9 @@
          "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
       },
       "tslib": {
-         "version": "2.6.3",
-         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-         "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+         "version": "2.8.1",
+         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+         "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
       },
       "tweetnacl": {
          "version": "1.0.3",
@@ -2154,41 +1034,6 @@
          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
          "dev": true
-      },
-      "which-boxed-primitive": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-         "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-         "requires": {
-            "is-bigint": "^1.0.1",
-            "is-boolean-object": "^1.1.0",
-            "is-number-object": "^1.0.4",
-            "is-string": "^1.0.5",
-            "is-symbol": "^1.0.3"
-         }
-      },
-      "which-collection": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-         "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-         "requires": {
-            "is-map": "^2.0.1",
-            "is-set": "^2.0.1",
-            "is-weakmap": "^2.0.1",
-            "is-weakset": "^2.0.1"
-         }
-      },
-      "which-typed-array": {
-         "version": "1.1.14",
-         "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-         "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
-         "requires": {
-            "available-typed-arrays": "^1.0.6",
-            "call-bind": "^1.0.5",
-            "for-each": "^0.3.3",
-            "gopd": "^1.0.1",
-            "has-tostringtag": "^1.0.1"
-         }
       },
       "xml2js": {
          "version": "0.6.2",

--- a/plugins/homekit/package.json
+++ b/plugins/homekit/package.json
@@ -36,9 +36,9 @@
       "realfs": true
    },
    "dependencies": {
+      "@homebridge/hap-nodejs": "^2.1.3",
       "@koush/werift-src": "file:../../external/werift",
       "check-disk-space": "^3.4.0",
-      "hap-nodejs": "^1.1.0",
       "lodash": "^4.17.21",
       "mkdirp": "^3.0.1",
       "qrcode-svg": "^1.1.0"

--- a/plugins/homekit/src/hap.ts
+++ b/plugins/homekit/src/hap.ts
@@ -1,14 +1,14 @@
-export * from 'hap-nodejs/dist/lib/definitions'; // must be loaded before Characteristic and Service class
-export * from 'hap-nodejs/dist/lib/Accessory';
-export * as uuid from 'hap-nodejs/dist/lib/util/uuid';
-export * from 'hap-nodejs/dist/lib/Characteristic';
-export * from 'hap-nodejs/dist/lib/camera';
-export * from 'hap-nodejs/dist/lib/camera/RecordingManagement';
-export * from 'hap-nodejs/dist/lib/model/ControllerStorage';
-export * from 'hap-nodejs/dist/lib/util/eventedhttp';
-export * from 'hap-nodejs/dist/lib/controller/CameraController';
-export * from 'hap-nodejs/dist/lib/datastream/DataStreamServer';
-export * from 'hap-nodejs/dist/lib/Service';
-export * from 'hap-nodejs/dist/types';
-export * from 'hap-nodejs/dist/lib/model/HAPStorage';
-export * from 'hap-nodejs/dist/lib/Bridge';
+export * from '@homebridge/hap-nodejs/dist/lib/definitions'; // must be loaded before Characteristic and Service class
+export * from '@homebridge/hap-nodejs/dist/lib/Accessory';
+export * as uuid from '@homebridge/hap-nodejs/dist/lib/util/uuid';
+export * from '@homebridge/hap-nodejs/dist/lib/Characteristic';
+export * from '@homebridge/hap-nodejs/dist/lib/camera';
+export * from '@homebridge/hap-nodejs/dist/lib/camera/RecordingManagement';
+export * from '@homebridge/hap-nodejs/dist/lib/model/ControllerStorage';
+export * from '@homebridge/hap-nodejs/dist/lib/util/eventedhttp';
+export * from '@homebridge/hap-nodejs/dist/lib/controller/CameraController';
+export * from '@homebridge/hap-nodejs/dist/lib/datastream/DataStreamServer';
+export * from '@homebridge/hap-nodejs/dist/lib/Service';
+export * from '@homebridge/hap-nodejs/dist/types';
+export * from '@homebridge/hap-nodejs/dist/lib/model/HAPStorage';
+export * from '@homebridge/hap-nodejs/dist/lib/Bridge';

--- a/plugins/homekit/webpack-accessory-info-loader.js
+++ b/plugins/homekit/webpack-accessory-info-loader.js
@@ -1,0 +1,4 @@
+module.exports = source => source.replace(
+    /JSON\.parse\(\(0, node_fs_1\.readFileSync\)\(require\.resolve\("\.\.\/\.\.\/\.\.\/package\.json"\), "utf-8"\)\)/,
+    'require("../../../package.json")'
+);

--- a/plugins/homekit/webpack.nodejs.config.js
+++ b/plugins/homekit/webpack.nodejs.config.js
@@ -1,0 +1,12 @@
+const path = require('path');
+const defaultConfig = require(process.env.SCRYPTED_DEFAULT_WEBPACK_CONFIG);
+
+// @homebridge/hap-nodejs uses readFileSync(require.resolve('package.json'))
+// transform it to a plain require() which webpack handles correctly.
+defaultConfig.module.rules.push({
+    test: /node_modules\/@homebridge\/hap-nodejs\/dist\/lib\/model\/AccessoryInfo\.js$/,
+    loader: path.resolve(__dirname, 'webpack-accessory-info-loader.js'),
+    enforce: 'pre',
+});
+
+module.exports = defaultConfig;


### PR DESCRIPTION
Resubmitting - I believe the scrypted submodule for hap-nodejs is dead:

1. Aug 2021 (https://github.com/koush/scrypted/commit/a46b2811ed4488a2e5e0576b75a4c3573a7b47f0 — initial commit): Submodule lived at plugins/homekit/HAP-NodeJS, tracked in root .gitmodules. The plugins/homekit/.gitmodules file was also created at this point.

2. Oct 2021 (https://github.com/koush/scrypted/commit/2563ec44535e3b72ff4e5fe22ba322b5793ecd1f): Submodule was moved from plugins/homekit/HAP-NodeJS → external/HAP-NodeJS in the root .gitmodules. At this point plugins/homekit/.gitmodules became stale — it was never updated or deleted.

3. Feb 2023 (https://github.com/koush/scrypted/commit/a520357a2399486b251589e1a3d1817d11b35649 — "hap: fix camera init without sensor (https://github.com/koush/scrypted/pull/639)"): The external/HAP-NodeJS gitlink was deleted entirely. From this point on, the plugin relied purely on the npm hap-nodejs package.

Removing the stale plugins/homekit/.gitmodules as well.