### PR TITLE
webrtc: prefer PCMU for Ring doorbells

### DIFF
--- a/plugins/webrtc/src/main.ts
+++ b/plugins/webrtc/src/main.ts
@@ -165,6 +165,9 @@ class WebRTCMixin extends SettingsMixinDeviceBase<RTCSignalingClient & VideoCame
 
         const fork = await result.result;
         try {
+            const sourceDevice = systemManager.getDeviceById(this.id);
+            const preferPcmu = sourceDevice.pluginId === '@scrypted/ring'
+                && sourceDevice.type === ScryptedDeviceType.Doorbell;
             const { getIntercom, mediaObject, pcClose } = await fork.createRTCPeerConnectionSource({
                 __json_copy_serialize_children: true,
                 nativeId: this.nativeId,
@@ -172,6 +175,7 @@ class WebRTCMixin extends SettingsMixinDeviceBase<RTCSignalingClient & VideoCame
                 mediaStreamOptions: this.createVideoStreamOptions(),
                 startRTCSignalingSession: (session) => this.mixinDevice.startRTCSignalingSession(session),
                 maximumCompatibilityMode: this.plugin.storageSettings.values.maximumCompatibilityMode,
+                preferPcmu,
             });
 
             this.webrtcIntercom = getIntercom();
@@ -723,6 +727,7 @@ export async function fork() {
             mediaStreamOptions: ResponseMediaStreamOptions,
             startRTCSignalingSession: (session: RTCSignalingSession) => Promise<RTCSessionControl | undefined>,
             maximumCompatibilityMode: boolean,
+            preferPcmu?: boolean,
         }): Promise<RTCPeerConnectionPipe> {
             try {
                 const ret = await createRTCPeerConnectionSource({
@@ -731,6 +736,7 @@ export async function fork() {
                     mediaStreamOptions: options.mediaStreamOptions,
                     startRTCSignalingSession: (session) => options.startRTCSignalingSession(session),
                     maximumCompatibilityMode: options.maximumCompatibilityMode,
+                    preferPcmu: options.preferPcmu,
                 });
                 ret.pcClose().finally(() => delayProcessExit());
                 return ret;

--- a/plugins/webrtc/src/wrtc-to-rtsp.ts
+++ b/plugins/webrtc/src/wrtc-to-rtsp.ts
@@ -33,8 +33,9 @@ export async function createRTCPeerConnectionSource(options: {
     mediaStreamOptions: ResponseMediaStreamOptions,
     startRTCSignalingSession: (session: RTCSignalingSession) => Promise<RTCSessionControl | undefined>,
     maximumCompatibilityMode: boolean,
+    preferPcmu?: boolean,
 }): Promise<RTCPeerConnectionPipe> {
-    const { mediaStreamOptions, startRTCSignalingSession, mixinId, nativeId, maximumCompatibilityMode } = options;
+    const { mediaStreamOptions, startRTCSignalingSession, mixinId, nativeId, maximumCompatibilityMode, preferPcmu } = options;
     const console = mixinId ? sdk.deviceManager.getMixinConsole(mixinId, nativeId) : sdk.deviceManager.getDeviceConsole(nativeId);
 
     const { clientPromise, port } = await listenZeroSingleClient('127.0.0.1');
@@ -64,11 +65,16 @@ export async function createRTCPeerConnectionSource(options: {
         const ensurePeerConnection = (setup: RTCAVSignalingSetup) => {
             if (peerConnection.finished)
                 return;
+            const audioCodecs = preferPcmu
+                ? requiredAudioCodecs.filter(codec => codec.name === 'PCMU' || codec.name === 'PCMA')
+                : requiredAudioCodecs;
+            if (preferPcmu)
+                console.log('Ring doorbell audio compatibility: requiring PCMU/PCMA source audio');
             const ret = new RTCPeerConnection({
                 bundlePolicy: setup.configuration?.bundlePolicy as BundlePolicy,
                 codecs: {
                     audio: [
-                        ...requiredAudioCodecs,
+                        ...audioCodecs,
                     ],
                     video: [
                         requiredVideoCodec,


### PR DESCRIPTION
Fixes #1617.

**Fix for Ring Wired Video Doorbell Pro / Video Doorbell Pro 2 distorted, crackling, fragmented, or missing audio in Apple Home/HomeKit through Scrypted.**

Ring Wired Video Doorbell Pro / Video Doorbell Pro 2 can select Opus even when PCMU is listed first in the WebRTC offer. In HomeKit this produces heavily fragmented, distorted, or missing incoming audio. Excluding Opus from the Ring doorbell source offer makes the device select its stable 8 kHz G.711 PCMU stream.

This change:

- detects only devices from `@scrypted/ring` with type `Doorbell`;
- offers PCMU/PCMA for that source connection;
- keeps the existing codec list for every other camera;
- does not alter video, recording, or intercom handling.

Validation:

- tested on Ring Wired Video Doorbell Pro / Video Doorbell Pro 2 (`lpd_v4`);
- Ring answer negotiated PCMU/8000/mono;
- a 12-second capture contained 201 RTP packets with no missing or reordered sequence numbers and consistent 480-timestamp increments;
- incoming HomeKit audio was physically verified without the previous interference artifacts;
- HomeKit-to-doorbell intercom remained functional;
- other Ring cameras stayed on the existing default codec path;
- `git diff --check` passes.

The tested custom package was WebRTC `0.2.89-phil.4`, used with HomeKit audio transcoding enabled.
