### PR TITLE
cloud: refresh cached cloudflared binary

### DIFF
--- a/plugins/cloud/src/cloudflared-install.ts
+++ b/plugins/cloud/src/cloudflared-install.ts
@@ -6,13 +6,13 @@ import { httpFetch } from '../../../server/src/fetch/http-fetch';
 
 export async function installCloudflared() {
     const pluginVolume = process.env.SCRYPTED_PLUGIN_VOLUME;
-    const version = 5;
+    const version = 6;
     const cloudflareD = path.join(pluginVolume, 'cloudflare.d', `v${version}`, `${process.platform}-${process.arch}`);
     const bin = path.join(cloudflareD, cloudflared.bin);
 
     if (!fs.existsSync(bin)) {
         for (let i = 0; i <= version; i++) {
-            const cloudflareD = path.join(pluginVolume, 'cloudflare.d', `v${version}`);
+            const cloudflareD = path.join(pluginVolume, 'cloudflare.d', `v${i}`);
             rmSync(cloudflareD, {
                 force: true,
                 recursive: true,


### PR DESCRIPTION
## What changed

- bump the Scrypted Cloud `cloudflared` cache generation from `v5` to `v6`, forcing one fresh download
- use the cleanup loop index when removing prior cache generations

## Why

`cloudflared` 2026.8.0 introduced path normalization that removed trailing slashes. For Scrypted public plugin routes, `/endpoint/@scrypted/core/public/` could therefore reach Scrypted as `/endpoint/@scrypted/core/public` and return `401 Not Authorized`.

Cloudflare tracked the regression in [cloudflared#1717](https://github.com/cloudflare/cloudflared/issues/1717) and reverted the normalization in [2026.8.2](https://github.com/cloudflare/cloudflared/releases/tag/2026.8.2). However, Scrypted currently reuses an existing cached binary indefinitely, leaving installations that downloaded the affected release on that binary after plugin and server restarts.

Moving to cache generation `v6` refreshes those installations. Correcting `v${version}` to `v${i}` also makes the existing cleanup loop remove each previous generation as intended.

## Validation

- `npm run build` in `plugins/cloud`
- focused installer simulation confirming stale `v0`, `v3`, and `v5` directories are removed, `v6` is installed once, and a subsequent call reuses the cached `v6` binary
- `git diff --check`
