### PR TITLE
auth-fetch: fix Digest authentication token quoting

### DIFF
--- a/packages/auth-fetch/src/auth-fetch.ts
+++ b/packages/auth-fetch/src/auth-fetch.ts
@@ -55,7 +55,11 @@ async function getAuth(options: AuthFetchOptions, url: string | URL, method: str
             ...digest.data,
         });
 
-        return header;
+        // RFC 7616 requires algorithm, qop, and nc to be unquoted tokens.
+        return header
+            .replace(`algorithm="${digest.data.algorithm}"`, `algorithm=${digest.data.algorithm}`)
+            .replace(`qop="${digest.data.qop}"`, `qop=${digest.data.qop}`)
+            .replace(`nc="${nc}"`, `nc=${nc}`);
     }
     else if (basic) {
         const { BASIC, buildAuthorizationHeader } = await import('http-auth-utils');


### PR DESCRIPTION
## Summary

Fix HTTP Digest authentication headers so `algorithm`, `qop`, and `nc` use unquoted token syntax.  Reported in issue #2122 

## Root cause

`http-auth-utils` quotes every Digest parameter when building the `Authorization` header. RFC 7616 section 3.4 requires clients not to quote `algorithm`, `qop`, or `nc`.

Some Amcrest camera models tolerate the quoted form, but others reject the authenticated retry with another HTTP 401.

## Validation

- Captured the expected initial Digest challenge from an affected Amcrest camera.
- Reproduced `401 -> 401` with quoted `qop` and `nc`.
- Repeated the same request with identical Digest inputs and unquoted tokens, producing `401 -> 200`.
- Verified `curl --digest` succeeds against the same endpoint.
- Applied the equivalent change as a temporary bundle canary in Scrypted; codec discovery, event listening, snapshots, and RTSP setup recovered without further authentication failures.

## Testing

The `@scrypted/auth-fetch` package does not currently have an automated test command (its test script exits with "Error: no test specified").