### PR TITLE
fix(server): drain MessagePort before terminate() in NodeThreadWorker.kill() to prevent shmem leak

### DIFF
--- a/server/src/plugin/runtime/node-thread-worker.ts
+++ b/server/src/plugin/runtime/node-thread-worker.ts
@@ -102,10 +102,20 @@ export class NodeThreadWorker extends EventEmitter implements RuntimeWorker {
     kill(): void {
         if (!this.worker)
             return;
-        this.worker.terminate();
-        this.port.close();
+        const port = this.port;
+        const worker = this.worker;
         this.port = undefined!;
         this.worker = undefined!;
+        // Close the MessagePort first so the worker's `port.on('close', ...)` handler
+        // fires and the worker can exit cleanly via process.exit(). This drains any
+        // in-flight ArrayBuffer transfers, preventing V8 MAP_SHARED tmpfs pages from
+        // becoming unevictable in the cgroup (each leaked transfer accumulates ~1–2 MB
+        // of unevictable shmem; 8 000 crashes => 12 GB of shmem => OOM).
+        try { port.close(); } catch {}
+        // Fallback: forcibly terminate if the worker thread hasn't exited within 2 s.
+        const killTimer = setTimeout(() => worker.terminate(), 2000);
+        killTimer.unref();
+        worker.once('exit', () => clearTimeout(killTimer));
     }
 
     send(message: RpcMessage, reject?: (e: Error) => void, serializationContext?: any): void {


### PR DESCRIPTION
## Problem

`NodeThreadWorker.kill()` calls `worker.terminate()` **before** `port.close()`. This causes unevictable shared memory accumulation in the cgroup.

### How V8 transfers Buffers between worker threads

Worker threads exchange ArrayBuffers via `MAP_SHARED` tmpfs pages (transferable memory). When `terminate()` destroys the isolate while a transfer is still in-flight, those tmpfs pages are marked **unevictable** in the cgroup and are never freed for the lifetime of the container.

### Observed impact

On a production deployment with 6 ONVIF cameras, intermittent RTSP reconnects caused the NVR plugin's worker to restart ~8 767 times over several hours. Each restart with the broken `kill()` order leaked ~1–2 MB of unevictable shmem:

```
/sys/fs/cgroup/.../memory.stat
  shmem:        12,343,296,000   ← 12.3 GB unevictable
  anon:             34,603,008   ← only 33 MB of real heap
```

This triggered cgroup OOM (failcnt 95 275 065), killed the `node` and `python3` processes, and cascaded to a host-level OOM kill of the QEMU/KVM Home Assistant VM.

## Root cause

```ts
// BEFORE — wrong order:
kill(): void {
    this.worker.terminate();  // destroys isolate while transfers in-flight
    this.port.close();        // too late — isolate already gone
}
```

The worker has a built-in clean-exit handler in `scrypted-plugin-main.ts`:
```ts
port.on('close', () => process.exit(1));
```
This handler is **never triggered** because `terminate()` destroys the isolate before the `close` event fires, preventing the transfers from draining.

## Fix

Close the `MessagePort` first, letting the worker's built-in `close` handler fire and drain pending transfers before the isolate is torn down. A 2-second timeout falls back to `worker.terminate()` in case the thread hangs.

```ts
// AFTER — correct order:
kill(): void {
    if (!this.worker) return;
    const port = this.port;
    const worker = this.worker;
    this.port = undefined!;
    this.worker = undefined!;
    try { port.close(); } catch {}
    // Fallback: forcibly terminate after 2s if the thread hasn't exited cleanly.
    const killTimer = setTimeout(() => worker.terminate(), 2000);
    killTimer.unref();
    worker.once('exit', () => clearTimeout(killTimer));
}
```

## Testing

After the fix, memory/shmem stays near-zero even under sustained fork churn. The container memory stabilized at ~950 MB vs 12+ GB before.