### PR TITLE
fix(homekit): add 6s snapshot timeout to prevent one hung camera from crashing the entire plugin

### DIFF
--- a/plugins/homekit/src/types/camera/camera-snapshot.ts
+++ b/plugins/homekit/src/types/camera/camera-snapshot.ts
@@ -1,10 +1,12 @@
-import { sleep } from "@scrypted/common/src/sleep";
 import sdk, { AudioSensor, Camera, Intercom, Logger, MotionSensor, ScryptedDevice, ScryptedInterface, VideoCamera } from "@scrypted/sdk";
-import throttle from "lodash/throttle";
 import { ResourceRequestReason, SnapshotRequest, SnapshotRequestCallback } from "../../hap";
 import type { HomeKitPlugin } from "../../main";
 
 const { systemManager, mediaManager } = sdk;
+
+// hap-nodejs warns at 8s and gives up at 25s. Stay well under the warning threshold
+// so a hung camera never stalls the HomeKit plugin's event loop.
+const SNAPSHOT_TIMEOUT_MS = 6000;
 
 function recommendSnapshotPlugin(console: Console, log: Logger, message: string) {
     if (systemManager.getDeviceByName('@scrypted/snapshot'))
@@ -30,26 +32,33 @@ export function createSnapshotHandler(device: ScryptedDevice & VideoCamera & Cam
 
     homekitPlugin.snapshotThrottles.set(device.id, takePicture);
 
+    // Race takePicture against a hard timeout so a hung camera can never stall
+    // the HomeKit plugin's event loop long enough to trigger hap-nodejs's slow/
+    // no-response warnings, which have been observed to crash the whole plugin.
+    function takePictureWithTimeout(request: SnapshotRequest): Promise<Buffer> {
+        return Promise.race([
+            takePicture(request),
+            new Promise<never>((_, reject) => {
+                const t = setTimeout(
+                    () => reject(new Error(`${device.name} snapshot timed out after ${SNAPSHOT_TIMEOUT_MS}ms`)),
+                    SNAPSHOT_TIMEOUT_MS,
+                );
+                // Don't let this timer prevent Node from exiting cleanly.
+                t.unref();
+            }),
+        ]);
+    }
+
     async function handleSnapshotRequest(request: SnapshotRequest, callback: SnapshotRequestCallback) {
         try {
             // non zero reason is for homekit secure video... or something else.
             if (request.reason) {
                 console.log('snapshot requested for reason:', request.reason);
-                callback(null, await takePicture(request));
+                callback(null, await takePictureWithTimeout(request));
                 return;
             }
 
-            // console.log(device.name, 'snapshot request', request);
-
-            // an idle Home.app will hit this endpoint every 10 seconds, and slow requests bog up the entire app.
-            // avoid slow requests by prefetching every 9 seconds.
-
-            // snapshots are requested em masse, so trigger them rather than wait for home to
-            // fetch everything serially.
-            // this call is not a bug, to force lodash to take a picture on the trailing edge,
-            // throttle must be called twice.
-
-            callback(null, await takePicture(request));
+            callback(null, await takePictureWithTimeout(request));
         }
         catch (e) {
             console.error('snapshot error', e);


### PR DESCRIPTION
## Problem

When a camera's `takePicture()` hangs indefinitely, hap-nodejs's snapshot timeout timers (8s "slow" warning, 25s "didn't respond") both fire while the Node.js event loop is blocked. This kills the **entire HomeKit plugin** — not just the offending camera — with `Error: disconnect`. All cameras then disappear from HomeKit and take ~7 minutes to come back (60s restart delay + re-advertisement time).

Observed in production: one camera would intermittently hang on snapshot → both hap-nodejs timers fired at the same millisecond → HomeKit plugin crash → all cameras drop from HomeKit simultaneously.

Relevant log sequence:
```
[Camera] The image snapshot handler for the given accessory is slow to respond!
[Camera] The image snapshot handler for the given accessory didn't respond at all!
e HomeKit @scrypted/homekit error Error: disconnect
e HomeKit plugin @scrypted/homekit unexpectedly exited, restarting in 60000ms
```

## Fix

Wrap every `takePicture()` call in `handleSnapshotRequest` with a `Promise.race` against a 6-second timeout — safely under hap-nodejs's 8-second slow-warning threshold.

If a camera hangs, `callback(error)` is called immediately (within 6s) instead of stalling the event loop. hap-nodejs handles the error gracefully for that one camera. All other cameras continue serving snapshots normally.

```typescript
function takePictureWithTimeout(request): Promise<Buffer> {
    return Promise.race([
        takePicture(request),
        new Promise<never>((_, reject) => {
            const t = setTimeout(
                () => reject(new Error(`${device.name} snapshot timed out after ${SNAPSHOT_TIMEOUT_MS}ms`)),
                SNAPSHOT_TIMEOUT_MS,
            );
            t.unref();
        }),
    ]);
}
```

The timeout uses `.unref()` so it does not prevent Node from exiting cleanly.

## Timeout value rationale

| Threshold | Value |
|---|---|
| This fix fires | **6 000 ms** |
| hap-nodejs "slow" warning | 8 000 ms |
| hap-nodejs "didn't respond" / reject | 25 000 ms |

Staying under the 8s warning means hap-nodejs never sees a slow handler for a hanging camera — it just receives a normal error callback.