### PR TITLE
fix(server): exit orphaned plugin workers when parent process dies

### DIFF
--- a/server/src/scrypted-plugin-main.ts
+++ b/server/src/scrypted-plugin-main.ts
@@ -46,6 +46,21 @@ function start(mainFilename: string) {
             console.error('peer host disconnected, exiting.');
             process.exit(1);
         });
+
+        // Backstop for orphaned workers.
+        // The 'disconnect' event above is not reliably delivered when the parent
+        // process dies abruptly (SIGKILL/crash): the worker is reparented to init
+        // (or a subreaper) and, if something keeps its event loop alive (e.g. a
+        // pending timer or socket), it lingers forever. Poll the parent pid and
+        // exit when it changes, so an orphaned worker can never leak.
+        // unref() so this timer alone never keeps an otherwise-idle worker alive.
+        const originalParentPid = process.ppid;
+        setInterval(() => {
+            if (process.ppid !== originalParentPid) {
+                console.error('parent process died (reparented), exiting.');
+                process.exit(1);
+            }
+        }, 10000).unref();
     }
 }
 


### PR DESCRIPTION
## Problem

Plugin workers spawned via `sdk.fork()` (node `child_process.fork`) rely **solely** on the IPC `'disconnect'` event to exit when their host process goes away — `server/src/scrypted-plugin-main.ts`:

```ts
process.on('disconnect', () => {
    console.error('peer host disconnected, exiting.');
    process.exit(1);
});
```

`'disconnect'` is not reliably delivered when the parent dies abruptly (SIGKILL / crash). The worker is reparented to init (or a subreaper) and, if anything keeps its event loop alive (a pending keepalive timer, an open socket), it lingers indefinitely. Local (non-cluster) forks have no other backstop — cluster forks have `PeerLiveness`, local forks do not.

## Impact (observed)

Single-node NVR install (non-cluster). Over ~7 days, orphaned `fork @scrypted/nvr` workers accumulated:

- 51 orphaned workers, `PPID=1`, state `Sl` (alive, sleeping), ~1.6 GB RSS combined, 225 threads.
- Container `pids.current` reached the 500 cap → new worker threads failed with `EAGAIN` / `ERR_WORKER_INIT_FAILED`.
- NVR recording/event pruner could no longer spawn its worker, so pruning silently stopped (`Error pruning recordings on periodic timer Error: EAGAIN`).

Confirmed the workers were orphaned-but-alive (so `process.on('disconnect')` never reaped them), and that they are plain local IPC forks (`SCRYPTED_CLUSTER_ADDRESS` unset → `utilizesClusterForkWorker()` returns false).

## Fix

Capture `process.ppid` at worker startup and poll it; if it changes, the parent is gone, so `process.exit(1)`. `unref()` so this timer alone never keeps an otherwise-idle worker alive.

Verified in the target environment: a forked child kept alive by a non-`unref`'d timer, whose parent is `SIGKILL`'d, now exits within the poll interval instead of leaking forever.

## Notes

- Zero dependencies, ~15 LOC, in the shared non-thread branch (covers both `fork` and `child` workers). Thread workers already exit via `port.on('close')`.
- Complementary to any per-plugin teardown fix: it makes a missed `worker.terminate()` non-permanent regardless of cause.
