### PR TITLE
objectdetector: fix "Built-In Motion Sensor" description to say "Assist" instead of "Filter"

### DIFF
--- a/plugins/objectdetector/src/main.ts
+++ b/plugins/objectdetector/src/main.ts
@@ -64,7 +64,7 @@ class ObjectDetectionMixin extends SettingsMixinDeviceBase<VideoCamera & Camera 
     },
     motionSensorSupplementation: {
       title: 'Built-In Motion Sensor',
-      description: `This camera has a built in motion sensor. Using ${this.objectDetection.name} may be unnecessary and will use additional CPU. Replace will ignore the built in motion sensor. Filter will verify the motion sent by built in motion sensor. The Default is ${BUILTIN_MOTION_SENSOR_REPLACE}.`,
+      description: `This camera has a built in motion sensor. Using ${this.objectDetection.name} may be unnecessary and will use additional CPU. Replace will ignore the built in motion sensor. ${BUILTIN_MOTION_SENSOR_ASSIST} will verify the motion sent by built in motion sensor. The Default is ${BUILTIN_MOTION_SENSOR_REPLACE}.`,
       choices: [
         'Default',
         BUILTIN_MOTION_SENSOR_ASSIST,


### PR DESCRIPTION
Fixes #2116

The `motionSensorSupplementation` setting's description hardcoded the literal word "Filter" instead of interpolating `BUILTIN_MOTION_SENSOR_ASSIST` ("Assist") — the only options are Default/Assist/Replace, so the description referenced a choice that does not exist. One-line fix, no behavior change.