### PR TITLE
python-sdk: publish to PyPI via manual workflow dispatch

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -1,8 +1,7 @@
 name: Python SDK
 
 on:
-  push:
-    tags: ["python-sdk-v*"]
+  workflow_dispatch:
   pull_request:
     paths:
       - "packages/python-client/**"
@@ -34,7 +33,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/python-sdk-v')
+    if: github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment: pypi


### PR DESCRIPTION
## Summary
- Replace the `python-sdk-v*` tag trigger with `workflow_dispatch` so the PyPI publish is kicked off manually from the Actions tab
- Gate the publish job on `github.event_name == 'workflow_dispatch'` instead of the tag ref

PyPI trusted publishing is unaffected — it binds to the workflow filename (`python-sdk.yml`) and the `pypi` environment, not the trigger type. The version published is whatever `packages/python-client/pyproject.toml` contains on the branch the workflow is dispatched from.

## Test plan
- PR build job runs on this change (workflow file is in its own `paths` filter)
- After merge: Actions → Python SDK → Run workflow, and confirm build + publish jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)