### PR TITLE
python-client: fix test.py for current rpc_reader and PluginRemote APIs

### DIFF
--- a/packages/python-client/test.py
+++ b/packages/python-client/test.py
@@ -52,7 +52,7 @@ class EioRpcTransport(rpc_reader.RpcTransport):
 
         asyncio.run_coroutine_threadsafe(send(), self.loop)
 
-    def writeJSON(self, json, reject):
+    def writeSerialized(self, json, reject):
         return self.writeBuffer(json, reject)
 
 
@@ -96,8 +96,9 @@ async def connect_scrypted_client(
         peer.params["print"] = print
 
         def callback(api, pluginId, hostInfo):
+            cluster_setup = plugin_remote.ClusterSetup(transport.loop, peer)
             remote = plugin_remote.PluginRemote(
-                peer, api, pluginId, hostInfo, transport.loop
+                cluster_setup, api, pluginId, hostInfo, transport.loop
             )
             wrapped = remote.setSystemState
 


### PR DESCRIPTION
Two small fixes to bring `packages/python-client/test.py` back in line with the server code it drives:

- `EioRpcTransport.writeJSON` → `writeSerialized` — `rpc.py` sends via `writeSerialized` now, so the old method never gets called and the connection hangs at the handshake.
- `PluginRemote.__init__` now takes a `ClusterSetup` as its first argument; the test was still passing the peer directly, which fails in `__init__` (`clusterSetup.peer`).

Verified by running the fixed test.py against a live scrypted server (logs in, completes the plugin-remote handshake, and enumerates all devices).

Found while building a Home Assistant integration on this reference client. Related: #2086 fixes the event dispatch in `plugin_remote.py` itself; this PR is independent and only touches the example client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)