### PR TITLE
reolink: add per-camera Motion Trigger setting (Motion + AI / AI Only)

### DIFF
--- a/.github/workflows/upstream-sync.yaml
+++ b/.github/workflows/upstream-sync.yaml
@@ -6,12 +6,18 @@ name: Upstream sync
 # Notes:
 #   * Scheduled workflows are disabled by default in forks - enable Actions on
 #     the "Actions" tab once, otherwise the cron never fires.
-#   * With the default GITHUB_TOKEN, pushes made here do NOT trigger other
-#     workflows, so `test.yml` will not run on the sync PR. To get CI on it,
-#     create a PAT with `repo` scope, store it as the `SYNC_TOKEN` secret, and
-#     this workflow will use it automatically.
+#   * A `SYNC_TOKEN` secret is effectively required. The default GITHUB_TOKEN
+#     may never push a commit that touches `.github/workflows/**` (no
+#     `permissions:` key can grant this), and upstream regularly changes its
+#     own workflows, so those syncs are rejected outright. It also cannot
+#     trigger other workflows, so `test.yml` would not run on the sync PR.
+#     Create a PAT - classic with `repo` + `workflow` scopes, or fine-grained
+#     with Contents and Workflows read/write - and store it as `SYNC_TOKEN`.
 #   * Submodules are deliberately not checked out: the merge only touches the
 #     superproject, and cloning them would make every run much slower.
+#   * Do not add a partial-clone filter here. Pushing a merge commit from a
+#     blobless clone needs upstream blobs the fork does not have, and the push
+#     fails; the full history is only ~40 MiB anyway.
 
 on:
   schedule:
@@ -24,6 +30,7 @@ permissions:
   issues: write
 
 env:
+  HAS_SYNC_TOKEN: ${{ secrets.SYNC_TOKEN != '' }}
   UPSTREAM_REPO: https://github.com/koush/scrypted.git
   UPSTREAM_BRANCH: main
   SYNC_BRANCH: sync/upstream
@@ -36,7 +43,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          filter: blob:none
           submodules: false
           token: ${{ secrets.SYNC_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -48,7 +54,7 @@ jobs:
       - name: 🔗 Fetch upstream
         run: |
           git remote add upstream "$UPSTREAM_REPO" 2>/dev/null || git remote set-url upstream "$UPSTREAM_REPO"
-          git fetch --filter=blob:none upstream "$UPSTREAM_BRANCH"
+          git fetch upstream "$UPSTREAM_BRANCH"
 
       - name: 🔍 Look for new upstream commits
         id: check
@@ -59,12 +65,34 @@ jobs:
             echo "Already up to date with upstream." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          if git diff --quiet "HEAD...upstream/$UPSTREAM_BRANCH" -- .github/workflows; then
+            echo "workflows=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
+          fi
           {
             echo "Upstream \`$UPSTREAM_BRANCH\` has **$count** new commit(s):"
             echo
             git log --no-merges --pretty='- %h %s (%an)' "HEAD..upstream/$UPSTREAM_BRANCH"
           } > /tmp/upstream-changes.md
           cat /tmp/upstream-changes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 🔑 Check the token may push workflow changes
+        if: steps.check.outputs.count != '0' && steps.check.outputs.workflows == 'true' && env.HAS_SYNC_TOKEN != 'true'
+        run: |
+          {
+            echo "### A \`SYNC_TOKEN\` secret is required"
+            echo
+            echo "These upstream commits change files under \`.github/workflows/\`, and"
+            echo "the default GITHUB_TOKEN is never allowed to push those - GitHub"
+            echo "rejects the push: refusing to allow a GitHub App to create or"
+            echo "update workflow ... without workflows permission."
+            echo
+            echo "Create a PAT (classic: \`repo\` + \`workflow\` scopes; fine-grained:"
+            echo "Contents and Workflows read/write) and store it as the \`SYNC_TOKEN\`"
+            echo "repository secret."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
 
       - name: 🔀 Merge upstream into the sync branch
         id: merge
@@ -81,10 +109,20 @@ jobs:
           after=$(git rev-parse HEAD)
           if [ "$before" = "$after" ]; then
             echo "updated=false" >> "$GITHUB_OUTPUT"
-          else
-            git push --force-with-lease origin "$SYNC_BRANCH"
-            echo "updated=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          if ! git push --force-with-lease origin "$SYNC_BRANCH"; then
+            {
+              echo "### Push to \`$SYNC_BRANCH\` failed"
+              echo
+              echo "The merge itself was clean. Check that Actions may write to this"
+              echo "repository (Settings > Actions > General > Workflow permissions:"
+              echo "\"Read and write permissions\"), and that \`SYNC_TOKEN\` is a PAT with"
+              echo "workflow scope if the sync touches \`.github/workflows/\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "updated=true" >> "$GITHUB_OUTPUT"
 
       - name: 🔁 Open or refresh the pull request
         if: steps.merge.outputs.conflict == 'false' && steps.merge.outputs.updated == 'true'

--- a/.github/workflows/upstream-sync.yaml
+++ b/.github/workflows/upstream-sync.yaml
@@ -1,0 +1,129 @@
+name: Upstream sync
+
+# Watches the upstream project this fork is based on and opens a PR with any
+# new commits, so they can be reviewed (and validated by CI) before merging.
+#
+# Notes:
+#   * Scheduled workflows are disabled by default in forks - enable Actions on
+#     the "Actions" tab once, otherwise the cron never fires.
+#   * With the default GITHUB_TOKEN, pushes made here do NOT trigger other
+#     workflows, so `test.yml` will not run on the sync PR. To get CI on it,
+#     create a PAT with `repo` scope, store it as the `SYNC_TOKEN` secret, and
+#     this workflow will use it automatically.
+#   * Submodules are deliberately not checked out: the merge only touches the
+#     superproject, and cloning them would make every run much slower.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  UPSTREAM_REPO: https://github.com/koush/scrypted.git
+  UPSTREAM_BRANCH: main
+  SYNC_BRANCH: sync/upstream
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          submodules: false
+          token: ${{ secrets.SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: ⚙️ Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: 🔗 Fetch upstream
+        run: |
+          git remote add upstream "$UPSTREAM_REPO" 2>/dev/null || git remote set-url upstream "$UPSTREAM_REPO"
+          git fetch --filter=blob:none upstream "$UPSTREAM_BRANCH"
+
+      - name: 🔍 Look for new upstream commits
+        id: check
+        run: |
+          count=$(git rev-list --count "HEAD..upstream/$UPSTREAM_BRANCH")
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" -eq 0 ]; then
+            echo "Already up to date with upstream." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "Upstream \`$UPSTREAM_BRANCH\` has **$count** new commit(s):"
+            echo
+            git log --no-merges --pretty='- %h %s (%an)' "HEAD..upstream/$UPSTREAM_BRANCH"
+          } > /tmp/upstream-changes.md
+          cat /tmp/upstream-changes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 🔀 Merge upstream into the sync branch
+        id: merge
+        if: steps.check.outputs.count != '0'
+        run: |
+          before=$(git rev-parse --verify --quiet "origin/$SYNC_BRANCH" || echo none)
+          git checkout -B "$SYNC_BRANCH"
+          if ! git merge --no-edit "upstream/$UPSTREAM_BRANCH"; then
+            git merge --abort || true
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "conflict=false" >> "$GITHUB_OUTPUT"
+          after=$(git rev-parse HEAD)
+          if [ "$before" = "$after" ]; then
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          else
+            git push --force-with-lease origin "$SYNC_BRANCH"
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 🔁 Open or refresh the pull request
+        if: steps.merge.outputs.conflict == 'false' && steps.merge.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          BASE: ${{ github.event.repository.default_branch }}
+        run: |
+          pr=$(gh pr list --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$pr" ]; then
+            gh pr comment "$pr" --body-file /tmp/upstream-changes.md
+          else
+            gh pr create --base "$BASE" --head "$SYNC_BRANCH" \
+              --title "Sync with upstream ($UPSTREAM_BRANCH)" \
+              --body-file /tmp/upstream-changes.md
+          fi
+
+      - name: 🚨 Report a conflicting merge
+        if: steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create upstream-sync --color BFD4F2 --description "Upstream sync automation" --force
+          issue=$(gh issue list --state open --label upstream-sync --json number --jq '.[0].number // empty')
+          {
+            echo "Merging upstream \`$UPSTREAM_BRANCH\` into this fork hit conflicts, so no PR was opened."
+            echo
+            cat /tmp/upstream-changes.md
+            echo
+            echo "Resolve locally:"
+            echo '```'
+            echo "git fetch upstream $UPSTREAM_BRANCH"
+            echo "git switch -c $SYNC_BRANCH"
+            echo "git merge upstream/$UPSTREAM_BRANCH"
+            echo '```'
+          } > /tmp/conflict.md
+          if [ -n "$issue" ]; then
+            gh issue comment "$issue" --body-file /tmp/conflict.md
+          else
+            gh issue create --label upstream-sync \
+              --title "Upstream sync needs a manual merge" \
+              --body-file /tmp/conflict.md
+          fi

--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -7,7 +7,7 @@ import { OnvifCameraAPI, OnvifEvent, connectCameraAPI } from './onvif-api';
 import { listenEvents } from './onvif-events';
 import { OnvifIntercom } from './onvif-intercom';
 import { DevInfo } from './probe';
-import { AIState, Enc, isDeviceHomeHub, isDeviceNvr, ReolinkCameraClient } from './reolink-api';
+import { AIState, Enc, isDeviceHomeHub, ReolinkCameraClient } from './reolink-api';
 import { ReolinkNvrDevice } from './nvr/nvr';
 import { ReolinkNvrClient } from './nvr/api';
 
@@ -129,6 +129,19 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
             title: 'Motion Timeout',
             defaultValue: 20,
             type: 'number',
+        },
+        motionTrigger: {
+            subgroup: 'Advanced',
+            title: 'Motion Trigger',
+            description: 'Which detections set the motion sensor, and therefore trigger HomeKit Secure Video. '
+                + 'Motion + AI uses both raw motion detection and AI object detection. '
+                + 'AI Only ignores raw motion, so whole-frame brightness changes such as the '
+                + 'day/night IR filter switching or a floodlight turning on no longer trigger recordings.',
+            choices: [
+                'Motion + AI',
+                'AI Only',
+            ],
+            defaultValue: 'Motion + AI',
         },
         hasObjectDetector: {
             json: true,
@@ -597,8 +610,8 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
 
         // reolink ai might not trigger motion if objects are detected, weird.
         const startAI = async (ret: Destroyable, triggerMotion: () => void) => {
-            let hasSucceeded = false;
             let hasSet = false;
+            let failures = 0;
             while (!killed) {
                 try {
                     const ai = this.hasPirEvents() ? await client.getEvents() : await client.getAiState();
@@ -614,16 +627,21 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
                             classes.push(key);
                     }
 
-                    if (!classes.length)
-                        return;
+                    // No supported classes yet. Re-probe on a slow cadence rather than
+                    // exiting: a transient or malformed response would otherwise end
+                    // object detection for the lifetime of the device, and when the
+                    // motion sensor is driven by AI alone that leaves no trigger at all.
+                    if (!classes.length) {
+                        await sleep(10000);
+                        continue;
+                    }
 
-
+                    failures = 0;
                     if (!hasSet) {
                         hasSet = true;
                         this.storageSettings.values.hasObjectDetector = ai;
                     }
 
-                    hasSucceeded = true;
                     const od: ObjectsDetected = {
                         timestamp: Date.now(),
                         detections: [],
@@ -644,9 +662,15 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
                     }
                 }
                 catch (e) {
-                    if (!hasSucceeded && !isDeviceNvr(deviceInfo))
-                        return;
                     ret.emit('error', e);
+                    // Back off instead of exiting. The previous behaviour gave up
+                    // permanently on the first failure for non-NVR devices, so a
+                    // camera that was briefly unreachable never detected objects
+                    // again. Backing off keeps a camera that genuinely has no AI
+                    // from being polled once a second forever.
+                    failures++;
+                    await sleep(Math.min(60000, 1000 * 2 ** Math.min(failures, 6)));
+                    continue;
                 }
                 await sleep(1000);
             }
@@ -717,6 +741,10 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
             clearTimeout(this.motionTimeout);
             this.motionTimeout = setTimeout(() => this.motionDetected = false, this.storageSettings.values.motionTimeout * 1000);
         };
+        // AI Only suppresses the raw motion detector as a motion trigger. The PIR
+        // path is deliberately exempt: a battery camera has no AI state, so PIR is
+        // its only trigger and gating it would leave the camera with none.
+        const aiOnly = () => this.storageSettings.values.motionTrigger === 'AI Only';
         (async () => {
             while (!killed) {
                 try {
@@ -729,7 +757,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
                         ret.emit('data', JSON.stringify(data));
                     } else {
                         const { value, data } = await client.getMotionState();
-                        if (value)
+                        if (value && !aiOnly())
                             triggerMotion();
                         ret.emit('data', JSON.stringify(data));
                     }


### PR DESCRIPTION
The motion sensor was set by two independent 1 Hz pollers with equal weight: GetMdState and the AI object detection state. HomeKit Secure Video has only a MOTION recording trigger, so any raw motion detection became an HKSV clip and a notification.

On an NVR-backed install that makes the camera notify on things that are not subjects at all. A day/night IR filter switch changes the whole frame and trips motion detection even at the lowest sensitivity, as does a floodlight turning on, and both recur every single day at dusk and dawn.

Motion Trigger gates the raw motion detector without touching the AI path, so person, vehicle and animal detections still drive HomeKit. It defaults to Motion + AI, preserving existing behaviour.

The PIR branch is deliberately exempt: a battery camera has no AI state, so PIR is its only trigger and gating it would leave the camera with none.

Also make the AI poll survive a bad response. It previously returned out of the loop for good when a poll reported no supported classes, and for non-NVR devices on the first exception, so a camera that was briefly unreachable never detected objects again. That was masked by raw motion keeping the sensor alive; with AI Only there is no such fallback, and a camera would have gone permanently silent with nothing indicating why. Failures now back off exponentially to 60s instead of exiting.