### PR TITLE
fix(onvif): add opt-in toggle to expose the RTSP URL Override field

### DIFF
--- a/plugins/onvif/src/main.ts
+++ b/plugins/onvif/src/main.ts
@@ -209,7 +209,7 @@ class OnvifCamera extends RtspSmartCamera implements ObjectDetector, Intercom, V
     }
 
     showRtspUrlOverride() {
-        return false;
+        return this.storage.getItem('enableRtspUrlOverride') === 'true';
     }
 
     showRtspPortOverride() {
@@ -229,6 +229,14 @@ class OnvifCamera extends RtspSmartCamera implements ObjectDetector, Intercom, V
 
         const ret: Setting[] = [
             ...await super.getOtherSettings(),
+            {
+                subgroup: 'Advanced',
+                key: 'enableRtspUrlOverride',
+                title: 'RTSP URL Override',
+                description: 'Enable to manually specify RTSP stream URLs, overriding those discovered via ONVIF. Useful for routing streams through a relay proxy (e.g., go2rtc) when the camera has limited simultaneous TCP connection capacity.',
+                type: 'boolean',
+                value: this.storage.getItem('enableRtspUrlOverride') === 'true',
+            },
             {
                 subgroup: 'Advanced',
                 title: 'Onvif Doorbell',


### PR DESCRIPTION
## Problem

`RtspSmartCamera` (the base class used by `@scrypted/onvif` and other RTSP camera plugins) exposes an RTSP URL override setting in the UI — but `OnvifCamera.showRtspUrlOverride()` is hardcoded to return `false`, permanently hiding it. This makes the field inaccessible even when explicitly needed.

**When is the RTSP URL override useful?**
- Routing a camera through an RTSP relay (e.g. go2rtc) that handles reconnects, reducing fork churn on `@scrypted/nvr`
- Cameras behind NAT or VLANs where the ONVIF-advertised RTSP URL is unreachable from the Scrypted host
- Testing / diagnostics (force a specific RTSP path without changing ONVIF device settings)

## Change

Add an opt-in boolean setting `enableRtspUrlOverride` (under the *Advanced* subgroup). When enabled, `showRtspUrlOverride()` returns `true`, making the RTSP URL field visible and editable.

This is a **pure additive, opt-in change** — cameras that haven't enabled the setting behave exactly as before.

## Before / After

| | Before | After |
|--|--------|-------|
| RTSP URL field visible | Never | When "RTSP URL Override" toggle is enabled |
| Default behaviour | Unchanged | Unchanged |
| Cameras already configured | Unaffected | Unaffected |