### PR TITLE
Fix leaking fd due to cleanup

### DIFF
--- a/server/python/cluster_setup.py
+++ b/server/python/cluster_setup.py
@@ -127,9 +127,13 @@ class ClusterSetup:
             except:
                 pass
             finally:
-                self.clusterPeers.pop(clusterPeerKey)
+                self.clusterPeers.pop(clusterPeerKey, None)
                 peer.kill("cluster client killed")
                 writer.close()
+                try:
+                    await writer.wait_closed()
+                except:
+                    pass
 
         clusterRpcServerInfo = await cluster_listen_zero(handleClusterClient)
         self.clusterPort = clusterRpcServerInfo["port"]
@@ -182,7 +186,7 @@ class ClusterSetup:
                     )
                 )
             except:
-                self.clusterPeers.pop(clusterPeerKey)
+                self.clusterPeers.pop(clusterPeerKey, None)
                 raise
 
             async def run_loop():
@@ -191,7 +195,13 @@ class ClusterSetup:
                 except:
                     pass
                 finally:
-                    self.clusterPeers.pop(clusterPeerKey)
+                    self.clusterPeers.pop(clusterPeerKey, None)
+                    clusterPeer.kill("cluster peer killed")
+                    writer.close()
+                    try:
+                        await writer.wait_closed()
+                    except:
+                        pass
 
             asyncio.run_coroutine_threadsafe(run_loop(), self.loop)
             return clusterPeer


### PR DESCRIPTION
Fixes cleanup of Python cluster peers by closing the asyncio writer, waiting for it to close, killing the peer, and defensively removing the cached peer entry.

Observed behavior: the @scrypted/opencv Python plugin accumulated thousands of CLOSE_WAIT sockets after repeated video analysis start/stop cycles. This left stale cluster/RPC peers around and correlated with intermittent video analysis hangs waiting for decoder results.

After this change, restarting the OpenCV plugin and exercising video analysis kept FD counts low and CLOSE_WAIT sockets did not accumulate. Stability of motion detect increased requiring less frequent restart.

[check_scrypted_fds.sh](https://github.com/user-attachments/files/28406211/check_scrypted_fds.sh)

HEALTHY:
 ./check-scrypted-fds.sh
time=2026-05-29T19:03:01Z
container=arch
plugin_pattern=@scrypted/opencv
pid=169
    PID    PPID     ELAPSED STAT %CPU %MEM COMMAND
    169      95  2-06:02:17 Sl   14.8  0.1 /usr/bin/python3 -u /server/node_modules/@scrypted/server/python/plugin_remote.py @scrypted/opencv
fd_count=20
socket_fds=14
tcp_states:
  LISTEN=2
  ESTABLISHED=3
  unknown_or_non_tcp=9
top_fd_targets:
     14 socket:[...]
      1 anon_inode:[eventpoll]
      1 /server/volume/scrypted.db/MANIFEST-010726
      1 /server/volume/scrypted.db/LOG
      1 /server/volume/scrypted.db/LOCK
      1 /server/volume/scrypted.db/010728.log (deleted)
      1 /server/volume/plugins/@scrypted/opencv/zip/1-e5bb1b31e3f4a76f8751aa4121cbb8bf.zip