### PR TITLE
twelvelabs: add Pegasus video understanding plugin

### DIFF
--- a/plugins/twelvelabs/.gitignore
+++ b/plugins/twelvelabs/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+out/
+node_modules/
+dist/
+.venv

--- a/plugins/twelvelabs/.npmignore
+++ b/plugins/twelvelabs/.npmignore
@@ -1,0 +1,9 @@
+.DS_Store
+out/
+node_modules/
+*.map
+src
+test
+.vscode
+dist/*.js
+.venv

--- a/plugins/twelvelabs/README.md
+++ b/plugins/twelvelabs/README.md
@@ -1,0 +1,39 @@
+# Twelve Labs Pegasus for Scrypted
+
+This plugin adds a [Twelve Labs](https://twelvelabs.io) Pegasus video-understanding
+device to Scrypted. Pegasus is a video-native model: given a video clip and a natural
+language prompt, it returns a text description of what happens in the clip.
+
+The plugin exposes a `ChatCompletion` device, so any Scrypted flow that can call a chat
+completion (NVR event pipelines, notifier automations, scripts) can turn a camera event
+clip into a natural-language description — for example "a delivery person left a package
+on the porch" instead of a generic "motion detected".
+
+## Setup
+
+1. Install the plugin.
+2. Get a free API key with a generous free tier at https://twelvelabs.io.
+3. Open the plugin settings and paste the **API Key**.
+
+That's it. Nothing runs until an API key is configured, and the plugin changes no Scrypted
+defaults.
+
+## Settings
+
+* **API Key** — your Twelve Labs API key (stored as a password).
+* **Pegasus Model** — the Pegasus model used for video understanding (defaults to `pegasus1.5`).
+* **API Base URL** — override only if you are self-hosting a proxy.
+
+## Usage
+
+Send a chat completion to the device with a video reference in the message content. The
+video can be:
+
+* an `http(s)` URL to a video file, or
+* a `data:video/...;base64,...` URL carrying the clip bytes (e.g. a Scrypted event clip).
+
+The message text becomes the prompt. If no prompt is provided, the plugin defaults to
+"Describe what happens in this video."
+
+Pegasus analyzes video, not still images, so image-only requests are rejected with a clear
+error.

--- a/plugins/twelvelabs/package-lock.json
+++ b/plugins/twelvelabs/package-lock.json
@@ -1,0 +1,85 @@
+{
+   "name": "@scrypted/twelvelabs",
+   "version": "0.0.1",
+   "lockfileVersion": 3,
+   "requires": true,
+   "packages": {
+      "": {
+         "name": "@scrypted/twelvelabs",
+         "version": "0.0.1",
+         "license": "Apache-2.0",
+         "dependencies": {
+            "@types/node": "^22.10.2"
+         },
+         "devDependencies": {
+            "@scrypted/sdk": "file:../../sdk"
+         }
+      },
+      "../../sdk": {
+         "name": "@scrypted/sdk",
+         "version": "0.5.59",
+         "dev": true,
+         "license": "ISC",
+         "dependencies": {
+            "@babel/preset-typescript": "^7.27.1",
+            "@rollup/plugin-commonjs": "^28.0.9",
+            "@rollup/plugin-json": "^6.1.0",
+            "@rollup/plugin-node-resolve": "^16.0.1",
+            "@rollup/plugin-terser": "^0.4.4",
+            "@rollup/plugin-typescript": "^12.3.0",
+            "@rollup/plugin-virtual": "^3.0.2",
+            "@scrypted/auth-fetch": "^1.0.5",
+            "adm-zip": "^0.5.16",
+            "babel-loader": "^10.0.0",
+            "babel-plugin-const-enum": "^1.2.0",
+            "ncp": "^2.0.0",
+            "openai": "^6.1.0",
+            "raw-loader": "^4.0.2",
+            "rimraf": "^6.0.1",
+            "rollup": "^4.52.5",
+            "tmp": "^0.2.3",
+            "ts-loader": "^9.5.4",
+            "tslib": "^2.8.1",
+            "typescript": "^5.9.3",
+            "webpack": "^5.99.9",
+            "webpack-bundle-analyzer": "^4.10.2"
+         },
+         "bin": {
+            "scrypted-changelog": "bin/cli.js",
+            "scrypted-debug": "bin/cli.js",
+            "scrypted-deploy": "bin/cli.js",
+            "scrypted-deploy-debug": "bin/cli.js",
+            "scrypted-package-json": "bin/cli.js",
+            "scrypted-setup-project": "bin/cli.js",
+            "scrypted-webpack": "bin/cli.js"
+         },
+         "devDependencies": {
+            "@types/adm-zip": "^0.5.8",
+            "@types/ncp": "^2.0.8",
+            "@types/node": "^24.9.2",
+            "@types/tmp": "^0.2.6",
+            "ts-node": "^10.9.2",
+            "typedoc": "^0.28.14"
+         }
+      },
+      "node_modules/@scrypted/sdk": {
+         "resolved": "../../sdk",
+         "link": true
+      },
+      "node_modules/@types/node": {
+         "version": "22.20.0",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+         "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+         "license": "MIT",
+         "dependencies": {
+            "undici-types": "~6.21.0"
+         }
+      },
+      "node_modules/undici-types": {
+         "version": "6.21.0",
+         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+         "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+         "license": "MIT"
+      }
+   }
+}

--- a/plugins/twelvelabs/package.json
+++ b/plugins/twelvelabs/package.json
@@ -1,0 +1,44 @@
+{
+   "name": "@scrypted/twelvelabs",
+   "version": "0.0.1",
+   "description": "Twelve Labs Pegasus video understanding plugin for Scrypted",
+   "author": "Mohit Varikuti",
+   "license": "Apache-2.0",
+   "scripts": {
+      "scrypted-setup-project": "scrypted-setup-project",
+      "prescrypted-setup-project": "scrypted-package-json",
+      "build": "scrypted-webpack",
+      "prepublishOnly": "NODE_ENV=production scrypted-webpack",
+      "prescrypted-vscode-launch": "scrypted-webpack",
+      "scrypted-vscode-launch": "scrypted-deploy-debug",
+      "scrypted-deploy-debug": "scrypted-deploy-debug",
+      "scrypted-debug": "scrypted-debug",
+      "scrypted-deploy": "scrypted-deploy",
+      "scrypted-readme": "scrypted-readme",
+      "scrypted-package-json": "scrypted-package-json",
+      "test": "node --test --experimental-transform-types"
+   },
+   "keywords": [
+      "scrypted",
+      "plugin",
+      "twelvelabs",
+      "pegasus",
+      "video",
+      "ai",
+      "llm"
+   ],
+   "scrypted": {
+      "name": "Twelve Labs Pegasus",
+      "type": "API",
+      "interfaces": [
+         "Settings",
+         "ChatCompletion"
+      ]
+   },
+   "dependencies": {
+      "@types/node": "^22.10.2"
+   },
+   "devDependencies": {
+      "@scrypted/sdk": "file:../../sdk"
+   }
+}

--- a/plugins/twelvelabs/src/extract.ts
+++ b/plugins/twelvelabs/src/extract.ts
@@ -1,0 +1,98 @@
+// Pull the prompt text and a single video source out of an OpenAI-shaped
+// ChatCompletion request body. Kept pure (no network, no SDK) so it can be
+// unit tested directly.
+//
+// Pegasus is video-native, so we look for a video reference in the message
+// content. Two forms are supported:
+//   - an http(s) URL to a video file (image_url / video_url / input_video parts,
+//     or a bare URL in text)
+//   - a data: URL carrying base64 video bytes (e.g. a Scrypted event clip)
+// Image-only inputs are rejected with a clear error, since Pegasus analyzes
+// video, not stills.
+
+import type { PegasusVideo } from './pegasus';
+
+export interface ExtractedAnalyzeInput {
+    prompt: string;
+    video: PegasusVideo;
+}
+
+const VIDEO_URL_RE = /\bhttps?:\/\/\S+\.(?:mp4|mov|m4v|webm|mkv|avi|ts)\b/i;
+const DATA_VIDEO_RE = /^data:video\/[^;]+;base64,(.+)$/i;
+
+function urlToVideo(url: string): PegasusVideo | undefined {
+    const data = DATA_VIDEO_RE.exec(url);
+    if (data)
+        return { type: 'base64_string', base64_string: data[1] };
+    if (/^https?:\/\//i.test(url))
+        return { type: 'url', url };
+    return undefined;
+}
+
+// Collect plain text and candidate URLs from a single message's content,
+// which per the OpenAI schema is either a string or an array of content parts.
+function collectFromContent(content: any, texts: string[], urls: string[]) {
+    if (content == null)
+        return;
+    if (typeof content === 'string') {
+        texts.push(content);
+        return;
+    }
+    if (!Array.isArray(content))
+        return;
+    for (const part of content) {
+        if (typeof part === 'string') {
+            texts.push(part);
+            continue;
+        }
+        if (typeof part?.text === 'string')
+            texts.push(part.text);
+        // image_url is the standard vision part; we reuse it (and the
+        // analogous video_url / input_video forms) to carry a video reference.
+        const url = part?.image_url?.url
+            ?? part?.video_url?.url
+            ?? part?.input_video?.url
+            ?? (typeof part?.url === 'string' ? part.url : undefined);
+        if (typeof url === 'string')
+            urls.push(url);
+    }
+}
+
+export function extractAnalyzeInput(body: any): ExtractedAnalyzeInput {
+    const messages: any[] = Array.isArray(body?.messages) ? body.messages : [];
+    const texts: string[] = [];
+    const urls: string[] = [];
+
+    for (const message of messages)
+        collectFromContent(message?.content, texts, urls);
+
+    let video: PegasusVideo | undefined;
+    // Prefer an explicit URL/data part.
+    for (const url of urls) {
+        const v = urlToVideo(url);
+        if (v) {
+            video = v;
+            break;
+        }
+    }
+    // Fall back to a video URL embedded in the prompt text. Strip the matched
+    // URL out so it doesn't leak into the prompt Pegasus receives.
+    if (!video) {
+        for (let i = 0; i < texts.length; i++) {
+            const match = VIDEO_URL_RE.exec(texts[i]);
+            if (match) {
+                video = { type: 'url', url: match[0] };
+                texts[i] = texts[i].replace(match[0], '');
+                break;
+            }
+        }
+    }
+
+    if (!video)
+        throw new Error('no video found in the request. Twelve Labs Pegasus analyzes video; provide a video URL or a base64 video data: URL in the message content.');
+
+    const prompt = texts.map(t => t.trim()).filter(Boolean).join('\n').trim()
+        || 'Describe what happens in this video.';
+
+    return { prompt, video };
+}

--- a/plugins/twelvelabs/src/main.ts
+++ b/plugins/twelvelabs/src/main.ts
@@ -1,0 +1,135 @@
+import sdk, {
+    ChatCompletion,
+    ChatCompletionCapabilities,
+    ChatCompletionCreateParamsNonStreaming,
+    ChatCompletionResponse,
+    ScryptedDeviceBase,
+    Setting,
+    Settings,
+    SettingValue,
+} from '@scrypted/sdk';
+import { StorageSettings } from '@scrypted/sdk/storage-settings';
+import { extractAnalyzeInput } from './extract';
+import { DEFAULT_BASE_URL, DEFAULT_MODEL, PegasusClient } from './pegasus';
+
+// Twelve Labs Pegasus plugin: exposes a ChatCompletion device that describes
+// video using the Twelve Labs Analyze (Pegasus) API. It is fully opt-in —
+// nothing runs until the user enters an API key — and changes no Scrypted
+// defaults. Point an NVR/notifier flow at this device to turn camera event
+// clips into natural-language descriptions.
+class TwelveLabsPlugin extends ScryptedDeviceBase implements Settings, ChatCompletion {
+    storageSettings = new StorageSettings(this, {
+        apiKey: {
+            title: 'API Key',
+            description: 'Twelve Labs API key. Get a free key with a generous free tier at https://twelvelabs.io.',
+            type: 'password',
+        },
+        model: {
+            title: 'Pegasus Model',
+            description: 'The Pegasus model used for video understanding.',
+            defaultValue: DEFAULT_MODEL,
+            choices: ['pegasus1.5', 'pegasus1.2'],
+        },
+        baseUrl: {
+            title: 'API Base URL',
+            description: 'Override the Twelve Labs API base URL. Leave as default unless self-hosting a proxy.',
+            defaultValue: DEFAULT_BASE_URL,
+        },
+    });
+
+    // Pegasus understands video and produces text. It does not generate images
+    // or audio, and the analyze endpoint requires a video input.
+    chatCompletionCapabilities: ChatCompletionCapabilities = {
+        image: true,
+    };
+
+    async getSettings(): Promise<Setting[]> {
+        return this.storageSettings.getSettings();
+    }
+
+    async putSetting(key: string, value: SettingValue): Promise<void> {
+        await this.storageSettings.putSetting(key, value);
+    }
+
+    private getClient(): PegasusClient {
+        const apiKey = this.storageSettings.values.apiKey;
+        if (!apiKey)
+            throw new Error('Twelve Labs API key is not set. Configure it in the plugin settings.');
+        return new PegasusClient(apiKey, this.storageSettings.values.baseUrl || DEFAULT_BASE_URL);
+    }
+
+    async getChatCompletion(body: ChatCompletionCreateParamsNonStreaming): Promise<ChatCompletionResponse> {
+        const { prompt, video } = extractAnalyzeInput(body);
+        const client = this.getClient();
+        const result = await client.analyze({
+            prompt,
+            video,
+            modelName: this.storageSettings.values.model || DEFAULT_MODEL,
+            temperature: body.temperature ?? undefined,
+            maxTokens: body.max_tokens ?? undefined,
+        });
+
+        const created = Math.floor(Date.now() / 1000);
+        return {
+            id: result.id,
+            object: 'chat.completion',
+            created,
+            model: this.storageSettings.values.model || DEFAULT_MODEL,
+            choices: [
+                {
+                    index: 0,
+                    finish_reason: (result.finishReason as any) || 'stop',
+                    logprobs: null,
+                    message: {
+                        role: 'assistant',
+                        content: result.data,
+                        refusal: null,
+                    },
+                },
+            ],
+            usage: {
+                prompt_tokens: 0,
+                completion_tokens: result.outputTokens ?? 0,
+                total_tokens: result.outputTokens ?? 0,
+            },
+        } as ChatCompletionResponse;
+    }
+
+    // Pegasus analyze is request/response, not incremental. Wrap the result as a
+    // single-chunk stream so streaming consumers still work.
+    async streamChatCompletion(params: any, _newMessages?: any, callback?: any): Promise<any> {
+        const completion = await this.getChatCompletion(params);
+        const choice = completion.choices[0];
+
+        const chunk: any = {
+            id: completion.id,
+            object: 'chat.completion.chunk',
+            created: completion.created,
+            model: completion.model,
+            choices: [
+                {
+                    index: 0,
+                    delta: { role: 'assistant', content: choice.message.content },
+                    finish_reason: choice.finish_reason,
+                    logprobs: null,
+                },
+            ],
+        };
+
+        if (typeof callback === 'function') {
+            await callback(chunk);
+            async function* single() {
+                yield completion;
+            }
+            return single();
+        }
+
+        async function* stream() {
+            yield chunk;
+            yield completion;
+        }
+        return stream();
+    }
+}
+
+export default TwelveLabsPlugin;

--- a/plugins/twelvelabs/src/pegasus.ts
+++ b/plugins/twelvelabs/src/pegasus.ts
@@ -1,0 +1,93 @@
+// Minimal client for the Twelve Labs Analyze (Pegasus) API.
+// https://docs.twelvelabs.io/v1.3/api-reference/analyze-videos
+//
+// Pegasus is a video understanding model: it takes a video (by URL or as
+// base64 data) plus a natural language prompt, and returns a text description.
+// This client intentionally covers only the analyze endpoint used by the
+// plugin; it has no other dependencies so it is trivially unit testable.
+
+export const DEFAULT_BASE_URL = 'https://api.twelvelabs.io/v1.3';
+export const DEFAULT_MODEL = 'pegasus1.5';
+
+export type PegasusVideo =
+    | { type: 'url'; url: string }
+    | { type: 'base64_string'; base64_string: string };
+
+export interface PegasusAnalyzeRequest {
+    video: PegasusVideo;
+    prompt: string;
+    modelName?: string;
+    temperature?: number;
+    maxTokens?: number;
+}
+
+export interface PegasusAnalyzeResult {
+    id: string;
+    data: string;
+    finishReason?: string;
+    outputTokens?: number;
+}
+
+// Build the JSON body for POST /analyze. Extracted so it can be unit tested
+// without performing any network IO.
+export function buildAnalyzeBody(req: PegasusAnalyzeRequest): Record<string, any> {
+    if (!req.prompt)
+        throw new Error('a prompt is required');
+    if (!req.video)
+        throw new Error('a video (url or base64) is required');
+
+    const body: Record<string, any> = {
+        model_name: req.modelName || DEFAULT_MODEL,
+        stream: false,
+        prompt: req.prompt,
+        video: req.video,
+    };
+    if (req.temperature !== undefined)
+        body.temperature = req.temperature;
+    if (req.maxTokens !== undefined)
+        body.max_tokens = req.maxTokens;
+    return body;
+}
+
+export class PegasusClient {
+    constructor(
+        private apiKey: string,
+        private baseUrl: string = DEFAULT_BASE_URL,
+        // injectable for tests; defaults to global fetch (Node 18+).
+        private fetchImpl: typeof fetch = fetch,
+    ) {
+        if (!apiKey)
+            throw new Error('a Twelve Labs API key is required');
+    }
+
+    async analyze(req: PegasusAnalyzeRequest): Promise<PegasusAnalyzeResult> {
+        const res = await this.fetchImpl(`${this.baseUrl}/analyze`, {
+            method: 'POST',
+            headers: {
+                'x-api-key': this.apiKey,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(buildAnalyzeBody(req)),
+        });
+
+        const text = await res.text();
+        if (!res.ok) {
+            let message = text;
+            try {
+                message = JSON.parse(text).message || text;
+            }
+            catch {
+                // not json; use raw text
+            }
+            throw new Error(`Twelve Labs analyze failed (${res.status}): ${message}`);
+        }
+
+        const json = JSON.parse(text);
+        return {
+            id: json.id,
+            data: json.data,
+            finishReason: json.finish_reason,
+            outputTokens: json.usage?.output_tokens,
+        };
+    }
+}

--- a/plugins/twelvelabs/test/twelvelabs.test.ts
+++ b/plugins/twelvelabs/test/twelvelabs.test.ts
@@ -1,0 +1,141 @@
+// Unit tests for the pure (no-network) pieces of the Twelve Labs plugin, plus
+// an optional live smoke test gated on TWELVELABS_API_KEY.
+//
+// Run: npm test   (uses node --test --experimental-strip-types)
+
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { buildAnalyzeBody, DEFAULT_MODEL, PegasusClient } from '../src/pegasus.ts';
+import { extractAnalyzeInput } from '../src/extract.ts';
+
+test('buildAnalyzeBody sets required fields and defaults', () => {
+    const body = buildAnalyzeBody({
+        prompt: 'what happens?',
+        video: { type: 'url', url: 'https://example.com/clip.mp4' },
+    });
+    assert.equal(body.model_name, DEFAULT_MODEL);
+    assert.equal(body.stream, false);
+    assert.equal(body.prompt, 'what happens?');
+    assert.deepEqual(body.video, { type: 'url', url: 'https://example.com/clip.mp4' });
+    // optional fields omitted when not provided
+    assert.ok(!('temperature' in body));
+    assert.ok(!('max_tokens' in body));
+});
+
+test('buildAnalyzeBody forwards model, temperature and maxTokens', () => {
+    const body = buildAnalyzeBody({
+        prompt: 'describe',
+        video: { type: 'base64_string', base64_string: 'AAAA' },
+        modelName: 'pegasus1.2',
+        temperature: 0.3,
+        maxTokens: 256,
+    });
+    assert.equal(body.model_name, 'pegasus1.2');
+    assert.equal(body.temperature, 0.3);
+    assert.equal(body.max_tokens, 256);
+    assert.deepEqual(body.video, { type: 'base64_string', base64_string: 'AAAA' });
+});
+
+test('buildAnalyzeBody rejects missing prompt or video', () => {
+    assert.throws(() => buildAnalyzeBody({ prompt: '', video: { type: 'url', url: 'https://x/y.mp4' } }), /prompt/);
+    assert.throws(() => buildAnalyzeBody({ prompt: 'hi', video: undefined as any }), /video/);
+});
+
+test('extractAnalyzeInput pulls a video_url part and joins prompt text', () => {
+    const { prompt, video } = extractAnalyzeInput({
+        messages: [
+            { role: 'system', content: 'You are a security camera analyst.' },
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'What is the person doing?' },
+                    { type: 'video_url', video_url: { url: 'https://nvr.local/event.mp4' } },
+                ],
+            },
+        ],
+    });
+    assert.deepEqual(video, { type: 'url', url: 'https://nvr.local/event.mp4' });
+    assert.match(prompt, /security camera analyst/);
+    assert.match(prompt, /What is the person doing\?/);
+});
+
+test('extractAnalyzeInput accepts an image_url part carrying a video and data: URLs', () => {
+    const fromImageUrl = extractAnalyzeInput({
+        messages: [{ role: 'user', content: [{ type: 'image_url', image_url: { url: 'https://x/clip.mov' } }] }],
+    });
+    assert.deepEqual(fromImageUrl.video, { type: 'url', url: 'https://x/clip.mov' });
+
+    const fromData = extractAnalyzeInput({
+        messages: [{ role: 'user', content: [{ type: 'image_url', image_url: { url: 'data:video/mp4;base64,QUJD' } }] }],
+    });
+    assert.deepEqual(fromData.video, { type: 'base64_string', base64_string: 'QUJD' });
+});
+
+test('extractAnalyzeInput finds a bare video URL in the prompt text and defaults the prompt', () => {
+    const { prompt, video } = extractAnalyzeInput({
+        messages: [{ role: 'user', content: 'https://nvr.local/clip.mp4' }],
+    });
+    assert.deepEqual(video, { type: 'url', url: 'https://nvr.local/clip.mp4' });
+    assert.equal(prompt, 'Describe what happens in this video.');
+});
+
+test('extractAnalyzeInput throws a clear error when no video is present', () => {
+    assert.throws(
+        () => extractAnalyzeInput({ messages: [{ role: 'user', content: 'just text, no clip' }] }),
+        /no video found/,
+    );
+});
+
+test('PegasusClient.analyze posts to /analyze and maps the response', async () => {
+    let captured: { url: string; init: any } | undefined;
+    const fakeFetch = (async (url: any, init: any) => {
+        captured = { url, init };
+        return {
+            ok: true,
+            status: 200,
+            text: async () =>
+                JSON.stringify({ id: 'a1', data: 'A dog runs across a yard.', finish_reason: 'stop', usage: { output_tokens: 7 } }),
+        } as any;
+    }) as unknown as typeof fetch;
+
+    const client = new PegasusClient('test-key', 'https://api.twelvelabs.io/v1.3', fakeFetch);
+    const result = await client.analyze({ prompt: 'describe', video: { type: 'url', url: 'https://x/y.mp4' } });
+
+    assert.equal(captured!.url, 'https://api.twelvelabs.io/v1.3/analyze');
+    assert.equal(captured!.init.method, 'POST');
+    assert.equal(captured!.init.headers['x-api-key'], 'test-key');
+    assert.deepEqual(result, { id: 'a1', data: 'A dog runs across a yard.', finishReason: 'stop', outputTokens: 7 });
+});
+
+test('PegasusClient.analyze surfaces API error messages', async () => {
+    const fakeFetch = (async () => ({
+        ok: false,
+        status: 400,
+        text: async () => JSON.stringify({ message: 'video_file_broken' }),
+    } as any)) as unknown as typeof fetch;
+
+    const client = new PegasusClient('k', undefined, fakeFetch);
+    await assert.rejects(
+        () => client.analyze({ prompt: 'p', video: { type: 'url', url: 'https://x/y.mp4' } }),
+        /400.*video_file_broken/,
+    );
+});
+
+// Opt-in live smoke test: only runs when TWELVELABS_API_KEY is set. Confirms the
+// request wiring against the real Analyze endpoint. The call may legitimately
+// return a content error for a given sample URL; we only assert that auth and
+// the request schema are accepted (i.e. not a 401/invalid-field rejection).
+test('live: analyze request is accepted by the API', { skip: !process.env.TWELVELABS_API_KEY }, async () => {
+    const client = new PegasusClient(process.env.TWELVELABS_API_KEY!);
+    try {
+        const res = await client.analyze({
+            prompt: 'Describe what happens in this video in one sentence.',
+            video: { type: 'url', url: 'https://download.samplelib.com/mp4/sample-10s.mp4' },
+        });
+        assert.equal(typeof res.data, 'string');
+    }
+    catch (e: any) {
+        // Auth / schema problems are real failures; content errors are not.
+        assert.doesNotMatch(String(e?.message), /\(401\)|\(403\)|invalid|model_name|unknown field/i, String(e?.message));
+    }
+});

--- a/plugins/twelvelabs/tsconfig.json
+++ b/plugins/twelvelabs/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "NodeNext",
+        "target": "ESNext",
+        "resolveJsonModule": true,
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "sourceMap": true
+    },
+    "include": [
+        "src/**/*"
+    ]
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds an opt-in Twelve Labs Pegasus plugin (`@scrypted/twelvelabs`) that exposes a `ChatCompletion` device for video understanding.

## What it adds
- A new plugin under `plugins/twelvelabs` implementing `Settings` + `ChatCompletion`.
- Given a camera event clip (an `http(s)` video URL or a `data:video/...;base64,...` URL) plus a prompt, it calls the Twelve Labs Analyze (Pegasus) API and returns a natural-language description of what happened in the clip.
- A small, dependency-free REST client for the Analyze endpoint (`src/pegasus.ts`) and a pure request parser (`src/extract.ts`) that pulls the video + prompt out of an OpenAI-shaped chat completion body.

## Why it helps Scrypted
Any flow that can call a chat completion (NVR event pipelines, notifier automations, scripts) can now turn a motion/event clip into a description like "a delivery person left a package on the porch" instead of a generic "motion detected". It's the first `ChatCompletion` provider that is video-native rather than image/frame based.

## Opt-in / non-breaking
Fully opt-in: nothing runs until a user enters an API key in the plugin settings, and it changes no Scrypted defaults or existing behavior. No new dependencies are added to the build (the client uses the built-in `fetch`).

## How it was tested
- `npm run build` (scrypted-webpack) compiles the plugin cleanly.
- `npm test` (`node --test`) runs 9 no-network unit tests for the body builder, the request parser, and the client's response/error mapping, plus 1 live smoke test gated on `TWELVELABS_API_KEY` (skipped when unset).
- I ran the live test against the real Analyze endpoint with a key: auth and the request schema are accepted (verified end to end).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.