### PR TITLE
fix(reolink): do not percent-encode RTMP credential params

### DIFF
--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -779,13 +779,21 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
         if (url.protocol !== 'rtmp:') {
             url.username = this.storage.getItem('username');
             url.password = this.storage.getItem('password') || '';
-        } else {
-            const params = url.searchParams;
-            for (const [k, v] of Object.entries(this.client.parameters)) {
-                params.set(k, v);
-            }
+            return url.toString();
         }
-        return url.toString();
+        // The Reolink RTMP server does not percent-decode query parameter
+        // values - it compares the raw bytes from the URL against the stored
+        // password. URLSearchParams.set() percent-encodes values when the URL
+        // is serialised (WHATWG application/x-www-form-urlencoded), which
+        // corrupts passwords containing characters such as '!', '#', '+',
+        // space, etc. Append the credential parameters as raw bytes so the
+        // password is delivered to the camera exactly as the user entered it.
+        // See #1509 for the same class of issue on the HTTP API path.
+        const sep = rtspUrl.includes('?') ? '&' : '?';
+        const extras = Object.entries(this.client.parameters)
+            .map(([k, v]) => `${k}=${v}`)
+            .join('&');
+        return rtspUrl + sep + extras;
     }
 
     async createVideoStream(vso: UrlMediaStreamOptions): Promise<MediaObject> {


### PR DESCRIPTION
Fixes #2057.

## Summary

`ReolinkCamera.addRtspCredentials()` uses `URLSearchParams.set()` to attach the camera credentials onto RTMP URLs. `URLSearchParams.set()` percent-encodes the values when the URL is serialised (it follows the WHATWG `application/x-www-form-urlencoded` serialiser, which percent-encodes `!`, `#`, `+`, space, etc.).

The Reolink RTMP server does **not** percent-decode query parameter values — it compares the raw bytes from the URL against the stored password. So when the plugin uses the `user`/`password` credential path (the path `getLoginParameters` takes on firmware that accepts HEAD-validate auth with an infinite lease, rather than going through the Login API token), passwords containing those characters are silently corrupted on the wire and the camera FINs the connection right after `play`.

See #2057 for evidence (two `ffmpeg` commands that differ only in `!` vs `%21` in the password value — one streams successfully, the other gets killed).

This is in the same family as #1509, which switched the HTTP API onto the Login-API JSON path specifically to avoid URL escaping limitations with some firmware. That PR fixed the HTTP API path; the RTMP URL construction path was left with the same kind of issue, which this change addresses.

## Change

Append the RTMP credential parameters as raw bytes rather than going through `URLSearchParams.set()`. The token-only path is unaffected (hex tokens contain no characters that the encoder would touch).

```diff
     addRtspCredentials(rtspUrl: string) {
         const url = new URL(rtspUrl);
         if (url.protocol !== 'rtmp:') {
             url.username = this.storage.getItem('username');
             url.password = this.storage.getItem('password') || '';
+            return url.toString();
+        }
+        // The Reolink RTMP server does not percent-decode query parameter
+        // values - it compares the raw bytes from the URL against the stored
+        // password. URLSearchParams.set() percent-encodes values when the URL
+        // is serialised (WHATWG application/x-www-form-urlencoded), which
+        // corrupts passwords containing characters such as '!', '#', '+',
+        // space, etc. Append the credential parameters as raw bytes so the
+        // password is delivered to the camera exactly as the user entered it.
+        // See #1509 for the same class of issue on the HTTP API path.
+        const sep = rtspUrl.includes('?') ? '&' : '?';
+        const extras = Object.entries(this.client.parameters)
+            .map(([k, v]) => `${k}=${v}`)
+            .join('&');
+        return rtspUrl + sep + extras;
-        } else {
-            const params = url.searchParams;
-            for (const [k, v] of Object.entries(this.client.parameters)) {
-                params.set(k, v);
-            }
-        }
-        return url.toString();
     }
```

## Backwards compatibility

* **Token credential path** (`client.parameters === { token: '<hex>' }`) — unchanged. Hex tokens contain no characters the encoder would have touched, so the on-wire URL is byte-identical to before.
* **`user`/`password` credential path** with passwords made up only of unreserved characters — unchanged. The encoder was a no-op for these passwords too.
* **`user`/`password` credential path** with passwords containing `!`, `#`, `+`, space, or other characters the WHATWG form-urlencoded serialiser touches — was broken (silent corruption on the wire); is now fixed.

No public API change.

## Scope note

This is **not** the same bug as #2055 / #2056 (the `getStreamLength`-before-`play` issue in the prebuffer-mixin RTMP client, which affects every Reolink user regardless of credential path). They were diagnosed together because the symptoms look identical (`Socket received FIN` immediately after the `play` command), but the root causes are independent and the fixes are in different plugins.
