### PR TITLE
fix(server): treat canMixin "not implemented" as passthrough to break infinite rebuild loop

### DIFF
--- a/server/src/plugin/plugin-device.ts
+++ b/server/src/plugin/plugin-device.ts
@@ -294,6 +294,24 @@ export class PluginDeviceProxyHandler implements PrimitiveProxyHandler<any> {
             };
         }
         catch (e) {
+            // When canMixin throws "not implemented", the mixin provider plugin is
+            // loading or temporarily unavailable. Treat as passthrough (no error flag)
+            // to prevent an infinite rebuild loop:
+            //   error=true → ensureProxy merges old interfaces → setPluginDeviceState
+            //   sees a change → notifyPluginDeviceDescriptorChanged → rebuildMixinTable
+            //   → another canMixin call → throws again → repeat indefinitely.
+            // Returning error=undefined keeps the interface set stable so notify is
+            // never triggered and the loop stops naturally once the plugin is ready.
+            if ((e as Error)?.message?.includes('not implemented')) {
+                console.warn(`Mixin provider ${mixinId} canMixin threw "not implemented" for ${this.id} — treating as temporary passthrough.`);
+                return {
+                    passthrough: true,
+                    allInterfaces,
+                    interfaces: new Set<string>(),
+                    error: undefined!,
+                    proxy: undefined!,
+                };
+            }
             // on any error, do not advertise interfaces
             // on this mixin, so as to prevent total failure?
             // this has been the behavior for a while,


### PR DESCRIPTION
When a mixin provider's canMixin() throws "not implemented" (plugin loading/restarting), the catch block returns error=e (truthy). ensureProxy() then merges old interfaces back, setPluginDeviceState sees a change, calls notifyPluginDeviceDescriptorChanged → rebuildMixinTable → canMixin throws again — infinite loop at ~2/s.

**Impact:** load average spikes to 19+, event loop saturated, plugin pings time out, all plugins restart in cascade. Self-sustaining once started.

**Fix:** Detect the "not implemented" message, return passthrough=true with error=undefined. Interface set stabilizes, notify is never triggered, loop stops.

**Tested live:** load dropped from 19.3 → 1.08 within 90s. All cameras stable in HomeKit.