### PR TITLE
fix(homekit): bump @homebridge/ciao to 1.3.8 to fix MDNSServer sentPackets memory leak

### DIFF
--- a/plugins/homekit/package-lock.json
+++ b/plugins/homekit/package-lock.json
@@ -1,7 +1,7 @@
 {
    "name": "@scrypted/homekit",
    "version": "1.2.65",
-   "lockfileVersion": 2,
+   "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
@@ -32,17 +32,21 @@
          "license": "ISC",
          "dependencies": {
             "@scrypted/sdk": "file:../sdk",
-            "@scrypted/types": "^0.5.27",
             "http-auth-utils": "^5.0.1",
             "typescript": "^5.5.3"
          },
          "devDependencies": {
-            "@types/node": "^20.11.0",
+            "@types/node": "^20.19.11",
             "monaco-editor": "^0.50.0",
-            "ts-node": "^10.9.2"
+            "ts-node": "^10.9.2",
+            "tslib": "^2.8.1"
+         },
+         "peerDependencies": {
+            "@scrypted/types": "^0.5.55"
          }
       },
       "../../external/werift": {
+         "name": "werift",
          "version": "0.0.1",
          "license": "MIT",
          "workspaces": [
@@ -67,155 +71,78 @@
             "node": ">=18"
          }
       },
-      "../../external/werift/packages/webrtc": {
-         "name": "@koush/werift",
-         "version": "0.14.5",
-         "extraneous": true,
-         "license": "MIT",
-         "dependencies": {
-            "@fidm/x509": "^1.2.1",
-            "@minhducsun2002/leb128": "^0.2.0",
-            "@peculiar/webcrypto": "^1.1.6",
-            "@peculiar/x509": "^1.2.2",
-            "@shinyoshiaki/ebml-builder": "^0.0.1",
-            "aes-js": "^3.1.2",
-            "binary-data": "^0.6.0",
-            "buffer-crc32": "^0.2.13",
-            "date-fns": "^2.27.0",
-            "debug": "^4.3.3",
-            "elliptic": "^6.5.3",
-            "int64-buffer": "^1.0.1",
-            "ip": "^1.1.5",
-            "jspack": "^0.0.4",
-            "lodash": "^4.17.20",
-            "nano-time": "^1.0.0",
-            "p-cancelable": "^2.1.1",
-            "rx.mini": "^1.1.0",
-            "turbo-crc32": "^1.0.1",
-            "tweetnacl": "^1.0.3",
-            "uuid": "^8.3.2"
-         },
-         "devDependencies": {
-            "@types/aes-js": "^3.1.1",
-            "@types/buffer-crc32": "^0.2.0",
-            "@types/debug": "^4.1.7",
-            "@types/elliptic": "^6.4.14",
-            "@types/ip": "^1.1.0",
-            "@types/jest": "^27.0.3",
-            "@types/lodash": "^4.14.178",
-            "@types/node": "^17.0.0",
-            "@types/uuid": "^8.3.3",
-            "@typescript-eslint/eslint-plugin": "^5.7.0",
-            "@typescript-eslint/parser": "^5.7.0",
-            "eslint-plugin-prettier": "^4.0.0",
-            "jest": "^27.4.5",
-            "node-actionlint": "^1.2.1",
-            "prettier": "^2.5.1",
-            "ts-jest": "^27.1.1",
-            "ts-node": "^10.4.0",
-            "typedoc": "^0.22.10",
-            "typescript": "^4.5.4"
-         },
-         "engines": {
-            "node": ">=15"
-         }
-      },
       "../../sdk": {
          "name": "@scrypted/sdk",
-         "version": "0.5.38",
+         "version": "0.5.59",
          "dev": true,
          "license": "ISC",
          "dependencies": {
             "@babel/preset-typescript": "^7.27.1",
-            "@rollup/plugin-commonjs": "^28.0.5",
+            "@rollup/plugin-commonjs": "^28.0.9",
             "@rollup/plugin-json": "^6.1.0",
             "@rollup/plugin-node-resolve": "^16.0.1",
-            "@rollup/plugin-typescript": "^12.1.2",
+            "@rollup/plugin-terser": "^0.4.4",
+            "@rollup/plugin-typescript": "^12.3.0",
             "@rollup/plugin-virtual": "^3.0.2",
+            "@scrypted/auth-fetch": "^1.0.5",
             "adm-zip": "^0.5.16",
-            "axios": "^1.10.0",
             "babel-loader": "^10.0.0",
             "babel-plugin-const-enum": "^1.2.0",
             "ncp": "^2.0.0",
-            "openai": "^5.3.0",
+            "openai": "^6.1.0",
             "raw-loader": "^4.0.2",
             "rimraf": "^6.0.1",
-            "rollup": "^4.43.0",
+            "rollup": "^4.52.5",
             "tmp": "^0.2.3",
-            "ts-loader": "^9.5.2",
+            "ts-loader": "^9.5.4",
             "tslib": "^2.8.1",
-            "typescript": "^5.8.3",
+            "typescript": "^5.9.3",
             "webpack": "^5.99.9",
             "webpack-bundle-analyzer": "^4.10.2"
          },
          "bin": {
-            "scrypted-changelog": "bin/scrypted-changelog.js",
-            "scrypted-debug": "bin/scrypted-debug.js",
-            "scrypted-deploy": "bin/scrypted-deploy.js",
-            "scrypted-deploy-debug": "bin/scrypted-deploy-debug.js",
-            "scrypted-package-json": "bin/scrypted-package-json.js",
-            "scrypted-setup-project": "bin/scrypted-setup-project.js",
-            "scrypted-webpack": "bin/scrypted-webpack.js"
+            "scrypted-changelog": "bin/cli.js",
+            "scrypted-debug": "bin/cli.js",
+            "scrypted-deploy": "bin/cli.js",
+            "scrypted-deploy-debug": "bin/cli.js",
+            "scrypted-package-json": "bin/cli.js",
+            "scrypted-setup-project": "bin/cli.js",
+            "scrypted-webpack": "bin/cli.js"
          },
          "devDependencies": {
-            "@types/node": "^24.0.1",
+            "@types/adm-zip": "^0.5.8",
+            "@types/ncp": "^2.0.8",
+            "@types/node": "^24.9.2",
+            "@types/tmp": "^0.2.6",
             "ts-node": "^10.9.2",
-            "typedoc": "^0.28.5"
+            "typedoc": "^0.28.14"
          }
       },
-      "../HAP-NodeJS": {
-         "extraneous": true
-      },
-      "../sdk": {
-         "extraneous": true
-      },
-      "HAP-NodeJS": {
-         "name": "hap-nodejs",
-         "version": "0.9.6",
-         "extraneous": true,
-         "license": "Apache-2.0",
+      "node_modules/@homebridge/ciao": {
+         "version": "1.3.8",
+         "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.8.tgz",
+         "integrity": "sha512-lNhpCsZVbdbjz2trFjQdzQ3cUIMZQMIMksi7wd3ntTIYgdaGLqT1Ms97DfVIJYHzRuduf56ISvgU8RRLTpK/ng==",
+         "license": "MIT",
          "dependencies": {
-            "@homebridge/ciao": "~1.1.2",
-            "bonjour-hap": "~3.6.3",
-            "debug": "^4.3.2",
-            "fast-srp-hap": "2.0.4",
-            "futoin-hkdf": "~1.4.2",
-            "ip": "^1.1.5",
-            "node-persist": "^0.0.11",
-            "source-map-support": "^0.5.20",
-            "tslib": "^2.3.1",
-            "tweetnacl": "^1.0.3"
+            "debug": "^4.4.3",
+            "fast-deep-equal": "^3.1.3",
+            "source-map-support": "^0.5.21",
+            "tslib": "^2.8.1"
          },
-         "devDependencies": {
-            "@types/debug": "^4.1.7",
-            "@types/escape-html": "^1.0.1",
-            "@types/jest": "^27.0.2",
-            "@types/node": "^10.17.60",
-            "commander": "^6.2.1",
-            "escape-html": "^1.0.3",
-            "jest": "^27.2.4",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.5",
-            "simple-plist": "^1.1.1",
-            "ts-jest": "^27.0.5",
-            "ts-node": "^10.2.1",
-            "typedoc": "0.22.5",
-            "typescript": "~4.4.3"
-         },
-         "engines": {
-            "node": ">=10.17.0"
+         "bin": {
+            "ciao-bcs": "lib/bonjour-conformance-testing.js"
          }
       },
       "node_modules/@homebridge/dbus-native": {
-         "version": "0.6.0",
-         "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.6.0.tgz",
-         "integrity": "sha512-xObqQeYHTXmt6wsfj10+krTo4xbzR9BgUfX2aQ+edDC9nc4ojfzLScfXCh3zluAm6UCowKw+AFfXn6WLWUOPkg==",
+         "version": "0.7.5",
+         "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.5.tgz",
+         "integrity": "sha512-SX4Mwg7JYED+o5WMz1+Y4FzGPGtXruDcwQt1SCkzfSqMTzrFj3uO5spEMn04Jj2kCqJVcrRQFWbqw+XW8suIXA==",
+         "license": "MIT",
          "dependencies": {
-            "@homebridge/long": "^5.2.1",
-            "@homebridge/put": "^0.0.8",
             "event-stream": "^4.0.1",
-            "hexy": "^0.3.5",
-            "minimist": "^1.2.6",
+            "hexy": "^0.4.0",
+            "long": "^5.3.2",
+            "minimist": "^1.2.8",
             "safe-buffer": "^5.1.2",
             "xml2js": "^0.6.2"
          },
@@ -223,27 +150,15 @@
             "dbus2js": "bin/dbus2js.js"
          }
       },
-      "node_modules/@homebridge/long": {
-         "version": "5.2.1",
-         "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
-         "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA=="
-      },
-      "node_modules/@homebridge/put": {
-         "version": "0.0.8",
-         "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
-         "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA==",
-         "engines": {
-            "node": ">=0.3.0"
-         }
-      },
       "node_modules/@koush/werift-src": {
          "resolved": "../../external/werift",
          "link": true
       },
       "node_modules/@leichtgewicht/ip-codec": {
-         "version": "2.0.4",
-         "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-         "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+         "version": "2.0.5",
+         "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+         "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+         "license": "MIT"
       },
       "node_modules/@scrypted/common": {
          "resolved": "../../common",
@@ -254,30 +169,33 @@
          "link": true
       },
       "node_modules/@types/debug": {
-         "version": "4.1.12",
-         "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-         "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+         "version": "4.1.13",
+         "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+         "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
          "dev": true,
+         "license": "MIT",
          "dependencies": {
             "@types/ms": "*"
          }
       },
       "node_modules/@types/lodash": {
-         "version": "4.17.7",
-         "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
-         "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
-         "dev": true
+         "version": "4.17.24",
+         "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+         "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/@types/ms": {
-         "version": "0.7.31",
-         "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-         "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-         "dev": true
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+         "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/@types/node": {
-         "version": "22.18.0",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
-         "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+         "version": "22.19.19",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+         "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -288,90 +206,49 @@
          "version": "1.1.5",
          "resolved": "https://registry.npmjs.org/@types/qrcode-svg/-/qrcode-svg-1.1.5.tgz",
          "integrity": "sha512-GjkD+HB8S1wrIsf3skHDtcYBjzNhTxocMbX+wG166xDkaVOnLiMUla7bLjbwxo6mMvqqWQNP0Dk8nkIeizSmnw==",
-         "dev": true
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/@types/url-parse": {
          "version": "1.4.11",
          "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.11.tgz",
          "integrity": "sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg==",
-         "dev": true
+         "dev": true,
+         "license": "MIT"
       },
-      "node_modules/array-buffer-byte-length": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-         "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "node_modules/bonjour-hap": {
+         "version": "3.10.2",
+         "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.2.tgz",
+         "integrity": "sha512-37ZEbMSKZ/K4O8sK9YDVFKJ62ZqlK4OPXcBUYaBnVlqr6vQjYwIoFuOQL0ZhztkCNgyyiCExfN4FcZB5cS9t1A==",
+         "license": "MIT",
          "dependencies": {
-            "call-bind": "^1.0.5",
-            "is-array-buffer": "^3.0.4"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/available-typed-arrays": {
-         "version": "1.0.6",
-         "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
-         "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
+            "fast-deep-equal": "^3.1.3",
+            "multicast-dns": "^7.2.5",
+            "multicast-dns-service-types": "^1.1.0"
          }
       },
       "node_modules/buffer-from": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-         "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-      },
-      "node_modules/call-bind": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-         "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-         "dependencies": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.4",
-            "set-function-length": "^1.2.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/call-bind-apply-helpers": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-         "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-         "license": "MIT",
-         "dependencies": {
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
+         "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+         "license": "MIT"
       },
       "node_modules/check-disk-space": {
          "version": "3.4.0",
          "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
          "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+         "license": "MIT",
          "engines": {
             "node": ">=16"
          }
       },
       "node_modules/debug": {
-         "version": "4.3.5",
-         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-         "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+         "version": "4.4.3",
+         "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+         "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+         "license": "MIT",
          "dependencies": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
          },
          "engines": {
             "node": ">=6.0"
@@ -382,73 +259,11 @@
             }
          }
       },
-      "node_modules/deep-equal": {
-         "version": "2.2.3",
-         "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-         "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-         "dependencies": {
-            "array-buffer-byte-length": "^1.0.0",
-            "call-bind": "^1.0.5",
-            "es-get-iterator": "^1.1.3",
-            "get-intrinsic": "^1.2.2",
-            "is-arguments": "^1.1.1",
-            "is-array-buffer": "^3.0.2",
-            "is-date-object": "^1.0.5",
-            "is-regex": "^1.1.4",
-            "is-shared-array-buffer": "^1.0.2",
-            "isarray": "^2.0.5",
-            "object-is": "^1.1.5",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.4",
-            "regexp.prototype.flags": "^1.5.1",
-            "side-channel": "^1.0.4",
-            "which-boxed-primitive": "^1.0.2",
-            "which-collection": "^1.0.1",
-            "which-typed-array": "^1.1.13"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/define-data-property": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-         "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-         "dependencies": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/define-properties": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-         "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-         "dependencies": {
-            "define-data-property": "^1.0.1",
-            "has-property-descriptors": "^1.0.0",
-            "object-keys": "^1.1.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/dns-packet": {
-         "version": "5.4.0",
-         "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
-         "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+         "version": "5.6.1",
+         "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+         "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+         "license": "MIT",
          "dependencies": {
             "@leichtgewicht/ip-codec": "^2.0.1"
          },
@@ -456,77 +271,17 @@
             "node": ">=6"
          }
       },
-      "node_modules/dunder-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-         "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-         "license": "MIT",
-         "dependencies": {
-            "call-bind-apply-helpers": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.2.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
       "node_modules/duplexer": {
          "version": "0.1.2",
          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-         "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-      },
-      "node_modules/es-define-property": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-         "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/es-errors": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-         "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/es-get-iterator": {
-         "version": "1.1.3",
-         "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-         "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.3",
-            "has-symbols": "^1.0.3",
-            "is-arguments": "^1.1.1",
-            "is-map": "^2.0.2",
-            "is-set": "^2.0.2",
-            "is-string": "^1.0.7",
-            "isarray": "^2.0.5",
-            "stop-iteration-iterator": "^1.0.0"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/es-object-atoms": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-         "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-         "license": "MIT",
-         "dependencies": {
-            "es-errors": "^1.3.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
+         "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+         "license": "MIT"
       },
       "node_modules/event-stream": {
          "version": "4.0.1",
          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
          "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+         "license": "MIT",
          "dependencies": {
             "duplexer": "^0.1.1",
             "from": "^0.1.7",
@@ -540,468 +295,89 @@
       "node_modules/fast-deep-equal": {
          "version": "3.1.3",
          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-         "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+         "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+         "license": "MIT"
       },
       "node_modules/fast-srp-hap": {
          "version": "2.0.4",
          "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
          "integrity": "sha512-lHRYYaaIbMrhZtsdGTwPN82UbqD9Bv8QfOlKs+Dz6YRnByZifOh93EYmf2iEWFtkOEIqR2IK8cFD0UN5wLIWBQ==",
+         "license": "MIT",
          "engines": {
             "node": ">=10.17.0"
-         }
-      },
-      "node_modules/for-each": {
-         "version": "0.3.3",
-         "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-         "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-         "dependencies": {
-            "is-callable": "^1.1.3"
          }
       },
       "node_modules/from": {
          "version": "0.1.7",
          "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-         "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
+         "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+         "license": "MIT"
       },
-      "node_modules/function-bind": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/functions-have-names": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-         "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/get-intrinsic": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-         "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-         "license": "MIT",
-         "dependencies": {
-            "call-bind-apply-helpers": "^1.0.2",
-            "es-define-property": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "es-object-atoms": "^1.1.1",
-            "function-bind": "^1.1.2",
-            "get-proto": "^1.0.1",
-            "gopd": "^1.2.0",
-            "has-symbols": "^1.1.0",
-            "hasown": "^2.0.2",
-            "math-intrinsics": "^1.1.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/get-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-         "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-         "license": "MIT",
-         "dependencies": {
-            "dunder-proto": "^1.0.1",
-            "es-object-atoms": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/gopd": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-         "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/hap-nodejs": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-1.1.0.tgz",
-         "integrity": "sha512-FVJotfbsUzBY7ydiz9cWDmlmyAHswh0AcLwGJ9T+SuRAVhZYsnoHRpom0si1mWzwXA2k0RqFOn52nssf0AlrGQ==",
-         "dependencies": {
-            "@homebridge/ciao": "^1.3.0",
-            "@homebridge/dbus-native": "^0.6.0",
-            "bonjour-hap": "^3.8.0",
-            "debug": "^4.3.5",
-            "fast-srp-hap": "^2.0.4",
-            "futoin-hkdf": "^1.5.3",
-            "node-persist": "^0.0.12",
-            "source-map-support": "^0.5.21",
-            "tslib": "^2.6.3",
-            "tweetnacl": "^1.0.3"
-         },
-         "engines": {
-            "node": "^18 || ^20"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/@homebridge/ciao": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.0.tgz",
-         "integrity": "sha512-PRbY5FiukY13gIDwiAAZng598gMyI61GL9VU19G2CB4D3vNwh8vESgI9TkjeecCDethTqJmNiruYvdunfQkt7w==",
-         "dependencies": {
-            "debug": "^4.3.5",
-            "fast-deep-equal": "^3.1.3",
-            "source-map-support": "^0.5.21",
-            "tslib": "^2.6.3"
-         },
-         "bin": {
-            "ciao-bcs": "lib/bonjour-conformance-testing.js"
-         },
-         "engines": {
-            "node": "^18 || ^20"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/array-flatten": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-         "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-      },
-      "node_modules/hap-nodejs/node_modules/bonjour-hap": {
-         "version": "3.8.0",
-         "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.8.0.tgz",
-         "integrity": "sha512-l/Ptvrt/pjN2pCgiVyyA0EkE0uVoXXYZ4DW4xhL4kDVBaw0w54/3Jhdhzn5EyT1Z8YhNXiNhSX0uW6xz2zSxqQ==",
-         "dependencies": {
-            "array-flatten": "^3.0.0",
-            "deep-equal": "^2.2.3",
-            "multicast-dns": "^7.2.5",
-            "multicast-dns-service-types": "^1.1.0"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/futoin-hkdf": {
+      "node_modules/futoin-hkdf": {
          "version": "1.5.3",
          "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
          "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==",
+         "license": "Apache-2.0",
          "engines": {
             "node": ">=8"
          }
       },
-      "node_modules/hap-nodejs/node_modules/mkdirp": {
-         "version": "0.5.6",
-         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-         "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "node_modules/hap-nodejs": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-1.2.0.tgz",
+         "integrity": "sha512-MusfG+9BJsLbjv7xtF5PDcYmgeYpbtchUhrvTvVBnXPoGMcPePhYt2bo7RphrOskzOpCuSJc8cOMTjJIlHwMNw==",
+         "license": "Apache-2.0",
          "dependencies": {
-            "minimist": "^1.2.6"
-         },
-         "bin": {
-            "mkdirp": "bin/cmd.js"
-         }
-      },
-      "node_modules/hap-nodejs/node_modules/node-persist": {
-         "version": "0.0.12",
-         "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
-         "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
-         "dependencies": {
-            "mkdirp": "~0.5.1",
-            "q": "~1.1.1"
-         }
-      },
-      "node_modules/has-bigints": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-         "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-property-descriptors": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-         "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-         "dependencies": {
-            "es-define-property": "^1.0.0"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-symbols": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-         "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-tostringtag": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-         "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-         "dependencies": {
-            "has-symbols": "^1.0.3"
+            "@homebridge/ciao": "^1.3.2",
+            "@homebridge/dbus-native": "^0.7.1",
+            "bonjour-hap": "^3.9.0",
+            "debug": "^4.4.1",
+            "fast-srp-hap": "^2.0.4",
+            "futoin-hkdf": "^1.5.3",
+            "node-persist": "^0.0.12",
+            "source-map-support": "^0.5.21",
+            "tslib": "^2.8.1",
+            "tweetnacl": "^1.0.3"
          },
          "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/hasown": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-         "dependencies": {
-            "function-bind": "^1.1.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
+            "node": "^18 || ^20 || ^22"
          }
       },
       "node_modules/hexy": {
-         "version": "0.3.5",
-         "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
-         "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw==",
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+         "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
+         "license": "MIT",
          "bin": {
             "hexy": "bin/hexy_cmd.js"
          },
          "engines": {
-            "node": ">=10.4"
+            "node": ">=14.0.0"
          }
-      },
-      "node_modules/internal-slot": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-         "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-         "dependencies": {
-            "es-errors": "^1.3.0",
-            "hasown": "^2.0.0",
-            "side-channel": "^1.0.4"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/is-arguments": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-         "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-array-buffer": {
-         "version": "3.0.4",
-         "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-         "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.2.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-bigint": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-         "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-         "dependencies": {
-            "has-bigints": "^1.0.1"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-boolean-object": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-         "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-callable": {
-         "version": "1.2.7",
-         "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-         "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-date-object": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-         "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-         "dependencies": {
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-map": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-         "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-number-object": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-         "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-         "dependencies": {
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-regex": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-         "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-set": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-         "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-shared-array-buffer": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-         "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-         "dependencies": {
-            "call-bind": "^1.0.2"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-string": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-         "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-         "dependencies": {
-            "has-tostringtag": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-symbol": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-         "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-         "dependencies": {
-            "has-symbols": "^1.0.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-weakmap": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-         "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/is-weakset": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-         "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-         "dependencies": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.1"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/isarray": {
-         "version": "2.0.5",
-         "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-         "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
       },
       "node_modules/lodash": {
-         "version": "4.17.21",
-         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-         "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+         "version": "4.18.1",
+         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+         "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+         "license": "MIT"
+      },
+      "node_modules/long": {
+         "version": "5.3.2",
+         "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+         "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+         "license": "Apache-2.0"
       },
       "node_modules/map-stream": {
          "version": "0.0.7",
          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-         "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
-      },
-      "node_modules/math-intrinsics": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-         "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-         "license": "MIT",
-         "engines": {
-            "node": ">= 0.4"
-         }
+         "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+         "license": "MIT"
       },
       "node_modules/minimist": {
          "version": "1.2.8",
          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+         "license": "MIT",
          "funding": {
             "url": "https://github.com/sponsors/ljharb"
          }
@@ -1010,6 +386,7 @@
          "version": "3.0.1",
          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
          "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+         "license": "MIT",
          "bin": {
             "mkdirp": "dist/cjs/src/bin.js"
          },
@@ -1021,14 +398,16 @@
          }
       },
       "node_modules/ms": {
-         "version": "2.1.2",
-         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-         "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+         "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+         "license": "MIT"
       },
       "node_modules/multicast-dns": {
          "version": "7.2.5",
          "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
          "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+         "license": "MIT",
          "dependencies": {
             "dns-packet": "^5.2.2",
             "thunky": "^1.0.2"
@@ -1040,60 +419,39 @@
       "node_modules/multicast-dns-service-types": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-         "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ=="
+         "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ==",
+         "license": "MIT"
       },
-      "node_modules/object-inspect": {
-         "version": "1.13.1",
-         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-         "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/object-is": {
-         "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-         "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "node_modules/node-persist": {
+         "version": "0.0.12",
+         "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
+         "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
+         "license": "MIT",
          "dependencies": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
+            "mkdirp": "~0.5.1",
+            "q": "~1.1.1"
          }
       },
-      "node_modules/object-keys": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-         "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/object.assign": {
-         "version": "4.1.5",
-         "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-         "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "node_modules/node-persist/node_modules/mkdirp": {
+         "version": "0.5.6",
+         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+         "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+         "license": "MIT",
          "dependencies": {
-            "call-bind": "^1.0.5",
-            "define-properties": "^1.2.1",
-            "has-symbols": "^1.0.3",
-            "object-keys": "^1.1.1"
+            "minimist": "^1.2.6"
          },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
+         "bin": {
+            "mkdirp": "bin/cmd.js"
          }
       },
       "node_modules/pause-stream": {
          "version": "0.0.11",
          "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
          "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+         "license": [
+            "MIT",
+            "Apache2"
+         ],
          "dependencies": {
             "through": "~2.3"
          }
@@ -1102,6 +460,8 @@
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
          "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
+         "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+         "license": "MIT",
          "engines": {
             "node": ">=0.6.0",
             "teleport": ">=0.2.0"
@@ -1111,25 +471,9 @@
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
          "integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw==",
+         "license": "MIT",
          "bin": {
             "qrcode-svg": "bin/qrcode-svg.js"
-         }
-      },
-      "node_modules/regexp.prototype.flags": {
-         "version": "1.5.2",
-         "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-         "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-         "dependencies": {
-            "call-bind": "^1.0.6",
-            "define-properties": "^1.2.1",
-            "es-errors": "^1.3.0",
-            "set-function-name": "^2.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/safe-buffer": {
@@ -1149,63 +493,23 @@
                "type": "consulting",
                "url": "https://feross.org/support"
             }
-         ]
+         ],
+         "license": "MIT"
       },
       "node_modules/sax": {
-         "version": "1.4.1",
-         "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-         "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
-      },
-      "node_modules/set-function-length": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-         "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
-         "dependencies": {
-            "define-data-property": "^1.1.2",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.3",
-            "gopd": "^1.0.1",
-            "has-property-descriptors": "^1.0.1"
-         },
+         "version": "1.6.0",
+         "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+         "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+         "license": "BlueOak-1.0.0",
          "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/set-function-name": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-         "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-         "dependencies": {
-            "define-data-property": "^1.0.1",
-            "functions-have-names": "^1.2.3",
-            "has-property-descriptors": "^1.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/side-channel": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-         "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
-         "dependencies": {
-            "call-bind": "^1.0.6",
-            "es-errors": "^1.3.0",
-            "get-intrinsic": "^1.2.4",
-            "object-inspect": "^1.13.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
+            "node": ">=11.0.0"
          }
       },
       "node_modules/source-map": {
          "version": "0.6.1",
          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+         "license": "BSD-3-Clause",
          "engines": {
             "node": ">=0.10.0"
          }
@@ -1214,6 +518,7 @@
          "version": "0.5.21",
          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+         "license": "MIT",
          "dependencies": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -1223,6 +528,7 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+         "license": "MIT",
          "dependencies": {
             "through": "2"
          },
@@ -1230,21 +536,11 @@
             "node": "*"
          }
       },
-      "node_modules/stop-iteration-iterator": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-         "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-         "dependencies": {
-            "internal-slot": "^1.0.4"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
       "node_modules/stream-combiner": {
          "version": "0.2.2",
          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
          "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+         "license": "MIT",
          "dependencies": {
             "duplexer": "~0.1.1",
             "through": "~2.3.4"
@@ -1253,22 +549,26 @@
       "node_modules/through": {
          "version": "2.3.8",
          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-         "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+         "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+         "license": "MIT"
       },
       "node_modules/thunky": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-         "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+         "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+         "license": "MIT"
       },
       "node_modules/tslib": {
-         "version": "2.6.3",
-         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-         "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+         "version": "2.8.1",
+         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+         "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+         "license": "0BSD"
       },
       "node_modules/tweetnacl": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-         "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+         "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+         "license": "Unlicense"
       },
       "node_modules/undici-types": {
          "version": "6.21.0",
@@ -1277,57 +577,11 @@
          "dev": true,
          "license": "MIT"
       },
-      "node_modules/which-boxed-primitive": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-         "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-         "dependencies": {
-            "is-bigint": "^1.0.1",
-            "is-boolean-object": "^1.1.0",
-            "is-number-object": "^1.0.4",
-            "is-string": "^1.0.5",
-            "is-symbol": "^1.0.3"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/which-collection": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-         "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-         "dependencies": {
-            "is-map": "^2.0.1",
-            "is-set": "^2.0.1",
-            "is-weakmap": "^2.0.1",
-            "is-weakset": "^2.0.1"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/which-typed-array": {
-         "version": "1.1.14",
-         "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-         "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
-         "dependencies": {
-            "available-typed-arrays": "^1.0.6",
-            "call-bind": "^1.0.5",
-            "for-each": "^0.3.3",
-            "gopd": "^1.0.1",
-            "has-tostringtag": "^1.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/xml2js": {
          "version": "0.6.2",
          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
          "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+         "license": "MIT",
          "dependencies": {
             "sax": ">=0.6.0",
             "xmlbuilder": "~11.0.0"
@@ -1336,874 +590,13 @@
             "node": ">=4.0.0"
          }
       },
-      "node_modules/xml2js/node_modules/xmlbuilder": {
+      "node_modules/xmlbuilder": {
          "version": "11.0.1",
          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+         "license": "MIT",
          "engines": {
             "node": ">=4.0"
-         }
-      }
-   },
-   "dependencies": {
-      "@homebridge/dbus-native": {
-         "version": "0.6.0",
-         "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.6.0.tgz",
-         "integrity": "sha512-xObqQeYHTXmt6wsfj10+krTo4xbzR9BgUfX2aQ+edDC9nc4ojfzLScfXCh3zluAm6UCowKw+AFfXn6WLWUOPkg==",
-         "requires": {
-            "@homebridge/long": "^5.2.1",
-            "@homebridge/put": "^0.0.8",
-            "event-stream": "^4.0.1",
-            "hexy": "^0.3.5",
-            "minimist": "^1.2.6",
-            "safe-buffer": "^5.1.2",
-            "xml2js": "^0.6.2"
-         }
-      },
-      "@homebridge/long": {
-         "version": "5.2.1",
-         "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
-         "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA=="
-      },
-      "@homebridge/put": {
-         "version": "0.0.8",
-         "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
-         "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA=="
-      },
-      "@koush/werift-src": {
-         "version": "file:../../external/werift",
-         "requires": {
-            "@biomejs/biome": "1.9.4",
-            "@types/node": "^22.13.4",
-            "knip": "^5.44.1",
-            "npm-run-all2": "^7.0.2",
-            "organize-imports-cli": "^0.10.0",
-            "ts-node": "^10.9.2",
-            "ts-node-dev": "^2.0.0",
-            "tsx": "^4.19.3",
-            "typedoc": "0.27.7",
-            "typedoc-plugin-markdown": "4.4.2",
-            "typescript": "5.7.3",
-            "vitest": "3.0.5"
-         }
-      },
-      "@leichtgewicht/ip-codec": {
-         "version": "2.0.4",
-         "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-         "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
-      },
-      "@scrypted/common": {
-         "version": "file:../../common",
-         "requires": {
-            "@scrypted/sdk": "file:../sdk",
-            "@scrypted/types": "^0.5.27",
-            "@types/node": "^20.11.0",
-            "http-auth-utils": "^5.0.1",
-            "monaco-editor": "^0.50.0",
-            "ts-node": "^10.9.2",
-            "typescript": "^5.5.3"
-         }
-      },
-      "@scrypted/sdk": {
-         "version": "file:../../sdk",
-         "requires": {
-            "@babel/preset-typescript": "^7.27.1",
-            "@rollup/plugin-commonjs": "^28.0.5",
-            "@rollup/plugin-json": "^6.1.0",
-            "@rollup/plugin-node-resolve": "^16.0.1",
-            "@rollup/plugin-typescript": "^12.1.2",
-            "@rollup/plugin-virtual": "^3.0.2",
-            "@types/node": "^24.0.1",
-            "adm-zip": "^0.5.16",
-            "axios": "^1.10.0",
-            "babel-loader": "^10.0.0",
-            "babel-plugin-const-enum": "^1.2.0",
-            "ncp": "^2.0.0",
-            "openai": "^5.3.0",
-            "raw-loader": "^4.0.2",
-            "rimraf": "^6.0.1",
-            "rollup": "^4.43.0",
-            "tmp": "^0.2.3",
-            "ts-loader": "^9.5.2",
-            "ts-node": "^10.9.2",
-            "tslib": "^2.8.1",
-            "typedoc": "^0.28.5",
-            "typescript": "^5.8.3",
-            "webpack": "^5.99.9",
-            "webpack-bundle-analyzer": "^4.10.2"
-         }
-      },
-      "@types/debug": {
-         "version": "4.1.12",
-         "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-         "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-         "dev": true,
-         "requires": {
-            "@types/ms": "*"
-         }
-      },
-      "@types/lodash": {
-         "version": "4.17.7",
-         "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
-         "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
-         "dev": true
-      },
-      "@types/ms": {
-         "version": "0.7.31",
-         "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-         "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-         "dev": true
-      },
-      "@types/node": {
-         "version": "22.18.0",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
-         "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
-         "dev": true,
-         "requires": {
-            "undici-types": "~6.21.0"
-         }
-      },
-      "@types/qrcode-svg": {
-         "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@types/qrcode-svg/-/qrcode-svg-1.1.5.tgz",
-         "integrity": "sha512-GjkD+HB8S1wrIsf3skHDtcYBjzNhTxocMbX+wG166xDkaVOnLiMUla7bLjbwxo6mMvqqWQNP0Dk8nkIeizSmnw==",
-         "dev": true
-      },
-      "@types/url-parse": {
-         "version": "1.4.11",
-         "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.11.tgz",
-         "integrity": "sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg==",
-         "dev": true
-      },
-      "array-buffer-byte-length": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-         "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
-         "requires": {
-            "call-bind": "^1.0.5",
-            "is-array-buffer": "^3.0.4"
-         }
-      },
-      "available-typed-arrays": {
-         "version": "1.0.6",
-         "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.6.tgz",
-         "integrity": "sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg=="
-      },
-      "buffer-from": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-         "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-      },
-      "call-bind": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-         "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-         "requires": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.4",
-            "set-function-length": "^1.2.1"
-         }
-      },
-      "call-bind-apply-helpers": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-         "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-         "requires": {
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2"
-         }
-      },
-      "check-disk-space": {
-         "version": "3.4.0",
-         "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
-         "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw=="
-      },
-      "debug": {
-         "version": "4.3.5",
-         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-         "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-         "requires": {
-            "ms": "2.1.2"
-         }
-      },
-      "deep-equal": {
-         "version": "2.2.3",
-         "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-         "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-         "requires": {
-            "array-buffer-byte-length": "^1.0.0",
-            "call-bind": "^1.0.5",
-            "es-get-iterator": "^1.1.3",
-            "get-intrinsic": "^1.2.2",
-            "is-arguments": "^1.1.1",
-            "is-array-buffer": "^3.0.2",
-            "is-date-object": "^1.0.5",
-            "is-regex": "^1.1.4",
-            "is-shared-array-buffer": "^1.0.2",
-            "isarray": "^2.0.5",
-            "object-is": "^1.1.5",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.4",
-            "regexp.prototype.flags": "^1.5.1",
-            "side-channel": "^1.0.4",
-            "which-boxed-primitive": "^1.0.2",
-            "which-collection": "^1.0.1",
-            "which-typed-array": "^1.1.13"
-         }
-      },
-      "define-data-property": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-         "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-         "requires": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.0.1"
-         }
-      },
-      "define-properties": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-         "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-         "requires": {
-            "define-data-property": "^1.0.1",
-            "has-property-descriptors": "^1.0.0",
-            "object-keys": "^1.1.1"
-         }
-      },
-      "dns-packet": {
-         "version": "5.4.0",
-         "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
-         "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
-         "requires": {
-            "@leichtgewicht/ip-codec": "^2.0.1"
-         }
-      },
-      "dunder-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-         "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-         "requires": {
-            "call-bind-apply-helpers": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.2.0"
-         }
-      },
-      "duplexer": {
-         "version": "0.1.2",
-         "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-         "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-      },
-      "es-define-property": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-         "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-      },
-      "es-errors": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-         "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-      },
-      "es-get-iterator": {
-         "version": "1.1.3",
-         "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-         "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.3",
-            "has-symbols": "^1.0.3",
-            "is-arguments": "^1.1.1",
-            "is-map": "^2.0.2",
-            "is-set": "^2.0.2",
-            "is-string": "^1.0.7",
-            "isarray": "^2.0.5",
-            "stop-iteration-iterator": "^1.0.0"
-         }
-      },
-      "es-object-atoms": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-         "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-         "requires": {
-            "es-errors": "^1.3.0"
-         }
-      },
-      "event-stream": {
-         "version": "4.0.1",
-         "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-         "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-         "requires": {
-            "duplexer": "^0.1.1",
-            "from": "^0.1.7",
-            "map-stream": "0.0.7",
-            "pause-stream": "^0.0.11",
-            "split": "^1.0.1",
-            "stream-combiner": "^0.2.2",
-            "through": "^2.3.8"
-         }
-      },
-      "fast-deep-equal": {
-         "version": "3.1.3",
-         "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-         "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-      },
-      "fast-srp-hap": {
-         "version": "2.0.4",
-         "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
-         "integrity": "sha512-lHRYYaaIbMrhZtsdGTwPN82UbqD9Bv8QfOlKs+Dz6YRnByZifOh93EYmf2iEWFtkOEIqR2IK8cFD0UN5wLIWBQ=="
-      },
-      "for-each": {
-         "version": "0.3.3",
-         "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-         "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-         "requires": {
-            "is-callable": "^1.1.3"
-         }
-      },
-      "from": {
-         "version": "0.1.7",
-         "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-         "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
-      },
-      "function-bind": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-      },
-      "functions-have-names": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-         "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
-      },
-      "get-intrinsic": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-         "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-         "requires": {
-            "call-bind-apply-helpers": "^1.0.2",
-            "es-define-property": "^1.0.1",
-            "es-errors": "^1.3.0",
-            "es-object-atoms": "^1.1.1",
-            "function-bind": "^1.1.2",
-            "get-proto": "^1.0.1",
-            "gopd": "^1.2.0",
-            "has-symbols": "^1.1.0",
-            "hasown": "^2.0.2",
-            "math-intrinsics": "^1.1.0"
-         }
-      },
-      "get-proto": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-         "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-         "requires": {
-            "dunder-proto": "^1.0.1",
-            "es-object-atoms": "^1.0.0"
-         }
-      },
-      "gopd": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-         "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-      },
-      "hap-nodejs": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-1.1.0.tgz",
-         "integrity": "sha512-FVJotfbsUzBY7ydiz9cWDmlmyAHswh0AcLwGJ9T+SuRAVhZYsnoHRpom0si1mWzwXA2k0RqFOn52nssf0AlrGQ==",
-         "requires": {
-            "@homebridge/ciao": "^1.3.0",
-            "@homebridge/dbus-native": "^0.6.0",
-            "bonjour-hap": "^3.8.0",
-            "debug": "^4.3.5",
-            "fast-srp-hap": "^2.0.4",
-            "futoin-hkdf": "^1.5.3",
-            "node-persist": "^0.0.12",
-            "source-map-support": "^0.5.21",
-            "tslib": "^2.6.3",
-            "tweetnacl": "^1.0.3"
-         },
-         "dependencies": {
-            "@homebridge/ciao": {
-               "version": "1.3.0",
-               "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.0.tgz",
-               "integrity": "sha512-PRbY5FiukY13gIDwiAAZng598gMyI61GL9VU19G2CB4D3vNwh8vESgI9TkjeecCDethTqJmNiruYvdunfQkt7w==",
-               "requires": {
-                  "debug": "^4.3.5",
-                  "fast-deep-equal": "^3.1.3",
-                  "source-map-support": "^0.5.21",
-                  "tslib": "^2.6.3"
-               }
-            },
-            "array-flatten": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-               "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
-            },
-            "bonjour-hap": {
-               "version": "3.8.0",
-               "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.8.0.tgz",
-               "integrity": "sha512-l/Ptvrt/pjN2pCgiVyyA0EkE0uVoXXYZ4DW4xhL4kDVBaw0w54/3Jhdhzn5EyT1Z8YhNXiNhSX0uW6xz2zSxqQ==",
-               "requires": {
-                  "array-flatten": "^3.0.0",
-                  "deep-equal": "^2.2.3",
-                  "multicast-dns": "^7.2.5",
-                  "multicast-dns-service-types": "^1.1.0"
-               }
-            },
-            "futoin-hkdf": {
-               "version": "1.5.3",
-               "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
-               "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ=="
-            },
-            "mkdirp": {
-               "version": "0.5.6",
-               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-               "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-               "requires": {
-                  "minimist": "^1.2.6"
-               }
-            },
-            "node-persist": {
-               "version": "0.0.12",
-               "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
-               "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
-               "requires": {
-                  "mkdirp": "~0.5.1",
-                  "q": "~1.1.1"
-               }
-            }
-         }
-      },
-      "has-bigints": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-         "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
-      },
-      "has-property-descriptors": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-         "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-         "requires": {
-            "es-define-property": "^1.0.0"
-         }
-      },
-      "has-symbols": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-         "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-      },
-      "has-tostringtag": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-         "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-         "requires": {
-            "has-symbols": "^1.0.3"
-         }
-      },
-      "hasown": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-         "requires": {
-            "function-bind": "^1.1.2"
-         }
-      },
-      "hexy": {
-         "version": "0.3.5",
-         "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
-         "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw=="
-      },
-      "internal-slot": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-         "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
-         "requires": {
-            "es-errors": "^1.3.0",
-            "hasown": "^2.0.0",
-            "side-channel": "^1.0.4"
-         }
-      },
-      "is-arguments": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-         "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-array-buffer": {
-         "version": "3.0.4",
-         "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-         "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.2.1"
-         }
-      },
-      "is-bigint": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-         "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-         "requires": {
-            "has-bigints": "^1.0.1"
-         }
-      },
-      "is-boolean-object": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-         "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-callable": {
-         "version": "1.2.7",
-         "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-         "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-      },
-      "is-date-object": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-         "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-         "requires": {
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-map": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-         "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-      },
-      "is-number-object": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-         "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-         "requires": {
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-regex": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-         "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-set": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-         "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-      },
-      "is-shared-array-buffer": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-         "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-         "requires": {
-            "call-bind": "^1.0.2"
-         }
-      },
-      "is-string": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-         "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-         "requires": {
-            "has-tostringtag": "^1.0.0"
-         }
-      },
-      "is-symbol": {
-         "version": "1.0.4",
-         "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-         "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-         "requires": {
-            "has-symbols": "^1.0.2"
-         }
-      },
-      "is-weakmap": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-         "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-      },
-      "is-weakset": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-         "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "get-intrinsic": "^1.1.1"
-         }
-      },
-      "isarray": {
-         "version": "2.0.5",
-         "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-         "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-      },
-      "lodash": {
-         "version": "4.17.21",
-         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-         "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-      },
-      "map-stream": {
-         "version": "0.0.7",
-         "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-         "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
-      },
-      "math-intrinsics": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-         "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-      },
-      "minimist": {
-         "version": "1.2.8",
-         "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-         "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-      },
-      "mkdirp": {
-         "version": "3.0.1",
-         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-         "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
-      },
-      "ms": {
-         "version": "2.1.2",
-         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-         "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-      },
-      "multicast-dns": {
-         "version": "7.2.5",
-         "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
-         "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
-         "requires": {
-            "dns-packet": "^5.2.2",
-            "thunky": "^1.0.2"
-         }
-      },
-      "multicast-dns-service-types": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-         "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ=="
-      },
-      "object-inspect": {
-         "version": "1.13.1",
-         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-         "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
-      },
-      "object-is": {
-         "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-         "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-         "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-         }
-      },
-      "object-keys": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-         "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-      },
-      "object.assign": {
-         "version": "4.1.5",
-         "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-         "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-         "requires": {
-            "call-bind": "^1.0.5",
-            "define-properties": "^1.2.1",
-            "has-symbols": "^1.0.3",
-            "object-keys": "^1.1.1"
-         }
-      },
-      "pause-stream": {
-         "version": "0.0.11",
-         "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-         "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-         "requires": {
-            "through": "~2.3"
-         }
-      },
-      "q": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-         "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA=="
-      },
-      "qrcode-svg": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
-         "integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw=="
-      },
-      "regexp.prototype.flags": {
-         "version": "1.5.2",
-         "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-         "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-         "requires": {
-            "call-bind": "^1.0.6",
-            "define-properties": "^1.2.1",
-            "es-errors": "^1.3.0",
-            "set-function-name": "^2.0.1"
-         }
-      },
-      "safe-buffer": {
-         "version": "5.2.1",
-         "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-         "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-      },
-      "sax": {
-         "version": "1.4.1",
-         "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-         "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
-      },
-      "set-function-length": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-         "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
-         "requires": {
-            "define-data-property": "^1.1.2",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.3",
-            "gopd": "^1.0.1",
-            "has-property-descriptors": "^1.0.1"
-         }
-      },
-      "set-function-name": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-         "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-         "requires": {
-            "define-data-property": "^1.0.1",
-            "functions-have-names": "^1.2.3",
-            "has-property-descriptors": "^1.0.0"
-         }
-      },
-      "side-channel": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-         "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
-         "requires": {
-            "call-bind": "^1.0.6",
-            "es-errors": "^1.3.0",
-            "get-intrinsic": "^1.2.4",
-            "object-inspect": "^1.13.1"
-         }
-      },
-      "source-map": {
-         "version": "0.6.1",
-         "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-         "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-      },
-      "source-map-support": {
-         "version": "0.5.21",
-         "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-         "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-         "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-         }
-      },
-      "split": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-         "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-         "requires": {
-            "through": "2"
-         }
-      },
-      "stop-iteration-iterator": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-         "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-         "requires": {
-            "internal-slot": "^1.0.4"
-         }
-      },
-      "stream-combiner": {
-         "version": "0.2.2",
-         "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-         "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
-         "requires": {
-            "duplexer": "~0.1.1",
-            "through": "~2.3.4"
-         }
-      },
-      "through": {
-         "version": "2.3.8",
-         "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-         "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
-      },
-      "thunky": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-         "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
-      },
-      "tslib": {
-         "version": "2.6.3",
-         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-         "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
-      },
-      "tweetnacl": {
-         "version": "1.0.3",
-         "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-         "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-      },
-      "undici-types": {
-         "version": "6.21.0",
-         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-         "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-         "dev": true
-      },
-      "which-boxed-primitive": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-         "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-         "requires": {
-            "is-bigint": "^1.0.1",
-            "is-boolean-object": "^1.1.0",
-            "is-number-object": "^1.0.4",
-            "is-string": "^1.0.5",
-            "is-symbol": "^1.0.3"
-         }
-      },
-      "which-collection": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-         "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-         "requires": {
-            "is-map": "^2.0.1",
-            "is-set": "^2.0.1",
-            "is-weakmap": "^2.0.1",
-            "is-weakset": "^2.0.1"
-         }
-      },
-      "which-typed-array": {
-         "version": "1.1.14",
-         "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-         "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
-         "requires": {
-            "available-typed-arrays": "^1.0.6",
-            "call-bind": "^1.0.5",
-            "for-each": "^0.3.3",
-            "gopd": "^1.0.1",
-            "has-tostringtag": "^1.0.1"
-         }
-      },
-      "xml2js": {
-         "version": "0.6.2",
-         "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-         "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-         "requires": {
-            "sax": ">=0.6.0",
-            "xmlbuilder": "~11.0.0"
-         },
-         "dependencies": {
-            "xmlbuilder": {
-               "version": "11.0.1",
-               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-               "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-            }
          }
       }
    }


### PR DESCRIPTION
## Summary
- Regenerates the stale `package-lock.json` for the homekit plugin
- The old lockfile pinned `hap-nodejs` to `1.1.0`, which pulled in `@homebridge/ciao@1.3.0` (missing the sentPackets fix)
- Regenerating resolves `hap-nodejs@1.2.0` (semver-compatible, within `^1.1.0`), which depends on `@homebridge/ciao: ^1.3.2` and naturally resolves to `1.3.8`
- `ciao@1.3.7` introduced the fix: "MDNSServer sentPackets memory leak" — replaces the unbounded sentPackets array with a hashed Map keyed by MD5 of raw packet bytes, with a self-rescheduling cleanup timer on a 5s TTL
- `ciao@1.3.8` adds additional cleanup for orphaned rejections in advertise/goodbye paths
- Install footprint drops from 114 → 55 packages, 1 vuln → 0 vulns

## Test plan
- [x] `npm install` succeeds
- [x] `npm run build` succeeds  
- [x] Verified `ciao@1.3.8` installed MDNSServer.js contains the `sentPackets` cleanup logic (Map-based, 5s TTL timer, shutdown clear)

## Notes
No code changes — just a lockfile refresh. This is a more targeted fix than #2029, which bumps the full `@homebridge/hap-nodejs` to v2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)