### PR TITLE
unifi-protect: optionally trigger motion from smart detections

### DIFF
--- a/plugins/unifi-protect/package-lock.json
+++ b/plugins/unifi-protect/package-lock.json
@@ -17,7 +17,9 @@
          },
          "devDependencies": {
             "@types/node": "^22.15.29",
-            "@types/ws": "^8.18.1"
+            "@types/ws": "^8.18.1",
+            "ts-node": "^10.9.2",
+            "typescript": "^5.9.3"
          }
       },
       "../../common": {
@@ -4088,6 +4090,207 @@
             "utf-8-validate": {
                "optional": true
             }
+         }
+      },
+      "node_modules/@cspotcode/source-map-support": {
+         "version": "0.8.1",
+         "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+         "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@jridgewell/trace-mapping": "0.3.9"
+         },
+         "engines": {
+            "node": ">=12"
+         }
+      },
+      "node_modules/@jridgewell/resolve-uri": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+         "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=6.0.0"
+         }
+      },
+      "node_modules/@jridgewell/sourcemap-codec": {
+         "version": "1.5.5",
+         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+         "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@jridgewell/trace-mapping": {
+         "version": "0.3.9",
+         "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+         "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+         }
+      },
+      "node_modules/@tsconfig/node10": {
+         "version": "1.0.13",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+         "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@tsconfig/node12": {
+         "version": "1.0.11",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+         "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@tsconfig/node14": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+         "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/@tsconfig/node16": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+         "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/acorn": {
+         "version": "8.18.0",
+         "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+         "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+         "dev": true,
+         "license": "MIT",
+         "bin": {
+            "acorn": "bin/acorn"
+         },
+         "engines": {
+            "node": ">=0.4.0"
+         }
+      },
+      "node_modules/acorn-walk": {
+         "version": "8.3.5",
+         "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+         "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "acorn": "^8.11.0"
+         },
+         "engines": {
+            "node": ">=0.4.0"
+         }
+      },
+      "node_modules/arg": {
+         "version": "4.1.3",
+         "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+         "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/create-require": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+         "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/diff": {
+         "version": "4.0.4",
+         "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+         "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+         "dev": true,
+         "license": "BSD-3-Clause",
+         "engines": {
+            "node": ">=0.3.1"
+         }
+      },
+      "node_modules/make-error": {
+         "version": "1.3.6",
+         "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+         "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+         "dev": true,
+         "license": "ISC"
+      },
+      "node_modules/ts-node": {
+         "version": "10.9.2",
+         "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+         "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "@cspotcode/source-map-support": "^0.8.0",
+            "@tsconfig/node10": "^1.0.7",
+            "@tsconfig/node12": "^1.0.7",
+            "@tsconfig/node14": "^1.0.0",
+            "@tsconfig/node16": "^1.0.2",
+            "acorn": "^8.4.1",
+            "acorn-walk": "^8.1.1",
+            "arg": "^4.1.0",
+            "create-require": "^1.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "v8-compile-cache-lib": "^3.0.1",
+            "yn": "3.1.1"
+         },
+         "bin": {
+            "ts-node": "dist/bin.js",
+            "ts-node-cwd": "dist/bin-cwd.js",
+            "ts-node-esm": "dist/bin-esm.js",
+            "ts-node-script": "dist/bin-script.js",
+            "ts-node-transpile-only": "dist/bin-transpile.js",
+            "ts-script": "dist/bin-script-deprecated.js"
+         },
+         "peerDependencies": {
+            "@swc/core": ">=1.2.50",
+            "@swc/wasm": ">=1.2.50",
+            "@types/node": "*",
+            "typescript": ">=2.7"
+         },
+         "peerDependenciesMeta": {
+            "@swc/core": {
+               "optional": true
+            },
+            "@swc/wasm": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/typescript": {
+         "version": "5.9.3",
+         "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+         "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "bin": {
+            "tsc": "bin/tsc",
+            "tsserver": "bin/tsserver"
+         },
+         "engines": {
+            "node": ">=14.17"
+         }
+      },
+      "node_modules/v8-compile-cache-lib": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+         "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+         "dev": true,
+         "license": "MIT"
+      },
+      "node_modules/yn": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+         "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=6"
          }
       }
    }

--- a/plugins/unifi-protect/package.json
+++ b/plugins/unifi-protect/package.json
@@ -15,7 +15,8 @@
       "scrypted-debug": "scrypted-debug",
       "scrypted-deploy": "scrypted-deploy",
       "scrypted-readme": "scrypted-readme",
-      "scrypted-package-json": "scrypted-package-json"
+      "scrypted-package-json": "scrypted-package-json",
+      "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"CommonJS\"}' node --require ts-node/register --test test/*.test.ts"
    },
    "keywords": [
       "scrypted",
@@ -36,7 +37,9 @@
    },
    "devDependencies": {
       "@types/node": "^22.15.29",
-      "@types/ws": "^8.18.1"
+      "@types/ws": "^8.18.1",
+      "ts-node": "^10.9.2",
+      "typescript": "^5.9.3"
    },
    "dependencies": {
       "@scrypted/common": "file:../../common",

--- a/plugins/unifi-protect/src/camera-sensors.ts
+++ b/plugins/unifi-protect/src/camera-sensors.ts
@@ -11,6 +11,22 @@ export interface UnifiFingerprintDevice {
     setFingerprintDetected(fingerprintDetected: boolean): void;
 }
 
+export function isSmartDetectionEvent(eventType: string) {
+    return eventType === 'smartDetectZone' || eventType === 'smartDetectLine';
+}
+
+export function shouldTriggerMotionFromEvent(eventType: string, smartDetectionAsMotion: boolean) {
+    return eventType === 'motion' || (smartDetectionAsMotion && isSmartDetectionEvent(eventType));
+}
+
+export function handleMotionEvent(device: UnifiMotionDevice, eventType: string, smartDetectionAsMotion: boolean) {
+    if (!shouldTriggerMotionFromEvent(eventType, smartDetectionAsMotion))
+        return false;
+
+    debounceMotionDetected(device);
+    return true;
+}
+
 export function debounceMotionDetected(device: UnifiMotionDevice) {
     device.setMotionDetected(true);
     clearTimeout(device.motionTimeout);

--- a/plugins/unifi-protect/src/camera.ts
+++ b/plugins/unifi-protect/src/camera.ts
@@ -307,6 +307,14 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     async getSettings(): Promise<Setting[]> {
         // const vsos = await this.getVideoStreamOptions();
         return [
+            {
+                key: 'smartDetectionAsMotion',
+                title: 'Smart Detections Trigger Motion',
+                description: 'Use Protect smart detection events to report motion. Enable this for cameras that report smart detections but do not report regular motion events.',
+                type: 'boolean',
+                value: this.smartDetectionAsMotion,
+                group: 'Advanced',
+            },
             // {
             //     title: 'Sensor Timeout',
             //     key: 'sensorTimeout',
@@ -314,6 +322,10 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
             //     description: 'Time to wait in seconds before clearing the motion, doorbell button, or object detection state.',
             // }
         ];
+    }
+
+    get smartDetectionAsMotion() {
+        return this.storage.getItem('smartDetectionAsMotion') === 'true';
     }
 
     async putSetting(key: string, value: string | number | boolean) {

--- a/plugins/unifi-protect/src/main.ts
+++ b/plugins/unifi-protect/src/main.ts
@@ -5,7 +5,7 @@ import { StorageSettings } from "@scrypted/sdk/storage-settings";
 import axios, { ResponseType } from "axios";
 import https from 'https';
 import { UnifiCamera } from "./camera";
-import { debounceFingerprintDetected, debounceMotionDetected } from "./camera-sensors";
+import { debounceFingerprintDetected, handleMotionEvent, isSmartDetectionEvent } from "./camera-sensors";
 import { UnifiLight } from "./light";
 import { UnifiLock } from "./lock";
 import { UnifiSensor } from "./sensor";
@@ -230,7 +230,7 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
                 //     modelKey: 'event'
                 // }
 
-                if (payload.type === 'smartDetectZone' || payload.type === 'smartDetectLine') {
+                if (isSmartDetectionEvent(payload.type)) {
                     unifiCamera.resetDetectionTimeout();
 
                     detections = payload.smartDetectTypes.map(type => ({
@@ -250,9 +250,6 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
                         unifiCamera.lastRing = payload.start;
                         unifiCamera.resetRingTimeout();
                     }
-                    else if (payload.type === 'motion') {
-                        debounceMotionDetected(unifiCamera);
-                    }
                     else if (payload.type === 'fingerprintIdentified') {
                         const anypay = payload as any;
                         const userId: string = anypay.metadata?.fingerprint?.userId || anypay.metadata?.fingerprint?.ulpId;
@@ -263,6 +260,8 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
                         }
                     }
                 }
+
+                handleMotionEvent(unifiCamera, payload.type, unifiCamera.smartDetectionAsMotion);
 
                 const detection: ObjectsDetected = {
                     detectionId,

--- a/plugins/unifi-protect/test/camera-sensors.test.ts
+++ b/plugins/unifi-protect/test/camera-sensors.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { handleMotionEvent, shouldTriggerMotionFromEvent, UnifiMotionDevice } from '../src/camera-sensors';
+
+test('regular motion events always trigger motion', () => {
+    assert.equal(shouldTriggerMotionFromEvent('motion', false), true);
+});
+
+test('smart detection events only trigger motion when enabled', () => {
+    assert.equal(shouldTriggerMotionFromEvent('smartDetectZone', false), false);
+    assert.equal(shouldTriggerMotionFromEvent('smartDetectLine', false), false);
+    assert.equal(shouldTriggerMotionFromEvent('smartDetectZone', true), true);
+    assert.equal(shouldTriggerMotionFromEvent('smartDetectLine', true), true);
+});
+
+test('unrelated events do not trigger motion', () => {
+    assert.equal(shouldTriggerMotionFromEvent('ring', true), false);
+    assert.equal(shouldTriggerMotionFromEvent('fingerprintIdentified', true), false);
+});
+
+test('event routing invokes the existing motion debounce only for configured events', () => {
+    const states: boolean[] = [];
+    const device: UnifiMotionDevice = {
+        motionTimeout: setTimeout(() => undefined, 0),
+        setMotionDetected: state => states.push(state),
+    };
+
+    assert.equal(handleMotionEvent(device, 'smartDetectZone', false), false);
+    assert.deepEqual(states, []);
+
+    assert.equal(handleMotionEvent(device, 'smartDetectZone', true), true);
+    assert.deepEqual(states, [true]);
+
+    assert.equal(handleMotionEvent(device, 'motion', false), true);
+    assert.deepEqual(states, [true, true]);
+
+    clearTimeout(device.motionTimeout);
+});


### PR DESCRIPTION
## Problem

Some UniFi Protect cameras can report `smartDetectZone`/`smartDetectLine` events without reporting a regular `motion` event. The plugin currently publishes those events through `ObjectDetector`, but the camera's `MotionSensor` remains inactive. Motion-based consumers such as HomeKit Secure Video therefore do not start a recording for those detections.

This was observed with a G5 PTZ, but the behavior should not be keyed to a camera name or model.

## Solution

- Add an opt-in per-camera advanced setting, **Smart Detections Trigger Motion**.
- When enabled, route `smartDetectZone` and `smartDetectLine` through the existing `debounceMotionDetected` path.
- Keep the setting disabled by default, so existing behavior is unchanged for every camera.
- Keep regular `motion` events working exactly as before and ignore unrelated event types.

This avoids model/name heuristics and lets users enable the fallback only on cameras that need it. Cameras that already report regular motion can leave the setting disabled.

## Tests

- Added focused tests for regular motion, enabled/disabled smart detection fallback, unrelated events, and the actual event-to-debounce routing.
- Confirmed the smart-detection test fails when the fallback implementation is temporarily reverted to the previous motion-only behavior.
- `npm test` — 4 tests passed on Node 18 and Node 22.
- `npm run build` — passed for `plugins/unifi-protect` after the repository's standard `npm-install.sh` setup. The build reports the existing `server/src/rpc.ts` TS4113 warning but completes successfully.

Related context: #1793
