### PR TITLE
Add HomeKit diagnostics panel

### DIFF
--- a/plugins/homekit/README.md
+++ b/plugins/homekit/README.md
@@ -10,7 +10,7 @@ You can use the admin page provided by your camera manufacturer to configure cod
 
 The HomeKit plugin settings include a Diagnostics section with a read-only snapshot of the current bridge, network, live streaming, and HomeKit Secure Video state.
 
-Use this first when pairing, live streaming, or recording is acting inconsistently. It shows the mDNS advertiser, bind addresses, recently connected HomeKit clients, active live streams, recent RTCP timeouts, active HKSV recording sessions, the last completed HKSV recording, saved HKSV debug clip size, and whether accessories are bridged or standalone.
+Use this first when pairing, live streaming, snapshots, or recording is acting inconsistently. It shows the mDNS advertiser, bind addresses, recently connected HomeKit clients, recent snapshot results, active live streams, recent RTCP timeouts, active HKSV recording sessions, the last completed HKSV recording, saved HKSV debug clip size, ffmpeg timestamp warnings, and whether accessories are bridged or standalone.
 
 If `Save Recordings` debug mode is enabled on a camera, the diagnostics report will call that out so the saved clips do not quietly fill the Scrypted volume.
 

--- a/plugins/homekit/README.md
+++ b/plugins/homekit/README.md
@@ -6,6 +6,14 @@ The HomeKit Plugin bridges compatible devices in Scrypted to HomeKit.
 
 You can use the admin page provided by your camera manufacturer to configure codec settings as required by HomeKit. It is highly recommended to configure the codec settings for *all* the camera substreams by using the [Scrypted Codec Settings guide](https://github.com/koush/scrypted/wiki/Codec-Settings). This will yield optimal local and remote streaming reliability.
 
+## HomeKit Diagnostics
+
+The HomeKit plugin settings include a Diagnostics section with a read-only snapshot of the current bridge, network, live streaming, and HomeKit Secure Video state.
+
+Use this first when pairing, live streaming, or recording is acting inconsistently. It shows the mDNS advertiser, bind addresses, recently connected HomeKit clients, active live streams, recent RTCP timeouts, active HKSV recording sessions, the last completed HKSV recording, saved HKSV debug clip size, and whether accessories are bridged or standalone.
+
+If `Save Recordings` debug mode is enabled on a camera, the diagnostics report will call that out so the saved clips do not quietly fill the Scrypted volume.
+
 ## Troubleshooting
 
 ### HomeKit Secure Video Not Recording

--- a/plugins/homekit/src/diagnostics.ts
+++ b/plugins/homekit/src/diagnostics.ts
@@ -1,0 +1,281 @@
+import sdk from '@scrypted/sdk';
+import packageJson from "../package.json";
+import { getScryptedServerAddresses } from './address-override';
+import type { HomeKitPlugin } from "./main";
+import { getDebugMode } from './types/camera/camera-debug-mode-storage';
+import { getHksvClipStorageStats } from './types/camera/camera-recording-files';
+
+const { deviceManager, systemManager } = sdk;
+
+export interface StreamSessionDiag {
+    sessionId: string;
+    deviceId: string;
+    deviceName?: string;
+    targetAddress?: string;
+    sourceAddress?: string;
+    startedAt: number;
+    negotiatedVideoCodec?: string;
+    negotiatedAudioCodec?: string;
+}
+
+export interface RtcpTimeoutDiag {
+    deviceId: string;
+    deviceName?: string;
+    at: number;
+}
+
+export interface RecordingSessionDiag {
+    key: string;
+    deviceId: string;
+    deviceName?: string;
+    startedAt: number;
+    fragments: number;
+    fragmentBytes: number;
+    lastFragmentAt?: number;
+    path: 'direct-tcp' | 'ffmpeg';
+    negotiatedVideoCodec?: string;
+    negotiatedAudioCodec?: string;
+    firstFragmentKeyframe?: boolean | 'unknown';
+    saveRecordings: boolean;
+}
+
+export interface RecordingResultDiag extends RecordingSessionDiag {
+    durationMs: number;
+    endedAt: number;
+    error?: string;
+}
+
+export interface BridgePublishDiag {
+    state: 'pending' | 'published' | 'error';
+    at: number;
+    error?: string;
+}
+
+export interface DiagnosticsState {
+    bridgePublish: BridgePublishDiag;
+    activeStreamSessions: Map<string, StreamSessionDiag>;
+    lastRtcpTimeout?: RtcpTimeoutDiag;
+    activeRecordingSessions: Map<string, RecordingSessionDiag>;
+    lastRecordingResult?: RecordingResultDiag;
+    completedRecordingCount: number;
+}
+
+export function createDiagnosticsState(): DiagnosticsState {
+    return {
+        bridgePublish: {
+            state: 'pending',
+            at: Date.now(),
+        },
+        activeStreamSessions: new Map(),
+        activeRecordingSessions: new Map(),
+        completedRecordingCount: 0,
+    };
+}
+
+function formatTime(time: number) {
+    if (!time)
+        return 'unknown';
+    return new Date(time).toISOString();
+}
+
+function formatDuration(ms: number) {
+    if (ms === undefined || ms === null)
+        return 'unknown';
+    return `${Math.round(ms / 1000)}s`;
+}
+
+function formatBytes(bytes: number) {
+    if (bytes === undefined || bytes === null)
+        return 'unknown';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let value = bytes;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit++;
+    }
+    return `${unit ? value.toFixed(1) : value} ${units[unit]}`;
+}
+
+function valueOrUnknown(value: any) {
+    if (value === undefined || value === null || value === '')
+        return 'unknown';
+    return value;
+}
+
+function appendSection(lines: string[], title: string) {
+    if (lines.length)
+        lines.push('');
+    lines.push(`${title}:`);
+}
+
+function appendMap<T>(lines: string[], entries: Iterable<T>, formatter: (entry: T) => string) {
+    let count = 0;
+    for (const entry of entries) {
+        lines.push(`- ${formatter(entry)}`);
+        count++;
+    }
+    if (!count)
+        lines.push('- none');
+}
+
+function getDeviceName(id: string) {
+    try {
+        return systemManager.getDeviceById(id)?.name;
+    }
+    catch (e) {
+    }
+}
+
+function getAccessoryIdentitySummary(plugin: HomeKitPlugin, id: string, standalone: boolean) {
+    try {
+        const storage = deviceManager.getMixinStorage(id, plugin.nativeId);
+        const mac = storage.getItem('mac');
+        const resetAccessory = storage.getItem('resetAccessory');
+        if (standalone)
+            return `${getDeviceName(id) || id}: standalone accessory, mac=${mac ? 'present' : 'missing'}, reset=${resetAccessory ? 'set' : 'unset'}`;
+        return `${getDeviceName(id) || id}: bridged accessory, uses bridge identity, reset=${resetAccessory ? 'set' : 'unset'}`;
+    }
+    catch (e) {
+        return `${getDeviceName(id) || id}: ${standalone ? 'standalone' : 'bridged'} accessory, identity=unknown`;
+    }
+}
+
+function escapeHtml(text: string) {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+export async function buildDiagnosticsReport(plugin: HomeKitPlugin): Promise<string> {
+    const lines: string[] = [];
+    const state = plugin.diagnostics;
+
+    appendSection(lines, 'Plugin');
+    lines.push(`Package: ${packageJson.name}`);
+    lines.push(`Version: ${packageJson.version}`);
+
+    appendSection(lines, 'Bridge Publish');
+    lines.push(`State: ${state.bridgePublish.state}`);
+    lines.push(`Updated: ${formatTime(state.bridgePublish.at)}`);
+    if (state.bridgePublish.error)
+        lines.push(`Error: ${state.bridgePublish.error}`);
+
+    appendSection(lines, 'Network');
+    try {
+        lines.push(`mDNS advertiser: ${plugin.getAdvertiser()}`);
+    }
+    catch (e) {
+        lines.push('mDNS advertiser: unknown');
+    }
+    try {
+        const bind = await plugin.getAdvertiserInterfaceBind();
+        lines.push(`mDNS bind addresses: ${Array.isArray(bind) ? bind.join(', ') : valueOrUnknown(bind || 'all addresses')}`);
+    }
+    catch (e) {
+        lines.push('mDNS bind addresses: unknown');
+    }
+    try {
+        const addresses = await getScryptedServerAddresses();
+        lines.push(`Scrypted server addresses: ${addresses?.length ? addresses.join(', ') : 'unknown'}`);
+    }
+    catch (e) {
+        lines.push('Scrypted server addresses: unknown');
+    }
+
+    appendSection(lines, 'HomeKit Connections');
+    appendMap(lines, plugin.seenConnections, address => address);
+
+    appendSection(lines, 'Standalone Accessories');
+    appendMap(lines, plugin.standalones, ([id]) => `${getDeviceName(id) || id} (${id})`);
+
+    appendSection(lines, 'Active Live Streams');
+    appendMap(lines, state.activeStreamSessions.values(), session => {
+        const duration = Date.now() - session.startedAt;
+        return `${session.deviceName || session.deviceId}: session=${session.sessionId}, target=${valueOrUnknown(session.targetAddress)}, source=${valueOrUnknown(session.sourceAddress)}, duration=${formatDuration(duration)}, video=${valueOrUnknown(session.negotiatedVideoCodec)}, audio=${valueOrUnknown(session.negotiatedAudioCodec)}`;
+    });
+
+    appendSection(lines, 'Last Live Stream RTCP Timeout');
+    if (state.lastRtcpTimeout) {
+        lines.push(`Device: ${state.lastRtcpTimeout.deviceName || state.lastRtcpTimeout.deviceId}`);
+        lines.push(`At: ${formatTime(state.lastRtcpTimeout.at)}`);
+    }
+    else {
+        lines.push('none');
+    }
+
+    appendSection(lines, 'Active HKSV Recordings');
+    appendMap(lines, state.activeRecordingSessions.values(), recording => {
+        const duration = Date.now() - recording.startedAt;
+        return `${recording.deviceName || recording.deviceId}: key=${recording.key}, path=${recording.path}, fragments=${recording.fragments}, bytes=${formatBytes(recording.fragmentBytes)}, lastFragment=${formatTime(recording.lastFragmentAt)}, duration=${formatDuration(duration)}, video=${valueOrUnknown(recording.negotiatedVideoCodec)}, audio=${valueOrUnknown(recording.negotiatedAudioCodec)}, saveRecordings=${recording.saveRecordings}`;
+    });
+
+    appendSection(lines, 'Last Completed HKSV Recording');
+    lines.push(`Completed since plugin start: ${state.completedRecordingCount}`);
+    if (state.lastRecordingResult) {
+        const result = state.lastRecordingResult;
+        lines.push(`Device: ${result.deviceName || result.deviceId}`);
+        lines.push(`Path: ${result.path}`);
+        lines.push(`Fragments: ${result.fragments}`);
+        lines.push(`Bytes: ${formatBytes(result.fragmentBytes)}`);
+        lines.push(`Duration: ${formatDuration(result.durationMs)}`);
+        lines.push(`Video: ${valueOrUnknown(result.negotiatedVideoCodec)}`);
+        lines.push(`Audio: ${valueOrUnknown(result.negotiatedAudioCodec)}`);
+        lines.push(`Save Recordings: ${result.saveRecordings}`);
+        lines.push(`Last Fragment: ${formatTime(result.lastFragmentAt)}`);
+        lines.push(`Ended: ${formatTime(result.endedAt)}`);
+        if (result.error)
+            lines.push(`Error: ${result.error}`);
+    }
+    else {
+        lines.push('Last completed: none since plugin start');
+    }
+
+    appendSection(lines, 'HKSV Debug Clips');
+    try {
+        const stats = await getHksvClipStorageStats();
+        lines.push(`Clip count: ${stats.clipCount}`);
+        lines.push(`Total size: ${formatBytes(stats.totalBytes)}`);
+        lines.push(`Scanned: ${formatTime(stats.scannedAt)}`);
+    }
+    catch (e) {
+        lines.push('Clip count: unknown');
+        lines.push('Total size: unknown');
+    }
+
+    appendSection(lines, 'Save Recordings Debug Mode');
+    let saveRecordingCount = 0;
+    for (const cameraMixin of plugin.cameraMixins.values()) {
+        try {
+            const debugMode = getDebugMode(cameraMixin.storage);
+            if (!debugMode.recording)
+                continue;
+            saveRecordingCount++;
+            lines.push(`- ${cameraMixin.name || cameraMixin.id}: Save Recordings is ON`);
+        }
+        catch (e) {
+        }
+    }
+    if (!saveRecordingCount)
+        lines.push('- none');
+
+    appendSection(lines, 'Accessory Identity');
+    const standaloneIds = new Set(plugin.standalones.keys());
+    lines.push('Standalone accessories:');
+    appendMap(lines, standaloneIds, id => getAccessoryIdentitySummary(plugin, id, true));
+
+    lines.push('Bridged camera accessories:');
+    let bridgedCameraCount = 0;
+    for (const cameraMixin of plugin.cameraMixins.values()) {
+        if (standaloneIds.has(cameraMixin.id))
+            continue;
+        bridgedCameraCount++;
+        lines.push(`- ${getAccessoryIdentitySummary(plugin, cameraMixin.id, false)}`);
+    }
+    if (!bridgedCameraCount)
+        lines.push('- none');
+
+    return `<pre>${escapeHtml(lines.join('\n'))}</pre>`;
+}

--- a/plugins/homekit/src/diagnostics.ts
+++ b/plugins/homekit/src/diagnostics.ts
@@ -24,6 +24,16 @@ export interface RtcpTimeoutDiag {
     at: number;
 }
 
+export interface SnapshotDiag {
+    deviceId: string;
+    deviceName?: string;
+    at: number;
+    status: 'success' | 'error';
+    reason?: string;
+    width?: number;
+    height?: number;
+}
+
 export interface RecordingSessionDiag {
     key: string;
     deviceId: string;
@@ -37,6 +47,7 @@ export interface RecordingSessionDiag {
     negotiatedAudioCodec?: string;
     firstFragmentKeyframe?: boolean | 'unknown';
     saveRecordings: boolean;
+    ffmpegWarnings: string[];
 }
 
 export interface RecordingResultDiag extends RecordingSessionDiag {
@@ -55,6 +66,7 @@ export interface DiagnosticsState {
     bridgePublish: BridgePublishDiag;
     activeStreamSessions: Map<string, StreamSessionDiag>;
     lastRtcpTimeout?: RtcpTimeoutDiag;
+    lastSnapshotByDevice: Map<string, SnapshotDiag>;
     activeRecordingSessions: Map<string, RecordingSessionDiag>;
     lastRecordingResult?: RecordingResultDiag;
     completedRecordingCount: number;
@@ -67,6 +79,7 @@ export function createDiagnosticsState(): DiagnosticsState {
             at: Date.now(),
         },
         activeStreamSessions: new Map(),
+        lastSnapshotByDevice: new Map(),
         activeRecordingSessions: new Map(),
         completedRecordingCount: 0,
     };
@@ -117,6 +130,15 @@ function appendMap<T>(lines: string[], entries: Iterable<T>, formatter: (entry: 
     }
     if (!count)
         lines.push('- none');
+}
+
+function appendFfmpegWarnings(lines: string[], warnings: string[]) {
+    if (!warnings?.length)
+        return;
+    lines.push('  FFmpeg warnings:');
+    for (const warning of warnings) {
+        lines.push(`  - ${warning}`);
+    }
 }
 
 function getDeviceName(id: string) {
@@ -188,6 +210,14 @@ export async function buildDiagnosticsReport(plugin: HomeKitPlugin): Promise<str
     appendSection(lines, 'HomeKit Connections');
     appendMap(lines, plugin.seenConnections, address => address);
 
+    appendSection(lines, 'Last Snapshot Results');
+    appendMap(lines, state.lastSnapshotByDevice.values(), snapshot => {
+        const name = snapshot.deviceName || snapshot.deviceId;
+        if (snapshot.status === 'success')
+            return `${name}: success, requested ${snapshot.width}x${snapshot.height}, at=${formatTime(snapshot.at)}`;
+        return `${name}: error, ${valueOrUnknown(snapshot.reason)}, at=${formatTime(snapshot.at)}`;
+    });
+
     appendSection(lines, 'Standalone Accessories');
     appendMap(lines, plugin.standalones, ([id]) => `${getDeviceName(id) || id} (${id})`);
 
@@ -207,10 +237,15 @@ export async function buildDiagnosticsReport(plugin: HomeKitPlugin): Promise<str
     }
 
     appendSection(lines, 'Active HKSV Recordings');
-    appendMap(lines, state.activeRecordingSessions.values(), recording => {
+    let activeRecordingCount = 0;
+    for (const recording of state.activeRecordingSessions.values()) {
         const duration = Date.now() - recording.startedAt;
-        return `${recording.deviceName || recording.deviceId}: key=${recording.key}, path=${recording.path}, fragments=${recording.fragments}, bytes=${formatBytes(recording.fragmentBytes)}, lastFragment=${formatTime(recording.lastFragmentAt)}, duration=${formatDuration(duration)}, video=${valueOrUnknown(recording.negotiatedVideoCodec)}, audio=${valueOrUnknown(recording.negotiatedAudioCodec)}, saveRecordings=${recording.saveRecordings}`;
-    });
+        lines.push(`- ${recording.deviceName || recording.deviceId}: key=${recording.key}, path=${recording.path}, fragments=${recording.fragments}, bytes=${formatBytes(recording.fragmentBytes)}, lastFragment=${formatTime(recording.lastFragmentAt)}, duration=${formatDuration(duration)}, video=${valueOrUnknown(recording.negotiatedVideoCodec)}, audio=${valueOrUnknown(recording.negotiatedAudioCodec)}, saveRecordings=${recording.saveRecordings}`);
+        appendFfmpegWarnings(lines, recording.ffmpegWarnings);
+        activeRecordingCount++;
+    }
+    if (!activeRecordingCount)
+        lines.push('- none');
 
     appendSection(lines, 'Last Completed HKSV Recording');
     lines.push(`Completed since plugin start: ${state.completedRecordingCount}`);
@@ -226,6 +261,7 @@ export async function buildDiagnosticsReport(plugin: HomeKitPlugin): Promise<str
         lines.push(`Save Recordings: ${result.saveRecordings}`);
         lines.push(`Last Fragment: ${formatTime(result.lastFragmentAt)}`);
         lines.push(`Ended: ${formatTime(result.endedAt)}`);
+        appendFfmpegWarnings(lines, result.ffmpegWarnings);
         if (result.error)
             lines.push(`Error: ${result.error}`);
     }

--- a/plugins/homekit/src/main.ts
+++ b/plugins/homekit/src/main.ts
@@ -7,12 +7,14 @@ import { getScryptedServerAddresses } from "./address-override";
 import { maybeAddBatteryService } from './battery';
 import { CameraMixin, canCameraMixin } from './camera-mixin';
 import { SnapshotThrottle, supportedTypes } from './common';
+import { buildDiagnosticsReport, createDiagnosticsState, DiagnosticsState } from './diagnostics';
 import { Accessory, Bridge, Categories, Characteristic, ControllerStorage, HAPStorage, MDNSAdvertiser, PublishInfo, Service } from './hap';
 import { createHAPUsernameStorageSettingsDict, getRandomPort as createRandomPort, getHAPUUID, logConnections, typeToCategory } from './hap-utils';
 import { HOMEKIT_MIXIN, HomekitMixin } from './homekit-mixin';
 import { addAccessoryDeviceInfo } from './info';
 import { randomPinCode } from './pincode';
 import './types';
+import { clearHksvClipStorageStatsCache } from './types/camera/camera-recording-files';
 import { VIDEO_CLIPS_NATIVE_ID } from './types/camera/camera-recording-files';
 import { reorderDevicesByProvider } from './util';
 import { VideoClipsMixinProvider } from './video-clips-provider';
@@ -65,6 +67,7 @@ export class HomeKitPlugin extends ScryptedDeviceBase implements MixinProvider, 
     videoClips: VideoClipsMixinProvider;
     videoClipsId: string;
     cameraMixins = new Map<string, CameraMixin>();
+    diagnostics: DiagnosticsState = createDiagnosticsState();
     storageSettings = new StorageSettings(this, {
         ...createHAPUsernameStorageSettingsDict(this, undefined),
         portOverride: {
@@ -117,6 +120,31 @@ export class HomeKitPlugin extends ScryptedDeviceBase implements MixinProvider, 
             type: 'boolean',
             defaultValue: true,
         },
+        diagnosticsReport: {
+            group: 'Diagnostics',
+            title: 'HomeKit Diagnostics',
+            type: 'html',
+            readonly: true,
+            noStore: true,
+            onGet: async () => {
+                try {
+                    const report = await buildDiagnosticsReport(this);
+                    return {
+                        defaultValue: report,
+                    };
+                }
+                catch (e) {
+                    return {
+                        defaultValue: `<pre>Diagnostics unavailable: ${String(e)}</pre>`,
+                    };
+                }
+            },
+        },
+        refreshDiagnostics: {
+            group: 'Diagnostics',
+            title: 'Refresh Diagnostics',
+            type: 'button',
+        },
     });
     mergedDevices = new Set<string>();
 
@@ -158,6 +186,11 @@ export class HomeKitPlugin extends ScryptedDeviceBase implements MixinProvider, 
     }
 
     async putSetting(key: string, value: string | number | boolean): Promise<void> {
+        if (key === 'refreshDiagnostics') {
+            clearHksvClipStorageStatsCache();
+            return;
+        }
+
         await this.storageSettings.putSetting(key, value);
 
         if (key === this.storageSettings.keys.portOverride) {
@@ -376,9 +409,23 @@ export class HomeKitPlugin extends ScryptedDeviceBase implements MixinProvider, 
             bind,
         };
 
+        this.diagnostics.bridgePublish = {
+            state: 'pending',
+            at: Date.now(),
+        };
         this.bridge.publish(publishInfo, true).then(() => {
+            this.diagnostics.bridgePublish = {
+                state: 'published',
+                at: Date.now(),
+            };
             this.storageSettings.values.qrCode = new QRCode(this.bridge.setupURI()).svg();
             logConnections(this.console, this.bridge, this.seenConnections);
+        }).catch(e => {
+            this.diagnostics.bridgePublish = {
+                state: 'error',
+                error: String(e),
+                at: Date.now(),
+            };
         });
 
         systemManager.listen(async (eventSource, eventDetails, eventData) => {

--- a/plugins/homekit/src/types/camera/camera-recording-files.ts
+++ b/plugins/homekit/src/types/camera/camera-recording-files.ts
@@ -11,6 +11,57 @@ export interface HksvVideoClip extends VideoClip {
     fragments: number;
 }
 
+export interface HksvClipStorageStats {
+    clipCount: number;
+    totalBytes: number;
+    scannedAt: number;
+}
+
+const hksvClipStatsTtl = 60000;
+let hksvClipStatsCache: HksvClipStorageStats;
+let hksvClipStatsCacheExpires = 0;
+
+export function clearHksvClipStorageStatsCache() {
+    hksvClipStatsCacheExpires = 0;
+}
+
+export async function getHksvClipStorageStats(): Promise<HksvClipStorageStats> {
+    const now = Date.now();
+    if (hksvClipStatsCache && now < hksvClipStatsCacheExpires)
+        return hksvClipStatsCache;
+
+    let clipCount = 0;
+    let totalBytes = 0;
+    try {
+        const savePath = await getSavePath();
+        const allFiles = await fs.promises.readdir(savePath);
+        const jsonFiles = allFiles.filter(file => file.endsWith('.json'));
+        clipCount = jsonFiles.length;
+
+        for (const jsonFile of jsonFiles) {
+            const hksvId = jsonFile.slice(0, -'.json'.length);
+            try {
+                const { id, startTime } = parseHksvId(hksvId);
+                const { mp4Path } = await getCameraRecordingFiles(id, startTime);
+                const stat = await fs.promises.stat(mp4Path);
+                totalBytes += stat.size;
+            }
+            catch (e) {
+            }
+        }
+    }
+    catch (e) {
+    }
+
+    hksvClipStatsCache = {
+        clipCount,
+        totalBytes,
+        scannedAt: now,
+    };
+    hksvClipStatsCacheExpires = now + hksvClipStatsTtl;
+    return hksvClipStatsCache;
+}
+
 export async function nukeClips() {
     const savePath = await getSavePath();
     await fs.promises.rm(savePath, { recursive: true, force: true });

--- a/plugins/homekit/src/types/camera/camera-recording.ts
+++ b/plugins/homekit/src/types/camera/camera-recording.ts
@@ -257,6 +257,21 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
         negotiatedAudioCodec: audioCodec,
         firstFragmentKeyframe: 'unknown',
         saveRecordings,
+        ffmpegWarnings: [],
+    });
+    const warningRe = /Timestamps are unset|Non-monotonic DTS|invalid timestamp|queue input is backward/;
+    session.cp?.stderr?.on('data', (data: Buffer) => {
+        const recordingDiag = homekitPlugin.diagnostics.activeRecordingSessions.get(recordingDiagKey);
+        if (!recordingDiag)
+            return;
+        for (const line of data.toString().split('\n')) {
+            const warning = line.trim();
+            if (!warningRe.test(warning))
+                continue;
+            recordingDiag.ffmpegWarnings.push(warning);
+            if (recordingDiag.ffmpegWarnings.length > 10)
+                recordingDiag.ffmpegWarnings.shift();
+        }
     });
     let recordingFile: Writable;
     const saveFragment = async (i: number, fragment: Buffer) => {

--- a/plugins/homekit/src/types/camera/camera-recording.ts
+++ b/plugins/homekit/src/types/camera/camera-recording.ts
@@ -244,6 +244,20 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
     }
 
     const start = Date.now();
+    const recordingDiagKey = `${device.id}-${start}`;
+    homekitPlugin.diagnostics.activeRecordingSessions.set(recordingDiagKey, {
+        key: recordingDiagKey,
+        deviceId: device.id,
+        deviceName: device.name,
+        startedAt: start,
+        fragments: 0,
+        fragmentBytes: 0,
+        path: needsFFmpeg ? 'ffmpeg' : 'direct-tcp',
+        negotiatedVideoCodec: videoCodec,
+        negotiatedAudioCodec: audioCodec,
+        firstFragmentKeyframe: 'unknown',
+        saveRecordings,
+    });
     let recordingFile: Writable;
     const saveFragment = async (i: number, fragment: Buffer) => {
         if (!saveRecordings)
@@ -290,6 +304,7 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
     }, maxVideoDuration);
 
     let pending: Buffer[] = [];
+    let recordingError: string;
     try {
         let i = 0;
         // if ffmpeg is being used to parse a prebuffered stream that is NOT mp4 (despite our request),
@@ -349,6 +364,12 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
                 saveFragment(i, fragment);
                 pending = [];
                 console.log(`motion fragment #${++i} sent. size:`, fragment.length);
+                const recordingDiag = homekitPlugin.diagnostics.activeRecordingSessions.get(recordingDiagKey);
+                if (recordingDiag) {
+                    recordingDiag.fragments = i;
+                    recordingDiag.fragmentBytes += fragment.length;
+                    recordingDiag.lastFragmentAt = Date.now();
+                }
                 const wasLast = isLast;
                 const recordingPacket: RecordingPacket = {
                     data: fragment,
@@ -361,10 +382,23 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
         }
     }
     catch (e) {
+        recordingError = e?.message || String(e);
         console.log(`motion recording error ${e}`);
     }
     finally {
         console.log(`motion recording finished`);
+        const recordingDiag = homekitPlugin.diagnostics.activeRecordingSessions.get(recordingDiagKey);
+        if (recordingDiag) {
+            const endedAt = Date.now();
+            homekitPlugin.diagnostics.completedRecordingCount++;
+            homekitPlugin.diagnostics.lastRecordingResult = {
+                ...recordingDiag,
+                durationMs: endedAt - recordingDiag.startedAt,
+                endedAt,
+                error: recordingError,
+            };
+            homekitPlugin.diagnostics.activeRecordingSessions.delete(recordingDiagKey);
+        }
         clearTimeout(videoTimeout);
         cleanupPipes();
         recordingFile?.end();

--- a/plugins/homekit/src/types/camera/camera-snapshot.ts
+++ b/plugins/homekit/src/types/camera/camera-snapshot.ts
@@ -25,7 +25,18 @@ export function createSnapshotHandler(device: ScryptedDevice & VideoCamera & Cam
                 height: request.height,
             },
         })
-        return await mediaManager.convertMediaObjectToBuffer(media, 'image/jpeg');
+        if (!media)
+            throw new Error(`${device.name} snapshot provider returned no media`);
+        const buffer = await mediaManager.convertMediaObjectToBuffer(media, 'image/jpeg');
+        homekitPlugin.diagnostics.lastSnapshotByDevice.set(device.id, {
+            deviceId: device.id,
+            deviceName: device.name,
+            at: Date.now(),
+            status: 'success',
+            width: request.width,
+            height: request.height,
+        });
+        return buffer;
     }
 
     homekitPlugin.snapshotThrottles.set(device.id, takePicture);
@@ -53,6 +64,13 @@ export function createSnapshotHandler(device: ScryptedDevice & VideoCamera & Cam
         }
         catch (e) {
             console.error('snapshot error', e);
+            homekitPlugin.diagnostics.lastSnapshotByDevice.set(device.id, {
+                deviceId: device.id,
+                deviceName: device.name,
+                at: Date.now(),
+                status: 'error',
+                reason: e?.message || String(e),
+            });
             recommendSnapshotPlugin(console, homekitPlugin.log, `${device.name} encountered an error while retrieving a new snapshot. Consider installing the Snapshot Plugin to show the most recent snapshot. origin:/#/component/plugin/install/@scrypted/snapshot}`);
             callback(e);
         }

--- a/plugins/homekit/src/types/camera/camera-streaming.ts
+++ b/plugins/homekit/src/types/camera/camera-streaming.ts
@@ -53,6 +53,7 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
                     if (!session)
                         return;
                     sessions.delete(sessionID);
+                    homekitPlugin.diagnostics.activeStreamSessions.delete(sessionID);
 
                     console.log(`streaming session killed, duration: ${Math.round((Date.now() - streamingSessionStartTime) / 1000)}s`);
                     session.killed = true;
@@ -140,6 +141,14 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
             };
 
             sessions.set(request.sessionID, session);
+            homekitPlugin.diagnostics.activeStreamSessions.set(request.sessionID, {
+                sessionId: request.sessionID,
+                deviceId: device.id,
+                deviceName: device.name,
+                targetAddress: session.prepareRequest.targetAddress,
+                sourceAddress,
+                startedAt: streamingSessionStartTime,
+            });
 
             const response: PrepareStreamResponse = {
                 video: {
@@ -233,6 +242,11 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
             const videoReturnRtcpReady = waitRtcp
                 ? timeoutPromise(1000, once(session.videoReturn, 'message')).catch(() => {
                     console.warn('Video RTCP Packet timed out. There may be a network (routing/firewall) issue preventing the Apple device sending UDP packets back to Scrypted.');
+                    homekitPlugin.diagnostics.lastRtcpTimeout = {
+                        deviceId: device.id,
+                        deviceName: device.name,
+                        at: Date.now(),
+                    };
                 })
                 : undefined;
             session.videoReturnRtcpReady = videoReturnRtcpReady;
@@ -302,6 +316,11 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
 
             const mediaObject = await device.getVideoStream(mediaOptions);
             const videoInput = await mediaManager.convertMediaObjectToJSON<FFmpegInput>(mediaObject, ScryptedMimeTypes.FFmpegInput);
+            const streamDiag = homekitPlugin.diagnostics.activeStreamSessions.get(request.sessionID);
+            if (streamDiag) {
+                streamDiag.negotiatedVideoCodec = videoInput.mediaStreamOptions?.video?.codec;
+                streamDiag.negotiatedAudioCodec = videoInput.mediaStreamOptions?.audio?.codec || mediaOptions.audio?.codec;
+            }
             let mediaStreamFeedback: MediaStreamFeedback;
             try {
                 // homekit mtu is unusable. webrtc uses 1200 due to weird cell networks, vpns, etc.


### PR DESCRIPTION
Once the HomeKit plugin is running, it's basically a black box. When a camera stops recording to HomeKit Secure Video or a pairing won't show up in the Home app, there's nothing to look at  which mDNS advertiser it picked, what it bound to, whether the bridge published, which Apple device is connecting, or whether a recording session is even producing fragments. Figuring that out means SSHing in and reading log lines. This is mostly the case when you are on Docker with multi ethernet/Vlan networking.

This adds a read-only Diagnostics section to the plugin settings that puts it all in one place: bridge publish state, mDNS advertiser and bind addresses, connected HomeKit clients, active live streams and the last RTCP timeout, HKSV recording sessions with fragment counts, and how much disk the debug clips are using (they pile up fast when Save Recordings is left on). It's visibility only  nothing here changes pairing, streaming, or recording. The point is to be able to see what's happening before touching the parts that affect pairing.