### PR TITLE
fix(homekit): force tcp rtsp_transport for two-way audio talkback

### DIFF
--- a/plugins/homekit/src/types/camera/camera-streaming.ts
+++ b/plugins/homekit/src/types/camera/camera-streaming.ts
@@ -378,6 +378,7 @@ export function createCameraStreamingDelegate(device: ScryptedDevice & VideoCame
                             url: rtspUrl,
                             // this may not work if homekit is using aac to deliver audio, since 
                             inputArguments: [
+                                '-rtsp_transport', 'tcp',
                                 "-acodec", isOpus ? "libopus" : "libfdk_aac",
                                 '-i', rtspUrl,
                             ],


### PR DESCRIPTION
### Summary

The HomeKit two-way audio (talkback) ffmpeg input was missing
`-rtsp_transport tcp`. Add it, matching the equivalent webrtc talkback path.

### Symptom

HomeKit two-way audio is silent. The plugin log repeatedly shows:

```
[rtsp @ ...] method SETUP failed: 461 Unsupported Transport
```

on the `rtsp://127.0.0.1` "HomeKit Audio Talkback" loopback.

### Cause

The talkback loopback is an `RtspServer` created over `listenZeroSingleClient`,
which only accepts TCP interleaved transport. The talkback `FFmpegInput` in
`camera-streaming.ts` was built without `-rtsp_transport`, so the consumer
ffmpeg issues a UDP `SETUP` first and the loopback rejects it with
`461 Unsupported Transport`.

The equivalent webrtc talkback path
(`plugins/webrtc/src/session-control.ts`) has always specified
`-rtsp_transport tcp`. The homekit path (rewritten in `cfc92fd65`, Jan 2023)
did not.

### Fix

Add `-rtsp_transport tcp` to the talkback input arguments so ffmpeg negotiates
the loopback over TCP directly, matching webrtc.

### Verification

Tested on a Hikvision DS-2CD3386FWDA4-LS (firmware V5.7.1 build 220309,
G.711ulaw ONVIF backchannel), Scrypted Home Assistant addon
`0.143.0-noble-full` (Scrypted 0.143.0, ffmpeg 6.x / Lavf60),
`@scrypted/homekit` 1.2.65 + this patch, HomeKit client iPhone Air on
iOS 26.5.1.

**Before** — no audio comes out of the camera speaker (talkback completely
silent). ffmpeg attempts a UDP SETUP and the loopback rejects it:

```
-hide_banner -acodec libopus -i rtsp://127.0.0.1:44201 -acodec pcm_mulaw ...
[rtsp @ ...] method SETUP failed: 461 Unsupported Transport
```

**After** — speaking from the Home app is now audible at the camera, confirmed
across several talk attempts. No 461; ffmpeg negotiates the loopback over TCP
directly:

```
-hide_banner -rtsp_transport tcp -acodec libopus -i rtsp://127.0.0.1:44429 -acodec pcm_mulaw ...
Input #0, rtsp, from 'rtsp://127.0.0.1:44429':
  Stream #0:0: Audio: opus, 48000 Hz, stereo, s16
```
