### PR TITLE
feat(webrtc): add per-camera "Disable Opus Audio" option

### DIFF
--- a/plugins/webrtc/src/main.ts
+++ b/plugins/webrtc/src/main.ts
@@ -37,7 +37,14 @@ function delayWorkerExit(f: ReturnType<WebRTCPlugin['createTrackedFork']>) {
 }
 
 class WebRTCMixin extends SettingsMixinDeviceBase<RTCSignalingClient & VideoCamera & RTCSignalingChannel & Intercom> implements RTCSignalingChannel, VideoCamera, Intercom {
-    storageSettings = new StorageSettings(this, {});
+    storageSettings = new StorageSettings(this, {
+        disableOpusAudio: {
+            title: 'Disable Opus Audio',
+            description: 'Enable this if the camera has crackly or distorted audio. Uses G.711 audio instead of Opus, which fixes the audio on some cameras (such as certain Ring doorbells). Audio quality will be slightly lower.',
+            type: 'boolean',
+            defaultValue: false,
+        },
+    });
     webrtcIntercom: Promise<Intercom>;
 
     constructor(public plugin: WebRTCPlugin, options: SettingsMixinDeviceOptions<RTCSignalingClient & RTCSignalingChannel & Settings & VideoCamera & Intercom>) {
@@ -172,6 +179,7 @@ class WebRTCMixin extends SettingsMixinDeviceBase<RTCSignalingClient & VideoCame
                 mediaStreamOptions: this.createVideoStreamOptions(),
                 startRTCSignalingSession: (session) => this.mixinDevice.startRTCSignalingSession(session),
                 maximumCompatibilityMode: this.plugin.storageSettings.values.maximumCompatibilityMode,
+                disableOpus: this.storageSettings.values.disableOpusAudio,
             });
 
             this.webrtcIntercom = getIntercom();
@@ -723,6 +731,7 @@ export async function fork() {
             mediaStreamOptions: ResponseMediaStreamOptions,
             startRTCSignalingSession: (session: RTCSignalingSession) => Promise<RTCSessionControl | undefined>,
             maximumCompatibilityMode: boolean,
+            disableOpus?: boolean,
         }): Promise<RTCPeerConnectionPipe> {
             try {
                 const ret = await createRTCPeerConnectionSource({
@@ -731,6 +740,7 @@ export async function fork() {
                     mediaStreamOptions: options.mediaStreamOptions,
                     startRTCSignalingSession: (session) => options.startRTCSignalingSession(session),
                     maximumCompatibilityMode: options.maximumCompatibilityMode,
+                    disableOpus: options.disableOpus,
                 });
                 ret.pcClose().finally(() => delayProcessExit());
                 return ret;

--- a/plugins/webrtc/src/wrtc-to-rtsp.ts
+++ b/plugins/webrtc/src/wrtc-to-rtsp.ts
@@ -33,8 +33,9 @@ export async function createRTCPeerConnectionSource(options: {
     mediaStreamOptions: ResponseMediaStreamOptions,
     startRTCSignalingSession: (session: RTCSignalingSession) => Promise<RTCSessionControl | undefined>,
     maximumCompatibilityMode: boolean,
+    disableOpus?: boolean,
 }): Promise<RTCPeerConnectionPipe> {
-    const { mediaStreamOptions, startRTCSignalingSession, mixinId, nativeId, maximumCompatibilityMode } = options;
+    const { mediaStreamOptions, startRTCSignalingSession, mixinId, nativeId, maximumCompatibilityMode, disableOpus } = options;
     const console = mixinId ? sdk.deviceManager.getMixinConsole(mixinId, nativeId) : sdk.deviceManager.getDeviceConsole(nativeId);
 
     const { clientPromise, port } = await listenZeroSingleClient('127.0.0.1');
@@ -67,9 +68,12 @@ export async function createRTCPeerConnectionSource(options: {
             const ret = new RTCPeerConnection({
                 bundlePolicy: setup.configuration?.bundlePolicy as BundlePolicy,
                 codecs: {
-                    audio: [
-                        ...requiredAudioCodecs,
-                    ],
+                    // When disableOpus is set, offer only G.711 so the camera/server transcodes the
+                    // audio server-side instead of forwarding raw Opus. Works around cameras (e.g.
+                    // some Ring doorbells) whose direct WebRTC Opus decodes with crackle.
+                    audio: disableOpus
+                        ? requiredAudioCodecs.filter(c => c.mimeType.toLowerCase() !== 'audio/opus')
+                        : [...requiredAudioCodecs],
                     video: [
                         requiredVideoCodec,
                     ],


### PR DESCRIPTION
## Problem
Some cameras — notably certain Ring Pro doorbells — deliver audio over their
direct WebRTC connection as 60ms SILK Opus that decodes to crackle on every
decoder tested (HomeKit/iOS, ffmpeg, browser), despite byte-perfect, in-order
RTP. Cameras that send 20ms CELT Opus are clean. The corruption is in the
camera's encoding on that path, upstream of Scrypted — which is why transcoding
downstream doesn't fix it.

## Fix
The audio is clean when the camera/media server transcodes it server-side
instead of forwarding raw Opus (Ring does this on a codec mismatch). This adds a
per-camera "Disable Opus Audio" option that offers only G.711 on the receiving
WebRTC connection, forcing that server-side transcode.

- Per-camera setting, default off — no change for existing cameras.
- When enabled: clean H.264 video + stable connection; audio drops to G.711.
- Fixes crackly audio in both live view and recordings.

## Testing
multiple Ring cameras: the affected doorbell goes crackly → clean with the toggle on;
other Ring cameras are unaffected and keep full 48kHz Opus with it off.

Related to #1617 — this matches the symptoms there (Ring doorbell audio crackle
over HomeKit). Would appreciate the reporter confirming whether enabling this
option resolves it on their device.