### PR TITLE
server: dispatch python plugin events to systemManager listeners

### DIFF
--- a/server/python/plugin_remote.py
+++ b/server/python/plugin_remote.py
@@ -159,8 +159,8 @@ class EventRegistry(object):
             events = set()
             self.listeners[token] = events
         callback = ensure_not_coroutine(callback)
-        self.listeners[id].add(callback)
-        return EventListenerRegisterImpl(lambda: self.listeners[id].remove(callback))
+        events.add(callback)
+        return EventListenerRegisterImpl(lambda: events.discard(callback))
 
     def notify(
         self,
@@ -649,6 +649,7 @@ class PluginRemote:
     ):
         self.systemState: Mapping[str, Mapping[str, SystemDeviceState]] = {}
         self.nativeIds: Mapping[str, DeviceStorage] = {}
+        self.systemManager: SystemManager = None
         self.mediaManager: MediaManager
         self.clusterManager: ClusterManager
         self.consoles: Mapping[str, Future[Tuple[StreamReader, StreamWriter]]] = {}
@@ -1113,18 +1114,18 @@ class PluginRemote:
 
     async def notify(self, id, eventDetails: EventDetails, value):
         property = eventDetails.get("property")
-        if property:
-            state = None
-            if self.systemState:
-                state = self.systemState.get(id, None)
-                if not state:
-                    print("state not found for %s" % id)
-                    return
-                state[property] = value
-                # systemManager.events.notify(id, eventTime, eventInterface, property, value.value, changed);
-        else:
-            # systemManager.events.notify(id, eventTime, eventInterface, property, value, changed);
-            pass
+        if property and not eventDetails.get("mixinId"):
+            state = self.systemState.get(id, None) if self.systemState else None
+            if not state:
+                print("state not found for %s" % id)
+                return
+            state[property] = value
+            if self.systemManager:
+                self.systemManager.events.notifyEventDetails(
+                    id, eventDetails, value.get("value", None) if value else None
+                )
+        elif self.systemManager:
+            self.systemManager.events.notifyEventDetails(id, eventDetails, value)
 
     async def ioEvent(self, id, event, message=None):
         pass


### PR DESCRIPTION
## What

The python port of plugin-remote's `notify()` updates `systemState` but the dispatch to `systemManager.events` was left as a commented-out TODO, so `systemManager.listen()` callbacks never fire in python plugins and API clients. The typescript implementation dispatches here via `notifyEventDetails` ([plugin-remote.ts](https://github.com/koush/scrypted/blob/main/server/src/plugin/plugin-remote.ts#L258-L272)).

This ports the current typescript semantics:
- plain property changes (no `mixinId`) update `systemState` and notify listeners with the unwrapped `value.value`
- all other events pass through to `notifyEventDetails` raw
- mixin property events no longer write device state (matching typescript)
- `PluginRemote.systemManager` is initialized to `None` and the dispatch is skipped until it is attached (`loadZip` already assigns it; API clients built on `PluginRemote` can assign their own)

Also fixes `EventRegistry.listenDevice` to register callbacks in the token-keyed listener set. It previously raised `KeyError` on the device id key, diverging from [event-registry.ts](https://github.com/koush/scrypted/blob/main/server/src/event-registry.ts#L40-L55), which broke watch-mode device listeners.

## How this was found and verified

Found while building a Home Assistant integration on the python client: device property events (e.g. `motionDetected`) arrived over RPC and updated local state, but registered system listeners were never invoked. Verified against a live scrypted server (104 devices): with this change, `systemManager.listen()` receives motion/audio property events and Logger events, matching typescript behavior. Also covered by contract tests in the downstream integration exercising `PluginRemote.notify` and `EventRegistry.listenDevice` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)