### PR TITLE
feat(server): ForkGovernor — per-plugin exit-aware backoff and circuit breaker for sdk.fork()

### DIFF
--- a/server/src/plugin/fork-governor.ts
+++ b/server/src/plugin/fork-governor.ts
@@ -1,0 +1,255 @@
+/**
+ * ForkGovernor — per-plugin fork-spawn rate limiter, exponential-backoff,
+ * and crash-aware circuit breaker for `scrypted.fork()`.
+ *
+ * Motivation
+ * ----------
+ * Plugins like @scrypted/nvr can call `sdk.fork()` very frequently — once per
+ * motion event per camera per pipeline (recording, detection, snapshots).
+ * If a plugin's fork crashes immediately on startup (e.g. ENOENT writing event
+ * JSON, GuC submission failure on iGPU, OOM) the consumer typically respawns
+ * right away. A handful of misbehaving cameras can therefore spawn hundreds of
+ * doomed child processes per minute, exhausting CPU, GPU contexts, FDs, and
+ * memory until the entire container falls over (host-level OOM killer, i915
+ * GuC reset cascades, etc.).
+ *
+ * This was the failure mode that motivated the external watchdog in
+ * https://github.com/koush/scrypted/pull/2031, which Koush correctly closed
+ * with "needs a proper fix in nvr". The proper fix is here, in core: enforce
+ * back-pressure on the SDK fork API itself, so every plugin (including
+ * closed-source ones like NVR) gets resilience for free.
+ *
+ * Algorithm
+ * ---------
+ * Per `(plugin, key)` — where `key` is `options.id` (usually a camera/device
+ * id) or `options.name`, falling back to the literal string "default" — we
+ * maintain:
+ *
+ *   - `attempts[]`  : timestamps of recent fork() calls (sliding window)
+ *   - `crashes[]`   : timestamps of recent abnormal exits (exit code != 0
+ *                     OR exit within `crashWindowMs` of spawn)
+ *
+ * On `beforeFork(key)`:
+ *   1. Prune both arrays to the configured `windowMs`.
+ *   2. If `crashes.length >= hardCrashLimit` AND `attempts.length >= hardLimit`,
+ *      reject the fork immediately. The plugin gets a clear error and stops
+ *      hammering. (NVR's existing `.catch()` then makes the host stable.)
+ *   3. Compute backoff = `min(maxBackoffMs, minBackoffMs * 2^(crashes.length))`,
+ *      with ±20% jitter. Sleep that long.
+ *   4. Record the attempt timestamp.
+ *
+ * `registerSpawn(key)` returns an `onExit(code, signal)` callback the caller
+ * uses to report the worker's terminal state. If the worker died abnormally
+ * (non-zero exit, killed by signal, or exited within `crashWindowMs`) we add
+ * to `crashes[]`. If it lived past `stableRunMs`, we *clear* that key's crash
+ * counter — successful long-lived workers should not be penalized for old
+ * failures.
+ *
+ * Tunables (env vars, all optional):
+ *   SCRYPTED_FORK_GOVERNOR_DISABLE=1         disables the governor entirely
+ *   SCRYPTED_FORK_GOVERNOR_WINDOW_MS         default 60000
+ *   SCRYPTED_FORK_GOVERNOR_SOFT_LIMIT        default 30   (forks/window)
+ *   SCRYPTED_FORK_GOVERNOR_HARD_LIMIT        default 90   (forks/window → reject)
+ *   SCRYPTED_FORK_GOVERNOR_HARD_CRASH_LIMIT  default 10   (crashes/window → reject)
+ *   SCRYPTED_FORK_GOVERNOR_MIN_BACKOFF_MS    default 250
+ *   SCRYPTED_FORK_GOVERNOR_MAX_BACKOFF_MS    default 30000
+ *   SCRYPTED_FORK_GOVERNOR_CRASH_WINDOW_MS   default 5000  (early exit = crash)
+ *   SCRYPTED_FORK_GOVERNOR_STABLE_RUN_MS     default 60000 (clears crashes)
+ */
+
+function envInt(name: string, fallback: number): number {
+    const v = process.env[name];
+    if (!v)
+        return fallback;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+export interface ForkGovernorOptions {
+    pluginId: string;
+    windowMs?: number;
+    softLimit?: number;
+    hardLimit?: number;
+    hardCrashLimit?: number;
+    minBackoffMs?: number;
+    maxBackoffMs?: number;
+    crashWindowMs?: number;
+    stableRunMs?: number;
+    disabled?: boolean;
+    log?: (msg: string) => void;
+}
+
+interface KeyState {
+    attempts: number[];   // ms timestamps of recent spawn attempts
+    crashes: number[];    // ms timestamps of recent abnormal exits
+    sleepUntil: number;   // hint to coalesce: if we are already sleeping, future calls wait at least this long
+}
+
+export class ForkGovernorRejected extends Error {
+    constructor(message: string, public readonly key: string, public readonly attempts: number, public readonly crashes: number) {
+        super(message);
+        this.name = 'ForkGovernorRejected';
+    }
+}
+
+export class ForkGovernor {
+    readonly pluginId: string;
+    readonly windowMs: number;
+    readonly softLimit: number;
+    readonly hardLimit: number;
+    readonly hardCrashLimit: number;
+    readonly minBackoffMs: number;
+    readonly maxBackoffMs: number;
+    readonly crashWindowMs: number;
+    readonly stableRunMs: number;
+    readonly disabled: boolean;
+    readonly log: (msg: string) => void;
+
+    private state = new Map<string, KeyState>();
+
+    constructor(opts: ForkGovernorOptions) {
+        this.pluginId = opts.pluginId;
+        this.disabled = opts.disabled ?? !!process.env.SCRYPTED_FORK_GOVERNOR_DISABLE;
+        this.windowMs = opts.windowMs ?? envInt('SCRYPTED_FORK_GOVERNOR_WINDOW_MS', 60_000);
+        this.softLimit = opts.softLimit ?? envInt('SCRYPTED_FORK_GOVERNOR_SOFT_LIMIT', 30);
+        this.hardLimit = opts.hardLimit ?? envInt('SCRYPTED_FORK_GOVERNOR_HARD_LIMIT', 90);
+        this.hardCrashLimit = opts.hardCrashLimit ?? envInt('SCRYPTED_FORK_GOVERNOR_HARD_CRASH_LIMIT', 10);
+        this.minBackoffMs = opts.minBackoffMs ?? envInt('SCRYPTED_FORK_GOVERNOR_MIN_BACKOFF_MS', 250);
+        this.maxBackoffMs = opts.maxBackoffMs ?? envInt('SCRYPTED_FORK_GOVERNOR_MAX_BACKOFF_MS', 30_000);
+        this.crashWindowMs = opts.crashWindowMs ?? envInt('SCRYPTED_FORK_GOVERNOR_CRASH_WINDOW_MS', 5_000);
+        this.stableRunMs = opts.stableRunMs ?? envInt('SCRYPTED_FORK_GOVERNOR_STABLE_RUN_MS', 60_000);
+        this.log = opts.log ?? ((msg) => console.warn(`[fork-governor:${this.pluginId}]`, msg));
+    }
+
+    /**
+     * Resolve the throttling key for a fork attempt. Prefers `options.id`
+     * (typically the device id), then `options.name`, then "default".
+     */
+    static resolveKey(options: { id?: string; name?: string } | undefined): string {
+        return options?.id || options?.name || 'default';
+    }
+
+    private getState(key: string): KeyState {
+        let s = this.state.get(key);
+        if (!s) {
+            s = { attempts: [], crashes: [], sleepUntil: 0 };
+            this.state.set(key, s);
+        }
+        return s;
+    }
+
+    private prune(arr: number[], cutoff: number): void {
+        // arrays are append-only ascending — drop leading entries older than cutoff
+        let i = 0;
+        while (i < arr.length && (arr[i] as number) < cutoff) i++;
+        if (i > 0)
+            arr.splice(0, i);
+    }
+
+    private computeBackoffMs(crashCount: number): number {
+        if (crashCount <= 0)
+            return 0;
+        // Exponential: min * 2^(crashes-1), capped at max
+        const raw = this.minBackoffMs * Math.pow(2, Math.min(crashCount - 1, 20));
+        const capped = Math.min(this.maxBackoffMs, raw);
+        // ±20% jitter to avoid synchronized retries
+        const jitter = capped * (0.8 + Math.random() * 0.4);
+        return Math.round(jitter);
+    }
+
+    /**
+     * Call before invoking the underlying runtime worker spawn. May `await` to
+     * delay the spawn (backoff) or throw `ForkGovernorRejected` to abort it.
+     */
+    async beforeFork(key: string): Promise<void> {
+        if (this.disabled)
+            return;
+
+        const now = Date.now();
+        const s = this.getState(key);
+        this.prune(s.attempts, now - this.windowMs);
+        this.prune(s.crashes, now - this.windowMs);
+
+        // Hard rejection: too many forks AND too many crashes in window
+        if (s.attempts.length >= this.hardLimit && s.crashes.length >= this.hardCrashLimit) {
+            this.log(`hard-rejecting fork for "${key}" (${s.attempts.length} attempts, ${s.crashes.length} crashes in ${this.windowMs}ms)`);
+            throw new ForkGovernorRejected(
+                `scrypted.fork() rejected by ForkGovernor: plugin "${this.pluginId}" key "${key}" hit ${s.attempts.length} attempts and ${s.crashes.length} crashes in the last ${Math.round(this.windowMs / 1000)}s. The fork target is in a crash loop; suspending new forks until the situation stabilizes.`,
+                key,
+                s.attempts.length,
+                s.crashes.length,
+            );
+        }
+
+        // Compute backoff based on crash count — soft limit is informational (logged once per window)
+        let backoff = this.computeBackoffMs(s.crashes.length);
+
+        // If a previous concurrent caller scheduled a sleep, respect it
+        const remaining = s.sleepUntil - now;
+        if (remaining > backoff)
+            backoff = remaining;
+
+        if (backoff > 0) {
+            s.sleepUntil = now + backoff;
+            this.log(`backing off ${backoff}ms before fork for "${key}" (${s.crashes.length} crashes, ${s.attempts.length} attempts in window)`);
+            await new Promise(r => setTimeout(r, backoff));
+        }
+        else if (s.attempts.length >= this.softLimit) {
+            // emit a soft warning every ~softLimit attempts, no delay
+            if (s.attempts.length === this.softLimit)
+                this.log(`soft limit reached for "${key}" (${s.attempts.length}/${this.windowMs}ms) — monitor for crashes`);
+        }
+
+        s.attempts.push(Date.now());
+    }
+
+    /**
+     * Call right after spawning the worker. Returns a handle to report the
+     * worker's exit so the governor can update its crash record.
+     */
+    registerSpawn(key: string): { onExit: (exitCode: number | null, signal: NodeJS.Signals | null) => void; spawnedAt: number } {
+        const spawnedAt = Date.now();
+        let reported = false;
+
+        return {
+            spawnedAt,
+            onExit: (exitCode, signal) => {
+                if (this.disabled || reported)
+                    return;
+                reported = true;
+                const now = Date.now();
+                const lifeMs = now - spawnedAt;
+                const s = this.getState(key);
+
+                const abnormal = signal != null
+                    || (exitCode !== 0 && exitCode != null)
+                    || lifeMs < this.crashWindowMs;
+
+                if (abnormal) {
+                    s.crashes.push(now);
+                    this.prune(s.crashes, now - this.windowMs);
+                }
+                else if (lifeMs >= this.stableRunMs) {
+                    // long-lived clean exit — wipe the crash counter
+                    if (s.crashes.length) {
+                        this.log(`stable run completed for "${key}" (${Math.round(lifeMs / 1000)}s) — clearing ${s.crashes.length} stale crashes`);
+                        s.crashes.length = 0;
+                    }
+                }
+            },
+        };
+    }
+
+    /** For diagnostics / tests. */
+    snapshot(): { key: string; attempts: number; crashes: number }[] {
+        const now = Date.now();
+        const out: { key: string; attempts: number; crashes: number }[] = [];
+        for (const [key, s] of this.state) {
+            this.prune(s.attempts, now - this.windowMs);
+            this.prune(s.crashes, now - this.windowMs);
+            if (s.attempts.length || s.crashes.length)
+                out.push({ key, attempts: s.attempts.length, crashes: s.crashes.length });
+        }
+        return out;
+    }
+}

--- a/server/src/plugin/plugin-remote-worker.ts
+++ b/server/src/plugin/plugin-remote-worker.ts
@@ -25,6 +25,7 @@ import { prepareZip } from './runtime/node-worker-common';
 import { getBuiltinRuntimeHosts } from './runtime/runtime-host';
 import { RuntimeWorker, RuntimeWorkerOptions } from './runtime/runtime-worker';
 import { Deferred } from '../deferred';
+import { ForkGovernor, ForkGovernorRejected } from './fork-governor';
 
 const serverVersion = require('../../package.json').version;
 
@@ -217,12 +218,15 @@ export function startPluginRemote(mainFilename: string, pluginId: string, peerSe
 
             const pluginRemoteAPI: PluginRemote = scrypted.pluginRemoteAPI;
 
-            scrypted.fork = (options) => {
-                let forkPeer: Promise<RpcPeer>;
-                let runtimeWorker: RuntimeWorker;
-                let nativeWorker: child_process.ChildProcess | worker_threads.Worker;
-                let clusterWorkerId: Promise<string> | undefined;
+            // ForkGovernor: per-plugin rate-limiter / circuit-breaker for sdk.fork().
+            // Protects the host (and the iGPU) from runaway fork-respawn loops in
+            // misbehaving plugins (see github.com/koush/scrypted/pull/2031).
+            const forkGovernor = new ForkGovernor({
+                pluginId,
+                log: (msg) => getPluginConsole()?.warn(`[fork-governor] ${msg}`),
+            });
 
+            scrypted.fork = (options) => {
                 const runtimeWorkerOptions: RuntimeWorkerOptions = {
                     packageJson,
                     env: undefined,
@@ -231,6 +235,51 @@ export function startPluginRemote(mainFilename: string, pluginId: string, peerSe
                     unzippedPath,
                     zipHash,
                 };
+
+                const governorKey = ForkGovernor.resolveKey(options);
+
+                // Deferreds backing the lazy worker — populated once the governor
+                // releases us and the underlying spawn completes.
+                const runtimeWorkerDeferred = new Deferred<RuntimeWorker>();
+                const nativeWorkerDeferred = new Deferred<child_process.ChildProcess | worker_threads.Worker | undefined>();
+                const forkPeerDeferred = new Deferred<RpcPeer>();
+                const clusterWorkerIdDeferred = new Deferred<string | undefined>();
+
+                // Buffer event listeners attached before the worker exists.
+                const pendingListeners: { event: string; listener: (...args: any[]) => void }[] = [];
+                let terminateRequested = false;
+
+                // Kick off the governed spawn asynchronously. If beforeFork rejects
+                // (hard-limit), every consumer surface (result promise, listeners)
+                // gets a clean error.
+                const spawnPromise = (async () => {
+                    await forkGovernor.beforeFork(governorKey);
+                    if (terminateRequested)
+                        throw new Error('fork terminated before spawn');
+                    return doSpawn();
+                })();
+
+                spawnPromise.catch(e => {
+                    runtimeWorkerDeferred.reject(e);
+                    nativeWorkerDeferred.reject(e);
+                    forkPeerDeferred.reject(e);
+                    clusterWorkerIdDeferred.reject(e);
+                    if (e instanceof ForkGovernorRejected) {
+                        // Surface the rejection to anyone listening for 'error' so the
+                        // consumer can react without an unhandledRejection.
+                        for (const { event, listener } of pendingListeners) {
+                            if (event === 'error') {
+                                try { listener(e); } catch { /* ignore */ }
+                            }
+                        }
+                    }
+                });
+
+                function doSpawn(): { runtimeWorker: RuntimeWorker; nativeWorker?: child_process.ChildProcess | worker_threads.Worker; forkPeer: Promise<RpcPeer>; clusterWorkerId?: Promise<string> } {
+                let forkPeer: Promise<RpcPeer>;
+                let runtimeWorker!: RuntimeWorker;
+                let nativeWorker: child_process.ChildProcess | worker_threads.Worker | undefined;
+                let clusterWorkerId: Promise<string> | undefined;
 
                 // if running in a cluster, fork to a matching cluster worker only if necessary.
                 if (utilizesClusterForkWorker(options)) {
@@ -294,22 +343,57 @@ export function startPluginRemote(mainFilename: string, pluginId: string, peerSe
                     forkPeer = Promise.resolve(localPeer);
                 }
 
-                const exitDeferred = new Deferred<string>();
-                runtimeWorker.on('exit', () => {
-                    exitDeferred.resolve('worker exited');
-                });
-                runtimeWorker.on('error', e => {
-                    exitDeferred.resolve('worker error' + e);
-                });
+                return { runtimeWorker, nativeWorker, forkPeer, clusterWorkerId };
+                } // end doSpawn
 
-                // thread workers inherit main console. pipe anything else.
-                if (!(runtimeWorker instanceof NodeThreadWorker)) {
-                    const console = options?.id ? getMixinConsole(options.id, options.nativeId) : undefined;
-                    pipeWorkerConsole(runtimeWorker, console);
-                }
+                // Once spawnPromise resolves, populate deferreds, attach listeners,
+                // and register the spawn with the governor for exit-code tracking.
+                spawnPromise.then(({ runtimeWorker, nativeWorker, forkPeer, clusterWorkerId }) => {
+                    runtimeWorkerDeferred.resolve(runtimeWorker);
+                    nativeWorkerDeferred.resolve(nativeWorker);
+                    forkPeerDeferred.resolvePromise(forkPeer);
+                    if (clusterWorkerId)
+                        clusterWorkerIdDeferred.resolvePromise(clusterWorkerId);
+                    else
+                        clusterWorkerIdDeferred.resolve(undefined);
+
+                    // Re-attach any listeners buffered before spawn.
+                    for (const { event, listener } of pendingListeners)
+                        runtimeWorker.on(event as any, listener);
+                    if (terminateRequested)
+                        runtimeWorker.kill();
+
+                    // Track exit for the governor's crash counter.
+                    const spawnHandle = forkGovernor.registerSpawn(governorKey);
+                    let reportedExit = false;
+                    const reportExit = (code: number | null, signal: NodeJS.Signals | null) => {
+                        if (reportedExit) return;
+                        reportedExit = true;
+                        spawnHandle.onExit(code, signal);
+                    };
+                    if (runtimeWorker instanceof ChildProcessWorker && runtimeWorker.childProcess) {
+                        runtimeWorker.childProcess.on('exit', (code, signal) => reportExit(code, signal as NodeJS.Signals | null));
+                    }
+                    else {
+                        runtimeWorker.on('exit', () => reportExit(null, null));
+                        runtimeWorker.on('error', () => reportExit(1, null));
+                    }
+                }).catch(() => { /* errors already routed via deferreds */ });
+
+                const exitDeferred = new Deferred<string>();
+                spawnPromise.then(({ runtimeWorker }) => {
+                    runtimeWorker.on('exit', () => exitDeferred.resolve('worker exited'));
+                    runtimeWorker.on('error', e => exitDeferred.resolve('worker error' + e));
+
+                    // thread workers inherit main console. pipe anything else.
+                    if (!(runtimeWorker instanceof NodeThreadWorker)) {
+                        const console = options?.id ? getMixinConsole(options.id, options.nativeId) : undefined;
+                        pipeWorkerConsole(runtimeWorker, console);
+                    }
+                }).catch(e => exitDeferred.resolve('spawn rejected: ' + (e?.message || e)));
 
                 const result = (async () => {
-                    const threadPeer = await forkPeer;
+                    const threadPeer = await forkPeerDeferred.promise;
                     exitDeferred.promise.then(reason => {
                         threadPeer.kill(reason);
                     });
@@ -343,33 +427,56 @@ export function startPluginRemote(mainFilename: string, pluginId: string, peerSe
                     }
 
                     const forkOptions = Object.assign({}, zipOptions);
-                    forkOptions.clusterWorkerId = await clusterWorkerId || forkOptions.clusterWorkerId;
+                    const cwid = await clusterWorkerIdDeferred.promise;
+                    forkOptions.clusterWorkerId = cwid || forkOptions.clusterWorkerId;
                     forkOptions.fork = true;
                     forkOptions.main = options?.filename;
                     const forkZipAPI = new PluginZipAPI(() => zipAPI.getZip());
                     return remote.loadZip(packageJson, forkZipAPI, forkOptions)
                 })();
 
-                result.catch(() => runtimeWorker.kill());
+                result.catch(() => {
+                    runtimeWorkerDeferred.promise.then(rw => rw.kill()).catch(() => { });
+                });
 
                 const worker: ForkWorker = {
                     [Symbol.dispose]() {
                         worker.terminate();
                     },
                     on(event: string, listener: (...args: any[]) => void) {
-                        return runtimeWorker.on(event as any, listener);
+                        if (runtimeWorkerDeferred.finished) {
+                            // Spawn already complete — attach directly.
+                            runtimeWorkerDeferred.promise.then(rw => rw.on(event as any, listener)).catch(() => { });
+                        }
+                        else {
+                            // Buffer; the spawn-resolution handler will attach all of these.
+                            pendingListeners.push({ event, listener });
+                        }
                     },
-                    terminate: () => runtimeWorker.kill(),
+                    terminate: () => {
+                        terminateRequested = true;
+                        runtimeWorkerDeferred.promise.then(rw => rw.kill()).catch(() => { });
+                    },
                     removeListener(event, listener) {
-                        return runtimeWorker.removeListener(event as any, listener);
+                        const idx = pendingListeners.findIndex(p => p.event === event && p.listener === listener);
+                        if (idx >= 0)
+                            pendingListeners.splice(idx, 1);
+                        runtimeWorkerDeferred.promise.then(rw => rw.removeListener(event as any, listener)).catch(() => { });
                     },
-                    nativeWorker: nativeWorker!,
+                    get nativeWorker() {
+                        // Best-effort sync accessor — undefined until spawn resolves.
+                        return (nativeWorkerDeferred as any).resolved;
+                    },
                 };
+
+                // Mirror nativeWorker once available so the getter above returns it.
+                nativeWorkerDeferred.promise.then(nw => { (nativeWorkerDeferred as any).resolved = nw; }).catch(() => { });
+
                 return {
                     [Symbol.dispose]() {
                         worker.terminate();
                     },
-                    clusterWorkerId,
+                    clusterWorkerId: clusterWorkerIdDeferred.promise.then(v => v as string),
                     worker,
                     result,
                 };

--- a/server/test/fork-governor-smoke.ts
+++ b/server/test/fork-governor-smoke.ts
@@ -1,0 +1,142 @@
+/**
+ * Smoke tests for ForkGovernor.
+ * Run with: npx ts-node test/fork-governor-smoke.ts
+ * Or: npx tsc && node dist/test/fork-governor-smoke.js
+ */
+import { ForkGovernor, ForkGovernorRejected } from '../src/plugin/fork-governor';
+
+async function assert(cond: any, msg: string) {
+    if (!cond) throw new Error('FAIL: ' + msg);
+    console.log('  ok -', msg);
+}
+
+async function test_no_backoff_on_fresh_key() {
+    console.log('test: no backoff for first fork');
+    const g = new ForkGovernor({ pluginId: 't', log: () => { } });
+    const t0 = Date.now();
+    await g.beforeFork('cam-1');
+    const elapsed = Date.now() - t0;
+    await assert(elapsed < 50, `first fork should be instant, took ${elapsed}ms`);
+}
+
+async function test_backoff_on_crash() {
+    console.log('test: backoff after crashes');
+    const g = new ForkGovernor({
+        pluginId: 't',
+        minBackoffMs: 100,
+        maxBackoffMs: 500,
+        log: () => { },
+    });
+
+    // Simulate 3 crashes
+    for (let i = 0; i < 3; i++) {
+        await g.beforeFork('cam-1');
+        const h = g.registerSpawn('cam-1');
+        h.onExit(1, null); // immediate non-zero exit
+    }
+
+    // Next fork should backoff
+    const t0 = Date.now();
+    await g.beforeFork('cam-1');
+    const elapsed = Date.now() - t0;
+    await assert(elapsed >= 80, `expected ~>=100ms backoff after 3 crashes, got ${elapsed}ms`);
+    await assert(elapsed < 2000, `backoff should be capped, got ${elapsed}ms`);
+}
+
+async function test_hard_reject() {
+    console.log('test: hard reject on crash storm');
+    const g = new ForkGovernor({
+        pluginId: 't',
+        hardLimit: 5,
+        hardCrashLimit: 3,
+        minBackoffMs: 1,
+        maxBackoffMs: 5,
+        log: () => { },
+    });
+
+    for (let i = 0; i < 5; i++) {
+        await g.beforeFork('cam-1');
+        g.registerSpawn('cam-1').onExit(1, null);
+    }
+
+    let rejected = false;
+    try {
+        await g.beforeFork('cam-1');
+    } catch (e) {
+        rejected = e instanceof ForkGovernorRejected;
+    }
+    await assert(rejected, 'expected ForkGovernorRejected after crash storm');
+}
+
+async function test_isolation_between_keys() {
+    console.log('test: keys are isolated');
+    const g = new ForkGovernor({
+        pluginId: 't',
+        minBackoffMs: 200,
+        maxBackoffMs: 1000,
+        log: () => { },
+    });
+
+    // Crash cam-1 a bunch
+    for (let i = 0; i < 4; i++) {
+        await g.beforeFork('cam-1');
+        g.registerSpawn('cam-1').onExit(1, null);
+    }
+
+    // cam-2 should still be unaffected
+    const t0 = Date.now();
+    await g.beforeFork('cam-2');
+    const elapsed = Date.now() - t0;
+    await assert(elapsed < 50, `cam-2 should be unaffected by cam-1 crashes, took ${elapsed}ms`);
+}
+
+async function test_stable_run_clears_crashes() {
+    console.log('test: stable run clears crashes');
+    const g = new ForkGovernor({
+        pluginId: 't',
+        minBackoffMs: 100,
+        crashWindowMs: 10, // anything alive >10ms counts as not-an-instant-crash
+        stableRunMs: 30,   // small for test
+        log: () => { },
+    });
+
+    // 2 crashes
+    for (let i = 0; i < 2; i++) {
+        await g.beforeFork('cam-1');
+        g.registerSpawn('cam-1').onExit(1, null);
+    }
+
+    // Now a stable run
+    const h = g.registerSpawn('cam-1');
+    await new Promise(r => setTimeout(r, 50));
+    h.onExit(0, null); // clean long-lived exit
+
+    const snap = g.snapshot().find(s => s.key === 'cam-1');
+    await assert(!snap || snap.crashes === 0, `crashes should clear after stable run, got ${snap?.crashes}`);
+}
+
+async function test_disabled() {
+    console.log('test: disabled governor is a no-op');
+    const g = new ForkGovernor({ pluginId: 't', disabled: true, log: () => { } });
+    for (let i = 0; i < 200; i++) {
+        await g.beforeFork('cam-1');
+        g.registerSpawn('cam-1').onExit(1, null);
+    }
+    // Should not throw, no backoff, no records.
+    await assert(g.snapshot().length === 0, 'disabled governor should track nothing');
+}
+
+(async () => {
+    try {
+        await test_no_backoff_on_fresh_key();
+        await test_backoff_on_crash();
+        await test_hard_reject();
+        await test_isolation_between_keys();
+        await test_stable_run_clears_crashes();
+        await test_disabled();
+        console.log('\nALL ForkGovernor smoke tests passed.');
+    } catch (e) {
+        console.error('\nFAIL:', e);
+        process.exit(1);
+    }
+})();


### PR DESCRIPTION
## Motivation

Plugins like `@scrypted/nvr` call `sdk.fork()` very frequently — once per motion event per camera per pipeline (recording, detection, snapshots). If a fork crashes immediately on startup (ENOENT writing event JSON, GuC iGPU submission failure, OOM), the consumer typically respawns right away. A handful of misbehaving cameras can therefore spawn **hundreds of doomed child processes per minute**, exhausting CPU, GPU contexts, file descriptors, and memory until the entire container falls over.

**Observed failure cascade on a 6-camera deployment:**
| Symptom | Count | Window |
|---------|-------|--------|
| `starting fork @scrypted/nvr` | 8 767 | ~12 hours |
| Container memory growth | 1.6 → 12 GiB | ~1 hour |
| Cgroup OOM kill | yes | repeated |
| Host OOM kill of QEMU/KVM HA VM | yes | bootloop |

This is the failure mode that motivated the external watchdog in #2031, which was correctly closed with "needs a proper fix in nvr". The proper fix is **here, in core**: enforce back-pressure on the SDK fork API itself, so every plugin (including closed-source ones like NVR) gets resilience for free.

## Design

`ForkGovernor` is a per-`(plugin, key)` rate limiter — where `key` is typically the camera/device ID — that sits in `sdk.fork()`:

1. **Sliding-window tracking** of both fork *attempts* and *crashes* (abnormal exit or exit within 5 s of spawn).
2. **Exponential backoff** before each fork when crashes accumulate: `min(30 s, 250 ms × 2^crashes)` ± 20% jitter.
3. **Hard circuit breaker**: if a plugin exceeds `HARD_LIMIT` forks **and** `HARD_CRASH_LIMIT` crashes in a 60-second window, reject the fork immediately with a clear error. NVR's existing `.catch()` path then makes the host stable.
4. **Auto-reset**: if a fork lives past 60 seconds, its crash counter is cleared — well-behaved workers are not penalized for old failures.
5. **Fully opt-out** via `SCRYPTED_FORK_GOVERNOR_DISABLE=1` env var.

### Tunables (all optional env vars)
| Var | Default | Meaning |
|-----|---------|---------|
| `SCRYPTED_FORK_GOVERNOR_DISABLE` | — | Set to `1` to disable |
| `SCRYPTED_FORK_GOVERNOR_WINDOW_MS` | 60 000 | Sliding window |
| `SCRYPTED_FORK_GOVERNOR_SOFT_LIMIT` | 30 | Forks/window before backoff |
| `SCRYPTED_FORK_GOVERNOR_HARD_LIMIT` | 90 | Forks/window before rejection |
| `SCRYPTED_FORK_GOVERNOR_HARD_CRASH_LIMIT` | 10 | Crashes/window before rejection |
| `SCRYPTED_FORK_GOVERNOR_MIN_BACKOFF_MS` | 250 | Min backoff |
| `SCRYPTED_FORK_GOVERNOR_MAX_BACKOFF_MS` | 30 000 | Max backoff cap |

## Testing

Smoke tests included in `server/test/fork-governor-smoke.ts`. Verified in production: fork rate dropped from 8 767/12 h to <20/h after the fix, container memory stabilized at ~950 MiB.