### PR TITLE
HA addon: add privileged: [NET_ADMIN] to enable plugin-managed virtual network interfaces

### DIFF
--- a/install/config.yaml
+++ b/install/config.yaml
@@ -31,6 +31,8 @@ backup_exclude:
   - '*/server/**'
   - '*/scrypted_nvr/**'
   - '*/scrypted_data/plugins/**'
+priveleged:
+  - NET_ADMIN
 map:
   - config:rw
   - media:rw


### PR DESCRIPTION
This PR adds the NET_ADMIN privelege to the homeassistant install configuration.

## Request

There's an onvif import plugin, but I was looking into what it would take for implementing an onvif export plugin.

An onvif export plugin from scrypted to some other system (eg, unifi protect) requires the ability to create fake mac addresses for each camera being exported, so to do this I'm asking if I can add the  NET_ADMIN privilege for HomeAssistant AddOns. 

This change does appear to subtract 1 from the security score at https://developers.home-assistant.io/docs/apps/presentation/ as one downside.

## Additional Notes

Here's the AI summary of the issue below:

```md
## Why

UniFi Protect 5.0+ third-party camera support identifies cameras by the MAC
it ARPs from the camera's IP address. Any plugin that exposes multiple
Scrypted cameras as virtual ONVIF devices can
therefore only ever get **one** camera adopted per host IP — Protect
deduplicates the rest. The established workaround (see the widely-used
[daniela-hase/onvif-server](https://github.com/daniela-hase/onvif-server))
is one macvlan interface per virtual camera, each with its own MAC + IP.

The addon already runs with `host_network: true`, so macvlan links created by
a plugin land on the host network namespace correctly — the only missing
piece is `CAP_NET_ADMIN` for the netlink calls. Docker's default capability
set excludes it, and HA offers users no per-install way to grant
capabilities to an addon; only the addon config can.

## Scope / security considerations

- NET_ADMIN is arguably narrower than access the addon already requests
  (`/dev/mem`, GPIO, uart, full host networking).
- HA's addon schema supports exactly this via the `privileged:` list; several
  published addons use it for network management (e.g. Bluetooth-related
  addons request NET_ADMIN + NET_RAW).
```