### PR TITLE
fix(homekit): crackling and muted Opus audio from Ring doorbells (#1617)

### DIFF
--- a/plugins/homekit/src/types/camera/camera-recording.ts
+++ b/plugins/homekit/src/types/camera/camera-recording.ts
@@ -145,6 +145,10 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
     const audioCodec = ffmpegInput.mediaStreamOptions?.audio?.codec;
     const videoCodec = ffmpegInput.mediaStreamOptions?.video?.codec;
     const isDefinitelyNotAAC = !audioCodec || audioCodec.toLowerCase().indexOf('aac') === -1;
+    // Recordings transcode Opus to AAC. ffmpeg's native Opus decoder does not apply the
+    // soft clip recommended by the Opus spec, and hard-clips content authored above 0 dBFS
+    // (e.g. some Ring doorbells), baking crackle into the recording. Always decode with libopus.
+    const isOpus = audioCodec?.toLowerCase() === 'opus';
     const needsFFmpeg = debugMode.video || debugMode.video
         || !ffmpegInput.url.startsWith('tcp://')
         || ffmpegInput.container !== 'mp4'
@@ -176,6 +180,10 @@ export async function* handleFragmentsRequests(streamId: number, device: Scrypte
             }
         }
 
+        // force the libopus decoder (before the input) so Opus authored above 0 dBFS is
+        // soft-clipped per spec instead of hard-clipped by ffmpeg's native Opus decoder.
+        if (isOpus)
+            inputArguments.push('-c:a', 'libopus');
         inputArguments.push(...ffmpegInput.inputArguments);
 
         if (noAudio) {

--- a/plugins/homekit/src/types/camera/camera-streaming-ffmpeg.ts
+++ b/plugins/homekit/src/types/camera/camera-streaming-ffmpeg.ts
@@ -1,14 +1,20 @@
 import { RtpPacket } from '@koush/werift-src/packages/rtp/src/rtp/rtp';
 import { getDebugModeH264EncoderArgs } from '@scrypted/common/src/ffmpeg-hardware-acceleration';
 import { addVideoFilterArguments } from '@scrypted/common/src/ffmpeg-helpers';
-import { createBindZero } from '@scrypted/common/src/listen-cluster';
+import { closeQuiet, createBindZero, reserveUdpPort } from '@scrypted/common/src/listen-cluster';
+import { ffmpegLogInitialOutput, safeKillFFmpeg } from '@scrypted/common/src/media-helpers';
 import { getSpsPps } from '@scrypted/common/src/sdp-utils';
-import { FFmpegInput, MediaStreamDestination, ScryptedDevice, VideoCamera } from '@scrypted/sdk';
+import sdk, { FFmpegInput, MediaStreamDestination, ScryptedDevice, VideoCamera } from '@scrypted/sdk';
+import child_process from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { RtpTrack, RtpTracks, startRtpForwarderProcess } from '../../../../webrtc/src/rtp-forwarders';
 import { AudioStreamingCodecType, SRTPCryptoSuites } from '../../hap';
 import { getDebugMode } from './camera-debug-mode-storage';
 import { CameraStreamingSession, waitForFirstVideoRtcp } from './camera-streaming-session';
 import { createCameraStreamSender } from './camera-streaming-srtp-sender';
+import { getOpusFrameDuration } from './opus-repacketizer';
 import { checkCompatibleCodec, transcodingDebugModeWarning } from './camera-utils';
 
 export async function startCameraStreamFfmpeg(device: ScryptedDevice & VideoCamera, console: Console, storage: Storage, ffmpegInput: FFmpegInput, session: CameraStreamingSession) {
@@ -139,9 +145,14 @@ export async function startCameraStreamFfmpeg(device: ScryptedDevice & VideoCame
     // homekit live streaming is extremely picky about audio audio packet time.
     // not sending packets of the correct duration will result in mute or choppy audio.
     // the packet time parameter is different between LAN and LTE.
-    let opusFramesPerPacket = request.audio.packet_time / 20;
 
     const noAudio = mso?.audio === null;
+    // if ffmpeg ends up transcoding Opus audio (debug mode, AAC-ELD, or non copyable stream),
+    // it must decode with libopus: ffmpeg's native Opus decoder does not apply the soft clip
+    // recommended by the Opus spec and hard clips content authored above 0 dBFS (e.g. some
+    // Ring doorbells) into loud crackling. harmless when the audio is codec copied.
+    if (!noAudio && mso?.audio?.codec?.toLowerCase() === 'opus')
+        ffmpegInput.inputArguments = ['-c:a', 'libopus', ...ffmpegInput.inputArguments || []];
     if (noAudio) {
         // no op...
     }
@@ -181,7 +192,6 @@ export async function startCameraStreamFfmpeg(device: ScryptedDevice & VideoCame
                 {
                     audioPacketTime: session.startRequest.audio.packet_time,
                     audioSampleRate: session.startRequest.audio.sample_rate,
-                    framesPerPacket: opusFramesPerPacket,
                 }
             );
 
@@ -189,8 +199,140 @@ export async function startCameraStreamFfmpeg(device: ScryptedDevice & VideoCame
                 audioSender.sendRtcp();
             };
 
+            // SILK and Hybrid mode Opus (TOC config < 16, e.g. from Ring doorbells) routinely
+            // synthesizes samples above 0 dBFS. The Opus spec recommends decoders soft clip such
+            // content back into range (opus_pcm_soft_clip), but HomeKit's decoder does not, and
+            // instead hard clips it, which is audible as loud crackling. Additionally, frames
+            // longer than the negotiated packet time (e.g. 60ms frames vs 20ms LAN packet time)
+            // can not be repacketized without a reencode, and HomeKit mutes them. Such streams
+            // are lazily rerouted through an ffmpeg transcoder: libopus performs the spec soft
+            // clip on decode, and the reencoded audio is in range at the correct packet time.
+            // CELT streams at a compatible frame duration are forwarded untouched.
+            let transcoding = false;
+            let transcoderFailed = false;
+            let transcoderSend: (rtp: Buffer) => void;
+            let pendingRtp: Buffer[] = [];
+
+            const startOpusSoftClipTranscoder = async (sourcePayloadType: number) => {
+                const pt = session.startRequest.audio.pt;
+
+                // register cleanup before any await: a stream torn down during startup must
+                // still reap the sockets, temp dir, and child process created so far.
+                const cleanups: (() => void)[] = [];
+                let closed = false;
+                const cleanup = () => {
+                    closed = true;
+                    while (cleanups.length)
+                        cleanups.pop()?.();
+                };
+                session.audioReturn.on('close', cleanup);
+
+                // ffmpeg binds the input port itself, so probe a free port and release it.
+                const inputPort = await reserveUdpPort();
+
+                const outputBind = await createBindZero();
+                cleanups.push(() => closeQuiet(outputBind.server));
+
+                const sdpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'opus-softclip-'));
+                cleanups.push(() => void fs.promises.rm(sdpDir, { recursive: true, force: true }).catch(() => { }));
+                const sdpPath = path.join(sdpDir, 'audio.sdp');
+                await fs.promises.writeFile(sdpPath, [
+                    'v=0',
+                    'o=- 0 0 IN IP4 127.0.0.1',
+                    's=scrypted-opus-softclip',
+                    'c=IN IP4 127.0.0.1',
+                    't=0 0',
+                    // the sdp must declare the payload type of the source stream, which may
+                    // differ from the payload type HAP requested for the output.
+                    `m=audio ${inputPort} RTP/AVP ${sourcePayloadType}`,
+                    `a=rtpmap:${sourcePayloadType} opus/48000/2`,
+                ].join('\n'));
+
+                const args = [
+                    '-hide_banner',
+                    '-protocol_whitelist', 'file,crypto,udp,rtp',
+                    '-analyzeduration', '0',
+                    '-probesize', '512',
+                    '-acodec', 'libopus',
+                    '-f', 'sdp',
+                    '-i', sdpPath,
+                    '-vn',
+                    // the soft clipped decode peaks at exactly 0 dBFS, and reencoding full scale
+                    // audio overshoots again (codec ripple), which HomeKit would hard clip. leave
+                    // ~2 dB of encoder headroom so the reencoded peaks stay in range.
+                    '-af', 'volume=0.8',
+                    '-acodec', 'libopus',
+                    '-application', 'lowdelay',
+                    '-frame_duration', request.audio.packet_time.toString(),
+                    '-ar', `${request.audio.sample_rate}k`,
+                    '-b:a', `${request.audio.max_bit_rate}k`,
+                    '-bufsize', `${request.audio.max_bit_rate * 4}k`,
+                    '-ac', `${request.audio.channel}`,
+                    '-payload_type', pt.toString(),
+                    '-f', 'rtp',
+                    `rtp://127.0.0.1:${outputBind.port}`,
+                ];
+
+                const cp = child_process.spawn(await sdk.mediaManager.getFFmpegPath(), args);
+                ffmpegLogInitialOutput(console, cp);
+                cleanups.push(() => safeKillFFmpeg(cp));
+                cp.on('exit', () => fs.promises.rm(sdpDir, { recursive: true, force: true }).catch(() => { }));
+
+                outputBind.server.on('message', data => {
+                    const packet = RtpPacket.deSerialize(data);
+                    if (packet.header.payloadType !== pt)
+                        return;
+                    audioSender.sendRtp(packet);
+                });
+
+                // give ffmpeg a moment to parse the sdp and bind the input port.
+                await new Promise(resolve => setTimeout(resolve, 250));
+
+                if (closed)
+                    throw new Error('stream closed during opus transcoder startup');
+
+                return (rtp: Buffer) => outputBind.server.send(rtp, inputPort, '127.0.0.1');
+            };
+
             onRtp = function (rtp) {
-                audioSender.sendRtp(RtpPacket.deSerialize(rtp));
+                if (transcoding) {
+                    if (transcoderSend)
+                        transcoderSend(rtp);
+                    else if (pendingRtp.length < 500)
+                        pendingRtp.push(rtp);
+                    return;
+                }
+
+                const packet = RtpPacket.deSerialize(rtp);
+                if (!packet.payload.length)
+                    return;
+
+                // opus encoders may switch mode or frame duration mid-stream, so the copy path
+                // checks the TOC of every packet, not just the first.
+                const config = packet.payload[0] >> 3;
+                const frameDuration = getOpusFrameDuration(packet.payload[0]);
+                if (!transcoderFailed && (config < 16 || frameDuration > request.audio.packet_time)) {
+                    transcoding = true;
+                    console.warn(`opus TOC config ${config} (${config < 16 ? 'SILK/Hybrid' : 'CELT'}), frame duration ${frameDuration}ms, packet time ${request.audio.packet_time}ms: transcoding through libopus to apply the Opus spec soft clip.`);
+                    startOpusSoftClipTranscoder(packet.header.payloadType).then(send => {
+                        transcoderSend = send;
+                        for (const pending of pendingRtp)
+                            transcoderSend(pending);
+                        pendingRtp = [];
+                    }).catch(e => {
+                        // degraded audio through the copy path beats a mute stream.
+                        console.error('opus soft clip transcoder failed to start, falling back to codec copy', e);
+                        transcoderFailed = true;
+                        transcoding = false;
+                        for (const pending of pendingRtp)
+                            audioSender.sendRtp(RtpPacket.deSerialize(pending));
+                        pendingRtp = [];
+                    });
+                    pendingRtp.push(rtp);
+                    return;
+                }
+
+                audioSender.sendRtp(packet);
             };
         }
         else {

--- a/plugins/homekit/src/types/camera/camera-streaming-srtp-sender.ts
+++ b/plugins/homekit/src/types/camera/camera-streaming-srtp-sender.ts
@@ -20,7 +20,6 @@ export function createCameraStreamSender(console: Console, config: Config, sende
     audioOptions?: {
         audioPacketTime: number,
         audioSampleRate: AudioStreamingSamplerate,
-        framesPerPacket: number,
     }) {
     const srtpSession = new SrtpSession(config);
     const srtcpSession = new SrtcpSession(config);
@@ -46,18 +45,20 @@ export function createCameraStreamSender(console: Console, config: Config, sende
         printNaluTypes();
     }, 1000);
 
-    let audioIntervalScale = 1;
+    // opus timestamps are advanced by the actual number of audio samples emitted, computed from the
+    // HAP-requested sample rate and the repacketizer's real per-packet duration.
+    let audioSampleRateKhz = 8;
+    let audioSampleCount = 0;
     if (audioOptions) {
         switch (audioOptions.audioSampleRate) {
             case AudioStreamingSamplerate.KHZ_24:
-                audioIntervalScale = 3;
+                audioSampleRateKhz = 24;
                 break;
             case AudioStreamingSamplerate.KHZ_16:
-                audioIntervalScale = 2;
+                audioSampleRateKhz = 16;
                 break;
         }
-        audioIntervalScale = audioIntervalScale * audioOptions.audioPacketTime / 20;
-        opusPacketizer = new OpusRepacketizer(audioOptions.framesPerPacket);
+        opusPacketizer = new OpusRepacketizer(audioOptions.audioPacketTime);
     }
     else {
         if (videoOptions.maxPacketSize) {
@@ -141,7 +142,10 @@ export function createCameraStreamSender(console: Console, config: Config, sende
             // HAP requests, and the packet time is respected,
             // opus 48khz will work just fine.
             for (const rtp of packets) {
-                rtp.header.timestamp = (firstTimestamp + packetCount * 160 * audioIntervalScale) % 0xFFFFFFFF;
+                // stamp each packet by the audio it actually contains, then advance by the same amount:
+                // emittedPacketTime (ms) of audio at the HAP-requested sample rate.
+                rtp.header.timestamp = (firstTimestamp + audioSampleCount) % 0xFFFFFFFF;
+                audioSampleCount += Math.round(audioSampleRateKhz * opusPacketizer.emittedPacketTime);
                 sendPacket(rtp);
             }
             return;

--- a/plugins/homekit/src/types/camera/opus-repacketizer.ts
+++ b/plugins/homekit/src/types/camera/opus-repacketizer.ts
@@ -61,14 +61,43 @@ import type { RtpPacket } from "@koush/werift-src/packages/rtp/src/rtp/rtp";
 // signaled length of the padding MUST be no larger than N, the total
 // size of the packet.
 
+// The Opus frame duration (ms) is encoded in the config (top 5 bits of the TOC byte), per RFC 6716 3.1.
+export function getOpusFrameDuration(toc: number): number {
+    const config = toc >> 3;
+    if (config < 12)
+        return [10, 20, 40, 60][config & 0b11]; // SILK
+    if (config < 16)
+        return [10, 20][config & 0b01];          // Hybrid
+    return [2.5, 5, 10, 20][config & 0b11];       // CELT
+}
+
+// Encode an opus frame length as 1 or 2 bytes, per RFC 6716 3.2.1: lengths < 252 use a single byte;
+// larger lengths use two bytes where total = b0 + b1 * 4 with 252 <= b0 <= 255.
+function encodeFrameLength(length: number): number[] {
+    if (length < 252)
+        return [length];
+    const b1 = Math.floor((length - 252) / 4);
+    const b0 = length - b1 * 4;
+    return [b0, b1];
+}
+
 export class OpusRepacketizer {
     depacketized: Buffer[] = [];
     extraPackets = 0;
 
-    // framesPerPacket argument is buggy in that it assumes that the frame durations are always 20.
-    // the frame duration can be determined from the config in the opus header above.
-    // however, frames of duration 20 seems to always be the case from the various test devices.
-    constructor(public framesPerPacket: number) {
+    // framesPerPacket and frameDuration are derived from the TOC of each incoming packet: the
+    // HAP-requested packet time divided by the actual opus frame duration. This replaces the old
+    // assumption that frames are always 20ms, which corrupted timestamps for e.g. 60ms SILK.
+    framesPerPacket: number;
+    frameDuration: number;
+
+    // packetTime is the packet duration (ms) HAP requested (e.g. 20 on LAN, 60 over LTE).
+    constructor(public packetTime: number) {
+    }
+
+    // actual duration (ms) of each emitted packet: framesPerPacket frames of frameDuration each.
+    get emittedPacketTime() {
+        return this.frameDuration * this.framesPerPacket;
     }
 
     // repacketize a packet with a single frame into a packet with multiple frames.
@@ -76,12 +105,24 @@ export class OpusRepacketizer {
         const code = packet.payload[0] & 0b00000011;
         let offset: number;
 
+        // derive frames-per-packet from the actual frame duration in the TOC. if the encoder switches
+        // config mid-stream the frame duration changes: recompute and drop any partially accumulated
+        // frames, which belong to the previous configuration.
+        const frameDuration = getOpusFrameDuration(packet.payload[0]);
+        if (frameDuration !== this.frameDuration) {
+            this.frameDuration = frameDuration;
+            // frames longer than the requested packet time can't be split without a re-encode, so they
+            // pass through one per packet (hence Math.max(1, ...)).
+            this.framesPerPacket = Math.max(1, Math.floor(this.packetTime / frameDuration));
+            this.depacketized = [];
+        }
+
         // see Frame Length Coding in RFC
         const decodeFrameLength = () => {
             let frameLength = packet.payload.readUInt8(offset++);
             if (frameLength >= 252) {
-                offset++;
-                frameLength += packet.payload.readUInt8(offset) * 4;
+                // 2-byte length: total = b0 + b1 * 4 (RFC 6716 3.2.1). read the second byte and advance.
+                frameLength += packet.payload.readUInt8(offset++) * 4;
             }
             return frameLength;
         }
@@ -183,8 +224,9 @@ export class OpusRepacketizer {
 
             const newHeader: number[] = [toc, frameCountByte];
 
-            // M-1 length bytes
-            newHeader.push(...depacketized.slice(0, -1).map(data => data.length));
+            // M-1 frame lengths, each 1 or 2 bytes (frames >= 252 bytes need the 2-byte encoding).
+            for (const data of depacketized.slice(0, -1))
+                newHeader.push(...encodeFrameLength(data.length));
 
             const headerBuffer = Buffer.from(newHeader);
             const payload = Buffer.concat([headerBuffer, ...depacketized]);

--- a/plugins/webrtc/src/ffmpeg-to-wrtc.ts
+++ b/plugins/webrtc/src/ffmpeg-to-wrtc.ts
@@ -280,9 +280,9 @@ export async function createTrackForwarder(options: {
         alternateCodecs: ['opus', 'pcm_mulaw', 'pcm_alaw'],
         onRtp: (buffer, codec) => {
             if (false && audioTransceiver.sender.codec.mimeType?.toLowerCase() === "audio/opus") {
-                // this will use 3 20ms frames, 60ms. seems to work up to 6/120ms
+                // this will pack 60ms per packet (e.g. 3 20ms frames). seems to work up to 120ms.
                 if (!opusRepacketizer)
-                    opusRepacketizer = new OpusRepacketizer(3);
+                    opusRepacketizer = new OpusRepacketizer(60);
                 for (const rtp of opusRepacketizer.repacketize(RtpPacket.deSerialize(buffer))) {
                     audioTransceiver.sender.sendRtp(rtp);
                 }

--- a/plugins/webrtc/src/rtp-forwarders.ts
+++ b/plugins/webrtc/src/rtp-forwarders.ts
@@ -349,6 +349,9 @@ export async function startRtpForwarderProcess(console: Console, ffmpegInput: FF
                         inputArguments = [
                             '-analyzeduration', '0',
                             '-probesize', '512',
+                            // ffmpeg's native Opus decoder does not apply the spec's soft-clip and
+                            // hard-clips content authored above 0 dBFS. libopus decodes it correctly.
+                            ...(audioSection.codec === 'opus' ? ['-c:a', 'libopus'] : []),
                             '-i', `rtsp://${audioClient.host}:${audioClient.port}`,
                         ];
                     }


### PR DESCRIPTION
Ring doorbells send Opus audio in SILK mode with 60ms frames, encoded above 0 dBFS. This causes two bugs:

- **Crackling**: ffmpeg's default Opus decoder doesn't apply the soft-clip the Opus spec expects for content above 0 dBFS, so it hard-clips instead — audible as crackle. This affected recordings and any transcoded live stream.
- **Muted audio**: 60ms frames can't be repacketized into HomeKit's negotiated 20ms packet time, so codec-copied live audio gets muted.

**Fix:**
- Recordings and audio transcodes now decode Opus with `libopus`, which soft-clips correctly.
- Live streaming checks each packet's Opus mode: CELT streams (the common case) are copied through unchanged. SILK or long-frame streams are transcoded through libopus with a small gain margin and re-packetized to the correct duration, falling back to copy if the transcoder fails to start.
- Fixed the opus repacketizer to use each packet's actual frame duration instead of assuming 20ms, plus two related RFC 6716 length-encoding bugs.

Tested on a Ring Video Doorbell Pro (HomeKit + HKSV) — live view and recordings are now clean. Verified CELT cameras are unaffected (no transcoding, unchanged behavior).

Supersedes #2063, which worked around this by disabling Opus entirely (forcing G.711). This fixes the root cause with no toggle and keeps full Opus audio quality.
