### PR TITLE
fix(unifi-protect): stop keying device identity on DHCP host/IP

### DIFF
--- a/plugins/unifi-protect/src/main.ts
+++ b/plugins/unifi-protect/src/main.ts
@@ -859,14 +859,18 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
             // for now fall back to old behavior which will be removed at a later date.
         }
 
-        const { id, mac, anonymousDeviceId, host } = device;
+        const { id, mac, anonymousDeviceId } = device;
         const idMaps = this.storageSettings.values.idMaps;
 
-        // try to find an existing nativeId given the mac and anonymous device id
+        // Try to find an existing nativeId using stable hardware identifiers.
+        // Do NOT match on host/IP: DHCP reassigns addresses, so a recycled IP
+        // would bind a newly provisioned camera to an unrelated camera's
+        // nativeId. The subsequent cleanDict() then clobbers the original
+        // camera's mac/anonymousDeviceId entries, collapsing two cameras onto
+        // a single device (and losing the other from the device list).
         const found = (mac && idMaps.mac?.[mac])
             || (anonymousDeviceId && idMaps.anonymousDeviceId?.[anonymousDeviceId])
             || (id && idMaps.id?.[id])
-            || (host && idMaps.host?.[host])
             ;
 
         // use the found id if one exists (device got provisioned a new id), otherwise use the id provided by the device.
@@ -889,24 +893,19 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         // Clean existing mappings before adding new ones
         idMaps.mac ||= {};
         idMaps.anonymousDeviceId ||= {};
-        idMaps.host ||= {};
         idMaps.id ||= {};
         idMaps.nativeId ||= {};
 
         cleanDict(idMaps.mac);
         cleanDict(idMaps.anonymousDeviceId);
-        cleanDict(idMaps.host);
         cleanDict(idMaps.id);
 
-        // map the mac, host, and anonymous device id to the native id.
+        // map the mac and anonymous device id to the native id.
         if (mac) {
             idMaps.mac[mac] = nativeId;
         }
         if (anonymousDeviceId) {
             idMaps.anonymousDeviceId[anonymousDeviceId] = nativeId;
-        }
-        if (host) {
-            idMaps.host[host] = nativeId;
         }
 
         // map the id and native id to each other.


### PR DESCRIPTION
## Problem

The Unifi Protect plugin was silently dropping cameras from the device list — a 13-camera NVR surfaced only 11 in Scrypted, and one device rendered an unrelated camera's stream under the wrong name.

Root cause is in `getNativeId` (`plugins/unifi-protect/src/main.ts`). When resolving a camera to its persistent Scrypted `nativeId`, the lookup fell back to matching on `host` (the camera's IP address):

```ts
const found = (mac && idMaps.mac?.[mac])
    || (anonymousDeviceId && idMaps.anonymousDeviceId?.[anonymousDeviceId])
    || (id && idMaps.id?.[id])
    || (host && idMaps.host?.[host]);   // <-- IP is not a stable identity
```

IPs are not stable. When DHCP recycles an address, a newly provisioned camera that picks up a previously-used IP resolves to the **prior** camera's `nativeId`. The subsequent `cleanDict()` pass then deletes the original camera's `mac`/`anonymousDeviceId` entries and rebinds them to the new camera — collapsing two distinct cameras onto a single Scrypted device and dropping the other from the device list entirely.

This was confirmed against a real affected install: three live camera IDs had all been mapped to one camera's `nativeId` in `idToNativeId`, and the displaced camera's MAC was missing from `idMaps.mac` (overwritten by `cleanDict`). The symptom — two missing cameras plus one device streaming the wrong feed under the wrong name — matched exactly.

## Fix

Match device identity only on stable hardware identifiers: `mac`, `anonymousDeviceId`, and `id`. Stop using `host` as an identity key, and stop maintaining the `idMaps.host` map.

## Notes

- `host` remains in the `getNativeId` parameter type since callers still pass device objects that carry it; it is simply no longer used for matching.
- Existing installs retain an orphaned `idMaps.host` in storage. It is now inert (nothing reads it) and harmless, so no migration is included. Affected installs self-heal on the next `getNativeId` write once the stale entry no longer participates in matching; a previously-collapsed device can be re-added via discovery.