### PR TITLE
fix(rebroadcast): do not send getStreamLength before play in RTMP client

### DIFF
--- a/plugins/prebuffer-mixin/src/rtmp-client.ts
+++ b/plugins/prebuffer-mixin/src/rtmp-client.ts
@@ -133,16 +133,17 @@ export class RtmpClient {
     }
     this.console?.log('Got createStream _result');
 
-    // Send getStreamLength then play (matching ffmpeg's order)
+    // Compute playPath from the URL (the part after /app/).
+    // Note: do NOT send a getStreamLength command here. ffmpeg's RTMP client only
+    // sends getStreamLength for seekable/VOD streams (libavformat rtmpproto.c
+    // gen_get_stream_length is guarded on RTMP_PT_*), never for live playback.
+    // Some live RTMP servers (e.g. Reolink cameras) FIN the TCP connection on
+    // receiving an unsolicited getStreamLength, which breaks the rebroadcast
+    // prebuffer instantly.
     const parsedUrl = new URL(this.url);
-    // Extract stream name (after /app/)
     const parts = parsedUrl.pathname.split('/');
     const streamName = parts.length > 2 ? parts.slice(2).join('/') : '';
     const playPath = streamName + parsedUrl.search;
-
-    this.console?.log('Sending getStreamLength with path:', playPath);
-    const getStreamLengthData = this.encodeAMF0Command('getStreamLength', this.transactionId++, null, playPath);
-    this.sendMessage(5, 0, RtmpMessageType.COMMAND_AMF0, 0, getStreamLengthData);
 
     this.console?.log('Sending play command with path:', playPath);
     this.sendPlay(this.streamId, playPath);


### PR DESCRIPTION
Fixes #2055.

## Summary

`RtmpClient.setup()` in `plugins/prebuffer-mixin/src/rtmp-client.ts` currently sends an AMF `getStreamLength` command between `createStream` and `play`. Some live RTMP servers — confirmed on Reolink cameras (e.g. Reolink Video Doorbell WiFi, firmware `v3.0.0.4662_2508071282`) — respond by closing the TCP connection (FIN) ~100–150 ms later, before the `play` command can take effect. The rebroadcast prebuffer then enters a tight ~5-second reconnect loop and never produces a usable stream. See #2055 for full reproduction and log evidence.

The original code comment claims to be "matching ffmpeg's order", but ffmpeg's `libavformat` RTMP client (`gen_get_stream_length` in `rtmpproto.c`) only sends `getStreamLength` conditionally for seekable/VOD streams — never as an unconditional preamble to `play` on a live stream. `rtmpdump` behaves the same way. The unconditional send in Scrypted is therefore both inaccurate to the stated intent and actively harmful to at least one popular camera vendor.

## Change

Removes only the three lines that build and send `getStreamLength`:

```diff
-    // Send getStreamLength then play (matching ffmpeg's order)
+    // Compute playPath from the URL (the part after /app/).
+    // Note: do NOT send a getStreamLength command here. ffmpeg's RTMP client only
+    // sends getStreamLength for seekable/VOD streams (libavformat rtmpproto.c
+    // gen_get_stream_length is guarded on RTMP_PT_*), never for live playback.
+    // Some live RTMP servers (e.g. Reolink cameras) FIN the TCP connection on
+    // receiving an unsolicited getStreamLength, which breaks the rebroadcast
+    // prebuffer instantly.
     const parsedUrl = new URL(this.url);
-    // Extract stream name (after /app/)
     const parts = parsedUrl.pathname.split('/');
     const streamName = parts.length > 2 ? parts.slice(2).join('/') : '';
     const playPath = streamName + parsedUrl.search;
 
-    this.console?.log('Sending getStreamLength with path:', playPath);
-    const getStreamLengthData = this.encodeAMF0Command('getStreamLength', this.transactionId++, null, playPath);
-    this.sendMessage(5, 0, RtmpMessageType.COMMAND_AMF0, 0, getStreamLengthData);
-
     this.console?.log('Sending play command with path:', playPath);
     this.sendPlay(this.streamId, playPath);
```

URL parsing, `sendPlay`, and `setBufferLength` are unchanged. `encodeAMF0Command` is still used by `sendConnect`, `sendCreateStream`, and `sendPlay`.

## Verification

Tested on a Reolink Video Doorbell WiFi (`D340W`, firmware `v3.0.0.4662_2508071282`) running against Scrypted `latest` (Docker, with the bundled `@scrypted/prebuffer-mixin@0.10.66`).

Before the change:
- `~11` prebuffer failures per minute on `RTMP sub.bcs`.
- Every `Sending play command` log line is followed by `Socket received FIN` within ~150 ms.
- Rebroadcast never delivers a frame to HomeKit.

After the change (verified with the equivalent surgical patch applied to the deployed minified bundle, then restart of the container):
- `0` FIN events in a 10-minute observation window.
- A single long-lived prebuffer session.
- HomeKit cameras stream normally, and motion-detection events flow during the same session.

## Backwards compatibility

I do not own other RTMP camera brands. Since ffmpeg has always been able to play live RTMP without sending `getStreamLength`, no RTMP server should require it for `play`. If a particular server *does* require it (unlikely for the camera/IPC use-case this plugin targets), the previous behaviour can be restored without breaking the connection by sending `getStreamLength` *only after* receiving an `onStatus` reply to `play` rather than before.
