### PR TITLE
fix(prebuffer): re-mkdir before fallback createWriteStream to prevent ENOENT race

### DIFF
--- a/plugins/prebuffer-mixin/src/file-rtsp-server.ts
+++ b/plugins/prebuffer-mixin/src/file-rtsp-server.ts
@@ -59,17 +59,12 @@ export class FileRtspServer extends RtspServer {
                         d.resolve(fd);
                 });
                 const fd = await d.promise;
-                try {
-                    await fs.promises.rename(truncate, recordingFile);
-                    truncateWriteStream = fs.createWriteStream(undefined, {
-                        fd,
-                        highWaterMark,
-                    })
-                    // this.writeConsole?.log('truncating', truncate);
-                }
-                catch (e) {
-                    throw e;
-                }
+                await fs.promises.rename(truncate, recordingFile);
+                truncateWriteStream = fs.createWriteStream(undefined, {
+                    fd,
+                    highWaterMark,
+                });
+                // this.writeConsole?.log('truncating', truncate);
             }
             catch (e) {
                 this.writeConsole?.warn('RTSP WRITE truncate target removed', truncate, e);
@@ -79,6 +74,18 @@ export class FileRtspServer extends RtspServer {
         // everything after this point must be sync due to cleanup potentially causing dangling state.
         this.cleanup();
         this.segmentBytesWritten = 0;
+
+        if (!truncateWriteStream) {
+            // The initial mkdir may have been invalidated by the NVR pruner during the async
+            // truncation phase above. Re-ensure the target directory exists synchronously so
+            // the createWriteStream call below cannot ENOENT on a missing parent directory.
+            try {
+                fs.mkdirSync(path.dirname(recordingFile), { recursive: true });
+            }
+            catch (e) {
+                this.writeConsole?.warn('RTSP WRITE mkdir failed', recordingFile, e);
+            }
+        }
 
         this.writeStream = truncateWriteStream || fs.createWriteStream(recordingFile, {
             highWaterMark,


### PR DESCRIPTION
## Problem

`FileRtspServer.write()` begins by calling `await mkdir(dirname(recordingFile))` at the top of the method. It then enters an async truncation block (`fs.open` callback + `fs.promises.rename`). **During those async yields**, the NVR pruner can delete the recording session directory (the pruner removes empty directories). When the truncation fails, the code falls through to the fallback `fs.createWriteStream(recordingFile)` — but the parent directory no longer exists → `ENOENT`.

```
Error: ENOENT: no such file or directory, open '/recordings/scrypted-38.events/1778074791870/1778172016960/seg-00012.mp2ts'
```

Observed: **42 ENOENT errors in 4 hours** across 5 cameras in production.

## Root cause

```
write() {
    await mkdir(dirname(recordingFile));  // directory created
    // ... async truncation (yields to event loop) ...
    //   NVR pruner runs here → deletes the now-empty directory
    // truncation fails → falls through to:
    this.writeStream = fs.createWriteStream(recordingFile);  // ENOENT!
}
```

## Fix

Add a synchronous `mkdirSync` immediately before the fallback `createWriteStream`. The sync call is only reached in the truncation-failure path (already rare), so there is no performance impact on the hot path.

Also removes the dead `try { throw e; } catch (e) { throw e; }` wrapper inside the truncation block (no-op).

## Testing

Verified 0 ENOENT errors over 8+ hours in production with 6 camera streams actively recording (vs 42 errors in 4 hours before the fix).