### PR TITLE
reolink: add opt-in Baichuan protocol for lower-latency two-way audio

### DIFF
--- a/plugins/reolink/package-lock.json
+++ b/plugins/reolink/package-lock.json
@@ -11,7 +11,9 @@
          "dependencies": {
             "@scrypted/common": "file:../../common",
             "@scrypted/sdk": "file:../../sdk",
-            "onvif": "file:../onvif/onvif"
+            "@types/xml2js": "^0.4.14",
+            "onvif": "file:../onvif/onvif",
+            "xml2js": "^0.6.2"
          },
          "devDependencies": {
             "@scrypted/sdk": "file:../../sdk",
@@ -119,9 +121,27 @@
             "undici-types": "~6.21.0"
          }
       },
+      "node_modules/@types/xml2js": {
+         "version": "0.4.14",
+         "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+         "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+         "license": "MIT",
+         "dependencies": {
+            "@types/node": "*"
+         }
+      },
       "node_modules/onvif": {
          "resolved": "../onvif/onvif",
          "link": true
+      },
+      "node_modules/sax": {
+         "version": "1.6.1",
+         "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+         "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+         "license": "BlueOak-1.0.0",
+         "engines": {
+            "node": ">=11.0.0"
+         }
       },
       "node_modules/undici-types": {
          "version": "6.21.0",
@@ -129,6 +149,28 @@
          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
          "dev": true,
          "license": "MIT"
+      },
+      "node_modules/xml2js": {
+         "version": "0.6.2",
+         "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+         "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+         "license": "MIT",
+         "dependencies": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~11.0.0"
+         },
+         "engines": {
+            "node": ">=4.0.0"
+         }
+      },
+      "node_modules/xmlbuilder": {
+         "version": "11.0.1",
+         "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+         "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=4.0"
+         }
       }
    }
 }

--- a/plugins/reolink/package.json
+++ b/plugins/reolink/package.json
@@ -39,7 +39,9 @@
    "dependencies": {
       "@scrypted/common": "file:../../common",
       "@scrypted/sdk": "file:../../sdk",
-      "onvif": "file:../onvif/onvif"
+      "@types/xml2js": "^0.4.14",
+      "onvif": "file:../onvif/onvif",
+      "xml2js": "^0.6.2"
    },
    "devDependencies": {
       "@scrypted/sdk": "file:../../sdk",

--- a/plugins/reolink/src/baichuan-intercom.ts
+++ b/plugins/reolink/src/baichuan-intercom.ts
@@ -1,0 +1,130 @@
+import { readLength, StreamEndError } from '@scrypted/common/src/read-stream';
+import { ffmpegLogInitialOutput, safeKillFFmpeg, safePrintFFmpegArguments } from '@scrypted/common/src/media-helpers';
+import sdk, { FFmpegInput, Intercom, MediaObject, ScryptedMimeTypes } from '@scrypted/sdk';
+import child_process, { ChildProcess } from 'child_process';
+import { Readable } from 'stream';
+import { RtspSmartCamera } from '../../rtsp/src/rtsp';
+import { BaichuanClient, TalkSession } from './baichuan/client';
+
+const { mediaManager } = sdk;
+
+const DEFAULT_BAICHUAN_PORT = 9000;
+
+/**
+ * Two-way audio over Reolink's proprietary Baichuan protocol, as a
+ * lower-latency alternative to the ONVIF backchannel (`OnvifIntercom`).
+ * Baichuan carries raw ADPCM audio blocks directly, with no RTP layer or
+ * jitter buffer, which is where most of the latency difference measured
+ * against a real device came from.
+ *
+ * One `BaichuanClient`/talk session is opened per `startIntercom()` call
+ * and fully torn down on `stopIntercom()` - see BaichuanClient's own doc
+ * comment for why sessions are not reused.
+ */
+export class BaichuanIntercom implements Intercom {
+    private process: ChildProcess;
+    private client: BaichuanClient;
+    private session: TalkSession;
+
+    constructor(public camera: RtspSmartCamera) {
+    }
+
+    async startIntercom(media: MediaObject): Promise<void> {
+        await this.stopIntercom();
+
+        const ffmpegInput: FFmpegInput = JSON.parse((await mediaManager.convertMediaObjectToBuffer(media, ScryptedMimeTypes.FFmpegInput)).toString());
+
+        const port = parseInt(this.camera.storage.getItem('baichuanPort')) || DEFAULT_BAICHUAN_PORT;
+        const client = new BaichuanClient({
+            host: this.camera.getIPAddress(),
+            port,
+            username: this.camera.getUsername(),
+            password: this.camera.getPassword(),
+            console: this.camera.console,
+        });
+
+        await client.connect();
+        await client.login();
+        const session = await client.startTalk();
+        this.client = client;
+        this.session = session;
+        this.camera.console.log(`baichuan intercom: talk session open (${session.sampleRate}Hz, ${session.samplesPerBlock} samples/block)`);
+
+        const ffmpegArgs = ffmpegInput.inputArguments.slice();
+        ffmpegArgs.push(
+            // Audio only - no video/data/subtitle streams to deal with.
+            '-vn', '-dn', '-sn',
+            // Raw signed 16-bit PCM, matching what AdpcmEncoder expects.
+            '-acodec', 'pcm_s16le',
+            // Bypass ffmpeg's own internal buffering; we want each block
+            // written to the pipe as soon as it's encoded.
+            '-avioflags', 'direct',
+            '-fflags', '+flush_packets+nobuffer',
+            '-flush_packets', '1',
+            '-flags', '+global_header+low_delay',
+            '-ac', '1',
+            '-ar', session.sampleRate.toString(),
+            '-f', 's16le',
+            '-muxdelay', '0',
+            'pipe:3',
+        );
+
+        safePrintFFmpegArguments(this.camera.console, ffmpegArgs);
+        const cp = child_process.spawn(await mediaManager.getFFmpegPath(), ffmpegArgs, {
+            stdio: ['pipe', 'pipe', 'pipe', 'pipe'],
+        });
+        this.process = cp;
+        ffmpegLogInitialOutput(this.camera.console, cp);
+        cp.on('exit', () => this.camera.console.log('baichuan intercom: ffmpeg exited'));
+
+        const socket = cp.stdio[3] as Readable;
+        const pcmBytesPerBlock = session.pcmBytesPerBlock;
+
+        (async () => {
+            try {
+                while (true) {
+                    const data = await readLength(socket, pcmBytesPerBlock);
+                    if (!data.length)
+                        break;
+                    // Read as int16 samples rather than viewing the Buffer's
+                    // underlying ArrayBuffer directly: Node may hand back a
+                    // Buffer backed by a shared, oddly-offset pool, which an
+                    // Int16Array view would misinterpret or throw on.
+                    const samples = new Int16Array(pcmBytesPerBlock / 2);
+                    for (let i = 0; i < samples.length; i++)
+                        samples[i] = data.readInt16LE(i * 2);
+                    await session.writeSamples(samples);
+                }
+            }
+            catch (e) {
+                if (!(e instanceof StreamEndError))
+                    this.camera.console.error('baichuan intercom: audio pipeline error', e);
+            }
+            finally {
+                await this.stopIntercom();
+            }
+        })();
+    }
+
+    async stopIntercom(): Promise<void> {
+        if (this.process) {
+            safeKillFFmpeg(this.process);
+            this.process = undefined;
+        }
+
+        const session = this.session;
+        const client = this.client;
+        this.session = undefined;
+        this.client = undefined;
+
+        try {
+            await session?.close();
+        }
+        catch (e) {
+            this.camera.console.error('baichuan intercom: error closing talk session', e);
+        }
+        finally {
+            client?.close();
+        }
+    }
+}

--- a/plugins/reolink/src/baichuan-intercom.ts
+++ b/plugins/reolink/src/baichuan-intercom.ts
@@ -22,9 +22,11 @@ const DEFAULT_BAICHUAN_PORT = 9000;
  * comment for why sessions are not reused.
  */
 export class BaichuanIntercom implements Intercom {
-    private process: ChildProcess;
-    private client: BaichuanClient;
-    private session: TalkSession;
+    // All three are assigned together in startIntercom() and cleared
+    // together in stopIntercom(); undefined whenever no session is active.
+    private process: ChildProcess | undefined;
+    private client: BaichuanClient | undefined;
+    private session: TalkSession | undefined;
 
     constructor(public camera: RtspSmartCamera) {
     }
@@ -84,7 +86,7 @@ export class BaichuanIntercom implements Intercom {
             try {
                 while (true) {
                     const data = await readLength(socket, pcmBytesPerBlock);
-                    if (!data.length)
+                    if (!data.length || session.closed)
                         break;
                     // Read as int16 samples rather than viewing the Buffer's
                     // underlying ArrayBuffer directly: Node may hand back a
@@ -97,7 +99,15 @@ export class BaichuanIntercom implements Intercom {
                 }
             }
             catch (e) {
-                if (!(e instanceof StreamEndError))
+                // A caller hanging up races naturally against the last
+                // already-in-flight chunk from ffmpeg: stopIntercom() (from
+                // the hangup) can close the session between this loop's
+                // readLength() returning and its writeSamples() call. That
+                // is a normal end of call, not a real error - the explicit
+                // session.closed check above avoids it in the common case,
+                // this only catches the rare case where the close happens
+                // mid-iteration.
+                if (!(e instanceof StreamEndError) && !(e instanceof Error && session.closed))
                     this.camera.console.error('baichuan intercom: audio pipeline error', e);
             }
             finally {

--- a/plugins/reolink/src/baichuan/adpcm.ts
+++ b/plugins/reolink/src/baichuan/adpcm.ts
@@ -1,0 +1,96 @@
+// IMA-ADPCM (DVI-4) encoder for Baichuan's Talk audio blocks.
+//
+// Ported 1:1 from AlexxIT/go2rtc's pkg/baichuan/adpcm.go (MIT licensed),
+// which is tested against real Reolink hardware including this doorbell
+// family, and cross-checked against a live-tested Python port produced
+// during this session's reverse-engineering. Two details matter and are
+// easy to get wrong porting from other IMA-ADPCM references:
+//
+//   1. The predictor/step-index state PERSISTS across `encodeBlock()` calls
+//      within one `AdpcmEncoder` instance - each 4-byte block header
+//      records whatever the running state happens to be at the *start* of
+//      that block, it is not reset to zero per block.
+//   2. Within a byte, the FIRST sample's 4-bit code goes in the HIGH
+//      nibble and the second sample's code in the LOW nibble. Getting this
+//      backwards produces audio that is present but unrecognizable noise.
+
+const STEP_TABLE = [
+    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31,
+    34, 37, 41, 45, 50, 55, 60, 66, 73, 80, 88, 97, 107, 118, 130, 143,
+    157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449, 494, 544, 598, 658,
+    724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272, 2499, 2749, 3024,
+    3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
+    15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767,
+];
+
+const INDEX_TABLE = [-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8];
+
+function clamp(value: number, min: number, max: number): number {
+    return value < min ? min : value > max ? max : value;
+}
+
+export class AdpcmEncoder {
+    private predicted = 0;
+    private index = 0;
+
+    private encodeNibble(sample: number): number {
+        const step = STEP_TABLE[this.index];
+        let diff = sample - this.predicted;
+        let nibble = 0;
+
+        if (diff < 0) {
+            nibble |= 8;
+            diff = -diff;
+        }
+
+        let delta = step >> 3;
+        if (diff >= step) {
+            nibble |= 4;
+            diff -= step;
+            delta += step;
+        }
+        if (diff >= step >> 1) {
+            nibble |= 2;
+            diff -= step >> 1;
+            delta += step >> 1;
+        }
+        if (diff >= step >> 2) {
+            nibble |= 1;
+            delta += step >> 2;
+        }
+
+        this.predicted = clamp(nibble & 8 ? this.predicted - delta : this.predicted + delta, -32768, 32767);
+        this.index = clamp(this.index + INDEX_TABLE[nibble], 0, 88);
+
+        return nibble;
+    }
+
+    /**
+     * Encodes one block of 16-bit PCM samples (an even count, typically the
+     * device's `lengthPerEncoder` from its TalkAbility response) into a
+     * Baichuan ADPCM block: a 4-byte header (predictor state at the start
+     * of this block) followed by one nibble per sample, two samples packed
+     * per byte.
+     */
+    encodeBlock(pcm: Int16Array | number[]): Buffer {
+        if (pcm.length === 0)
+            throw new Error('adpcm block requires at least one sample');
+        if (pcm.length % 2 !== 0)
+            throw new Error(`adpcm block sample count must be even, got ${pcm.length}`);
+
+        const out = Buffer.alloc(4 + pcm.length / 2);
+        out.writeInt16LE(this.predicted, 0);
+        out.writeUInt8(this.index & 0xff, 2);
+        out.writeUInt8(0, 3);
+
+        let writePos = 4;
+        for (let i = 0; i < pcm.length; i += 2) {
+            const first = this.encodeNibble(pcm[i]);
+            const second = this.encodeNibble(pcm[i + 1]);
+            out.writeUInt8((first << 4) | second, writePos);
+            writePos++;
+        }
+
+        return out;
+    }
+}

--- a/plugins/reolink/src/baichuan/client.ts
+++ b/plugins/reolink/src/baichuan/client.ts
@@ -1,0 +1,380 @@
+import { readLength } from '@scrypted/common/src/read-stream';
+import net from 'net';
+import {
+    EncryptionMode,
+    deriveAesKey,
+    encryptXml,
+    decryptXml,
+    md5Truncated,
+} from './crypto';
+import {
+    BcHeader,
+    HeaderClass,
+    MsgId,
+    buildBody,
+    headerLenForClass,
+    packHeader,
+    parseHeader,
+    serializeTalkAdpcmBlock,
+    splitBody,
+} from './protocol';
+import { AdpcmEncoder } from './adpcm';
+import {
+    TalkAbility,
+    TalkAudioConfig,
+    buildExtensionXml,
+    buildLoginXml,
+    buildTalkConfigXml,
+    parseNonce,
+    parseTalkAbility,
+} from './xml';
+
+export interface BaichuanClientOptions {
+    host: string;
+    port: number;
+    username: string;
+    password: string;
+    channelId?: number;
+    console?: Console;
+    /** Milliseconds to wait for the TCP connection and for each reply. */
+    timeout?: number;
+}
+
+export class BaichuanStatusError extends Error {
+    constructor(public readonly code: number, public readonly msgId: number) {
+        super(`baichuan: request msgId=${msgId} failed with status ${code}`);
+    }
+}
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+/**
+ * A minimal Baichuan protocol client covering what two-way audio (Talk)
+ * needs: login, TalkAbility, TalkConfig/Talk/TalkReset. Not a general
+ * purpose Baichuan client (no video, no PTZ, etc. - see the plugin's
+ * BaichuanIntercom for how this is used, and the phase 1 plan for why
+ * those are out of scope here).
+ *
+ * One client is meant to cover one short-lived session (e.g. one intercom
+ * call): call `login()` once, use it, then `close()`. Reusing a client
+ * across multiple Talk sessions was tried live and left the device's audio
+ * pipeline in a state where TalkConfig still returned success but no audio
+ * actually played - a fresh connection per session avoids that reliably
+ * and matches how the official app behaves.
+ */
+export class BaichuanClient {
+    // Assigned in connect(), which must be awaited before any other method is used.
+    private socket!: net.Socket;
+    private encryptionMode = EncryptionMode.BC;
+    private aesKey: Buffer | undefined;
+    private msgNum = 0;
+    private readonly channelId: number;
+    private readonly console: Console | undefined;
+    private readonly timeout: number;
+
+    constructor(private readonly options: BaichuanClientOptions) {
+        this.channelId = options.channelId ?? 0;
+        this.console = options.console;
+        this.timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    }
+
+    private nextMsgNum(): number {
+        this.msgNum++;
+        return this.msgNum;
+    }
+
+    async connect(): Promise<void> {
+        this.socket = new net.Socket();
+        await new Promise<void>((resolve, reject) => {
+            const onError = (err: Error) => {
+                this.socket.removeListener('connect', onConnect);
+                reject(err);
+            };
+            const onConnect = () => {
+                this.socket.removeListener('error', onError);
+                resolve();
+            };
+            this.socket.once('error', onError);
+            this.socket.once('connect', onConnect);
+            this.socket.setTimeout(this.timeout);
+            this.socket.connect(this.options.port, this.options.host);
+        });
+    }
+
+    /**
+     * Performs the full login handshake: an unauthenticated legacy probe to
+     * obtain the session nonce and the device's negotiated encryption
+     * level, followed by the modern LoginUser/LoginNet exchange.
+     *
+     * The very first probe message (and only that message) uses the
+     * 20-byte legacy header layout; every subsequent message, including
+     * the modern login itself, uses the 24-byte layout. Both login
+     * messages are always encrypted with the classic BC XOR cipher
+     * regardless of the negotiated AES level - observed live and confirmed
+     * against the go2rtc reference (login always caps at BC, matching
+     * "the encryption protocol cannot go higher than BCEncrypt" for msg id
+     * 1). AES only applies to every message after login completes.
+     */
+    async login(): Promise<void> {
+        // Request the highest encryption level (0x12 = full AES); the device
+        // tells us in its reply what it actually negotiated.
+        const probeHeader: BcHeader = {
+            msgId: MsgId.Login,
+            bodyLen: 0,
+            channelId: this.channelId,
+            streamType: 0,
+            msgNum: 0,
+            responseCode: 0xdc12,
+            msgClass: HeaderClass.Legacy,
+        };
+        this.socket.write(packHeader(probeHeader));
+
+        const probeReply = await this.readRawMessage();
+        const nonce = parseNonce(this.decodeXml(probeReply.header, probeReply.body, EncryptionMode.BC));
+        const encryptionLevel = probeReply.header.responseCode & 0xff;
+        this.encryptionMode = encryptionLevel === 0 ? EncryptionMode.None : encryptionLevel === 1 ? EncryptionMode.BC : EncryptionMode.AES;
+        this.aesKey = deriveAesKey(nonce, this.options.password);
+
+        const loginXml = buildLoginXml(
+            md5Truncated(`${this.options.username}${nonce}`),
+            md5Truncated(`${this.options.password}${nonce}`),
+        );
+        const loginBody = encryptXml(EncryptionMode.BC, undefined, this.channelId, Buffer.from(loginXml, 'utf8'));
+        const loginHeader: BcHeader = {
+            msgId: MsgId.Login,
+            bodyLen: loginBody.length,
+            channelId: this.channelId,
+            streamType: 0,
+            msgNum: 0,
+            responseCode: 0,
+            msgClass: HeaderClass.ModernWithOffset,
+            binOffset: 0,
+        };
+        this.socket.write(Buffer.concat([packHeader(loginHeader), loginBody]));
+
+        const loginReply = await this.waitForReply(0);
+        if (loginReply.header.responseCode !== 200)
+            throw new BaichuanStatusError(loginReply.header.responseCode, MsgId.Login);
+    }
+
+    close(): void {
+        this.socket?.destroy();
+    }
+
+    private async readHeader(): Promise<BcHeader> {
+        const hdr20 = await readLength(this.socket, 20);
+        const msgClass = hdr20.readUInt16LE(18);
+        const hdr = headerLenForClass(msgClass) === 24 ? Buffer.concat([hdr20, await readLength(this.socket, 4)]) : hdr20;
+        return parseHeader(hdr);
+    }
+
+    private async readRawMessage(): Promise<{ header: BcHeader; body: Buffer }> {
+        const header = await this.readHeader();
+        const body = header.bodyLen ? await readLength(this.socket, header.bodyLen) : Buffer.alloc(0);
+        return { header, body };
+    }
+
+    private decodeXml(header: BcHeader, body: Buffer, modeOverride?: EncryptionMode): string {
+        const { rest } = splitBody(header, body);
+        if (!rest || !rest.length)
+            return '';
+        const mode = modeOverride ?? (header.msgId === MsgId.Login ? EncryptionMode.BC : this.encryptionMode);
+        return decryptXml(mode, this.aesKey, header.channelId, rest).toString('utf8');
+    }
+
+    /**
+     * Reads messages off the socket until one with `msgNum` arrives. The
+     * device sends unsolicited status broadcasts (msgNum 0) interleaved
+     * with replies - e.g. we observed VideoInput/Serial/AbilityInfo pushes
+     * arrive right after login, unprompted - which must be skipped rather
+     * than mistaken for the reply we're waiting for.
+     */
+    private async waitForReply(msgNum: number, maxSkip = 20): Promise<{ header: BcHeader; xml: string }> {
+        for (let i = 0; i < maxSkip; i++) {
+            const { header, body } = await this.readRawMessage();
+            if (header.msgNum !== msgNum) {
+                this.console?.debug?.(`baichuan: skipping unsolicited message msgId=${header.msgId} msgNum=${header.msgNum}`);
+                continue;
+            }
+            return { header, xml: this.decodeXml(header, body) };
+        }
+        throw new Error(`baichuan: no reply for msgNum=${msgNum} after ${maxSkip} messages`);
+    }
+
+    /**
+     * Sends a request and waits for its matching reply. Throws
+     * `BaichuanStatusError` if the device's response code is not 200 -
+     * callers that need to handle a specific non-200 code (e.g. TalkConfig's
+     * 422 "already talking") should catch that error and check `.code`.
+     */
+    async request(msgId: number, opts: { extensionXml?: string; bodyXml?: string; binary?: Buffer } = {}): Promise<{ header: BcHeader; xml: string }> {
+        const msgNum = this.nextMsgNum();
+        const mode = this.encryptionMode;
+
+        const extension = opts.extensionXml
+            ? encryptXml(mode, this.aesKey, this.channelId, Buffer.from(opts.extensionXml, 'utf8'))
+            : undefined;
+        const payload = opts.bodyXml
+            ? encryptXml(mode, this.aesKey, this.channelId, Buffer.from(opts.bodyXml, 'utf8'))
+            : undefined;
+        const { body, binOffset } = buildBody({ extension, payload, binary: opts.binary });
+
+        const header: BcHeader = {
+            msgId,
+            bodyLen: body.length,
+            channelId: this.channelId,
+            streamType: 0,
+            msgNum,
+            responseCode: 0,
+            msgClass: HeaderClass.ModernWithOffset,
+            binOffset: binOffset ?? 0,
+        };
+        this.socket.write(Buffer.concat([packHeader(header), body]));
+
+        const reply = await this.waitForReply(msgNum);
+        if (reply.header.responseCode !== 200)
+            throw new BaichuanStatusError(reply.header.responseCode, msgId);
+        return reply;
+    }
+
+    async getTalkAbility(): Promise<TalkAbility> {
+        const reply = await this.request(MsgId.TalkAbility, {
+            extensionXml: buildExtensionXml({ channelId: this.channelId }),
+        });
+        return parseTalkAbility(reply.xml);
+    }
+
+    /**
+     * Sends TalkReset (also doubles as "stop talking"). A 422 here just
+     * means nothing was talking - not an error worth surfacing.
+     */
+    async stopTalk(): Promise<void> {
+        try {
+            await this.request(MsgId.TalkReset, {
+                extensionXml: buildExtensionXml({ channelId: this.channelId }),
+            });
+        }
+        catch (e) {
+            if (e instanceof BaichuanStatusError && e.code === 422)
+                return;
+            throw e;
+        }
+    }
+
+    /**
+     * Negotiates and opens a Talk session using the first ADPCM profile the
+     * device actually advertises (never hardcode duplex/audioStreamMode -
+     * different Reolink models advertise different supported values; this
+     * doorbell advertises `duplexList: [FDX]` and
+     * `audioStreamModeList: [followVideoStream, mixAudioStream]`, prefering
+     * "fullDuplex"/"speaker" when a device happens to advertise those,
+     * matching the go2rtc reference client's selection logic).
+     */
+    async startTalk(): Promise<TalkSession> {
+        const ability = await this.getTalkAbility();
+        const audioConfig = ability.audioConfigOptions.find(c => c.audioType === 'adpcm');
+        if (!audioConfig)
+            throw new Error('baichuan: device does not advertise an ADPCM talk profile');
+        if (!ability.duplexOptions.length || !ability.audioStreamModeOptions.length)
+            throw new Error('baichuan: device returned no talk duplex/audioStreamMode options');
+
+        const duplex = ability.duplexOptions.includes('fullDuplex') ? 'fullDuplex' : ability.duplexOptions[0];
+        const audioStreamMode = ability.audioStreamModeOptions.includes('speaker')
+            ? 'speaker'
+            : ability.audioStreamModeOptions[0];
+
+        const talkConfigXml = buildTalkConfigXml(this.channelId, duplex, audioStreamMode, audioConfig);
+        const extensionXml = buildExtensionXml({ channelId: this.channelId });
+
+        try {
+            await this.request(MsgId.TalkConfig, { extensionXml, bodyXml: talkConfigXml });
+        }
+        catch (e) {
+            // Another session left talk open; per the observed device
+            // behavior (and go2rtc's client), reset then retry once.
+            if (e instanceof BaichuanStatusError && e.code === 422) {
+                await this.stopTalk();
+                await this.request(MsgId.TalkConfig, { extensionXml, bodyXml: talkConfigXml });
+            }
+            else {
+                throw e;
+            }
+        }
+
+        return new TalkSession(this, audioConfig);
+    }
+
+    /** @internal used by TalkSession */
+    async writeAdpcmBlock(block: Buffer, seq: number): Promise<void> {
+        const payload = serializeTalkAdpcmBlock(block, seq);
+        // The device does ack each Talk block individually (confirmed
+        // live), but we deliberately do not wait for it here: blocking on
+        // a round trip per 64ms audio block is exactly the kind of added
+        // latency this client exists to avoid. Any stray acks are simply
+        // skipped as unsolicited messages by the next waitForReply() call
+        // (e.g. stopTalk's), which is harmless.
+        const msgNum = this.nextMsgNum();
+        const extension = encryptXml(
+            this.encryptionMode, this.aesKey, this.channelId,
+            Buffer.from(buildExtensionXml({ channelId: this.channelId, binaryData: true }), 'utf8'),
+        );
+        const { body, binOffset } = buildBody({ extension, binary: payload });
+        const header: BcHeader = {
+            msgId: MsgId.Talk,
+            bodyLen: body.length,
+            channelId: this.channelId,
+            streamType: 0,
+            msgNum,
+            responseCode: 0,
+            msgClass: HeaderClass.ModernWithOffset,
+            binOffset: binOffset ?? 0,
+        };
+        this.socket.write(Buffer.concat([packHeader(header), body]));
+    }
+}
+
+/**
+ * An open Talk (two-way audio) session. Encodes and sends PCM audio as
+ * ADPCM blocks matching the device's negotiated frame size; the caller is
+ * responsible for producing PCM at `sampleRate` and feeding it in chunks of
+ * exactly `samplesPerBlock` samples (see BaichuanIntercom for the ffmpeg
+ * pipeline that does this).
+ */
+export class TalkSession {
+    private readonly encoder = new AdpcmEncoder();
+    private seq = 0;
+    closed = false;
+
+    constructor(private readonly client: BaichuanClient, public readonly audioConfig: TalkAudioConfig) {
+    }
+
+    get sampleRate(): number {
+        return this.audioConfig.sampleRate;
+    }
+
+    get samplesPerBlock(): number {
+        return this.audioConfig.lengthPerEncoder;
+    }
+
+    /** Size, in bytes, of one PCM chunk the caller must read before calling `writeSamples`. */
+    get pcmBytesPerBlock(): number {
+        return this.samplesPerBlock * 2; // 16-bit samples
+    }
+
+    async writeSamples(pcm: Int16Array): Promise<void> {
+        if (this.closed)
+            throw new Error('baichuan: talk session is closed');
+        if (pcm.length !== this.samplesPerBlock)
+            throw new Error(`baichuan: expected ${this.samplesPerBlock} samples, got ${pcm.length}`);
+        const block = this.encoder.encodeBlock(pcm);
+        this.seq++;
+        await this.client.writeAdpcmBlock(block, this.seq);
+    }
+
+    async close(): Promise<void> {
+        if (this.closed)
+            return;
+        this.closed = true;
+        await this.client.stopTalk();
+    }
+}

--- a/plugins/reolink/src/baichuan/client.ts
+++ b/plugins/reolink/src/baichuan/client.ts
@@ -1,4 +1,5 @@
 import { readLength } from '@scrypted/common/src/read-stream';
+import { sleep } from '@scrypted/common/src/sleep';
 import net from 'net';
 import {
     EncryptionMode,
@@ -85,6 +86,27 @@ export class BaichuanClient {
 
     async connect(): Promise<void> {
         this.socket = new net.Socket();
+
+        // A persistent 'error' listener for the socket's whole lifetime,
+        // not just during connect: Node treats an 'error' event with no
+        // listener as an uncaught exception and crashes the *entire*
+        // process, not just this session - which would take down the rest
+        // of Scrypted, not just this one intercom call. Any error past the
+        // connect phase (including the timeout destroy() just below)
+        // surfaces to callers naturally anyway, since it causes the
+        // socket's pending readLength()/write() calls to fail via
+        // 'close'/'end', so this handler only needs to stop the crash and
+        // log, not resolve/reject anything itself.
+        this.socket.on('error', err => this.console?.error?.('baichuan: socket error', err));
+
+        // socket.setTimeout() alone only emits a 'timeout' event on
+        // inactivity - it does not tear down the connection by itself.
+        // Without also destroying it here, a connection that stalls after
+        // connecting (no error, no data, ever) would leave any pending
+        // readLength() call awaiting data forever.
+        this.socket.on('timeout', () => this.socket.destroy(new Error('baichuan: socket inactivity timeout')));
+        this.socket.setTimeout(this.timeout);
+
         await new Promise<void>((resolve, reject) => {
             const onError = (err: Error) => {
                 this.socket.removeListener('connect', onConnect);
@@ -96,7 +118,6 @@ export class BaichuanClient {
             };
             this.socket.once('error', onError);
             this.socket.once('connect', onConnect);
-            this.socket.setTimeout(this.timeout);
             this.socket.connect(this.options.port, this.options.host);
         });
     }
@@ -188,17 +209,39 @@ export class BaichuanClient {
      * with replies - e.g. we observed VideoInput/Serial/AbilityInfo pushes
      * arrive right after login, unprompted - which must be skipped rather
      * than mistaken for the reply we're waiting for.
+     *
+     * Bounded by wall-clock time, not a message count: a real Talk session
+     * can run for minutes and generate hundreds of per-block acks (see
+     * writeAdpcmBlock) that pile up unread on the socket between calls to
+     * this function, since we don't wait on those individually. A fixed
+     * skip-count limit was tried first and failed in exactly this way -
+     * stopTalk()'s TalkReset timed out after a longer real conversation
+     * because there were more queued acks to drain than the limit allowed,
+     * even though every one of them was legitimately ours to skip.
      */
-    private async waitForReply(msgNum: number, maxSkip = 20): Promise<{ header: BcHeader; xml: string }> {
-        for (let i = 0; i < maxSkip; i++) {
-            const { header, body } = await this.readRawMessage();
-            if (header.msgNum !== msgNum) {
-                this.console?.debug?.(`baichuan: skipping unsolicited message msgId=${header.msgId} msgNum=${header.msgNum}`);
-                continue;
+    private async waitForReply(msgNum: number, timeoutMs = 8000): Promise<{ header: BcHeader; xml: string }> {
+        const findReply = (async () => {
+            while (true) {
+                const { header, body } = await this.readRawMessage();
+                if (header.msgNum !== msgNum) {
+                    this.console?.debug?.(`baichuan: skipping unsolicited message msgId=${header.msgId} msgNum=${header.msgNum}`);
+                    continue;
+                }
+                return { header, xml: this.decodeXml(header, body) };
             }
-            return { header, xml: this.decodeXml(header, body) };
+        })();
+
+        let timer: NodeJS.Timeout;
+        const timeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(`baichuan: no reply for msgNum=${msgNum} within ${timeoutMs}ms`)), timeoutMs);
+        });
+
+        try {
+            return await Promise.race([findReply, timeout]);
         }
-        throw new Error(`baichuan: no reply for msgNum=${msgNum} after ${maxSkip} messages`);
+        finally {
+            clearTimeout(timer!);
+        }
     }
 
     /**
@@ -343,6 +386,7 @@ export class BaichuanClient {
 export class TalkSession {
     private readonly encoder = new AdpcmEncoder();
     private seq = 0;
+    private nextSendAt: number | undefined;
     closed = false;
 
     constructor(private readonly client: BaichuanClient, public readonly audioConfig: TalkAudioConfig) {
@@ -361,11 +405,36 @@ export class TalkSession {
         return this.samplesPerBlock * 2; // 16-bit samples
     }
 
+    /**
+     * Encodes and sends one block, paced to real time. The device's own
+     * playback buffer expects roughly one block every `samplesPerBlock /
+     * sampleRate` seconds (64ms for this doorbell's 1024-sample/16kHz
+     * profile); a caller that feeds blocks faster than that - e.g. audio
+     * generated up front and written back-to-back, as opposed to a live
+     * microphone feed that is naturally paced by ffmpeg producing one
+     * chunk at a time - was observed live to eventually make TalkReset
+     * fail (response code 400) after the burst, presumably because the
+     * device's small internal buffer got overrun. A caller that is already
+     * at or behind real time (the normal case: ffmpeg only has the next
+     * chunk ready every ~64ms) is unaffected - this only ever adds delay
+     * when the caller is running ahead of the audio's own real-time clock.
+     */
     async writeSamples(pcm: Int16Array): Promise<void> {
         if (this.closed)
             throw new Error('baichuan: talk session is closed');
         if (pcm.length !== this.samplesPerBlock)
             throw new Error(`baichuan: expected ${this.samplesPerBlock} samples, got ${pcm.length}`);
+
+        const blockDurationMs = (this.samplesPerBlock / this.sampleRate) * 1000;
+        const now = Date.now();
+        if (this.nextSendAt !== undefined && now < this.nextSendAt)
+            await sleep(this.nextSendAt - now);
+
+        const sendTime = Date.now();
+        this.nextSendAt = this.nextSendAt !== undefined && sendTime <= this.nextSendAt
+            ? this.nextSendAt + blockDurationMs
+            : sendTime + blockDurationMs;
+
         const block = this.encoder.encodeBlock(pcm);
         this.seq++;
         await this.client.writeAdpcmBlock(block, this.seq);

--- a/plugins/reolink/src/baichuan/crypto.ts
+++ b/plugins/reolink/src/baichuan/crypto.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto';
+
+// The Baichuan protocol's legacy XML XOR cipher uses this fixed 8-byte key,
+// cycled and additionally XORed with the low byte of the packet offset.
+const BC_XML_KEY = Buffer.from([0x1f, 0x2d, 0x3c, 0x4b, 0x5a, 0x69, 0x78, 0xff]);
+
+// Baichuan's AES payloads always use this literal ASCII string as the IV,
+// regardless of device or session.
+const AES_IV = Buffer.from('0123456789abcdef');
+
+export enum EncryptionMode {
+    None = 'none',
+    BC = 'bc',
+    AES = 'aes',
+}
+
+/**
+ * The classic Baichuan XML XOR cipher (a.k.a. "BCEncrypt"). Symmetric: the
+ * same function encrypts and decrypts. `offset` is the packet's channel id /
+ * encryption-offset header byte.
+ */
+export function bcXor(data: Buffer, offset: number): Buffer {
+    const out = Buffer.alloc(data.length);
+    for (let i = 0; i < data.length; i++) {
+        const key = BC_XML_KEY[(offset + i) % BC_XML_KEY.length];
+        out[i] = data[i] ^ key ^ (offset & 0xff);
+    }
+    return out;
+}
+
+/**
+ * MD5 hex digest, uppercased, with Reolink's "modern" login truncation
+ * quirk applied: only the first 31 of the 32 hex characters are kept. This
+ * matches the firmware's own (buggy) legacy C string handling, and both the
+ * username and password sent in the modern LoginUser XML must be hashed
+ * this way for the login to be accepted.
+ */
+export function md5Truncated(input: string): string {
+    return crypto.createHash('md5').update(input).digest('hex').toUpperCase().slice(0, 31);
+}
+
+/**
+ * Derives the AES-128 session key from the login nonce and the plaintext
+ * password: MD5("<nonce>-<password>"), hex-encoded and uppercased, then the
+ * first 16 *characters* of that hex string are used verbatim as the 16 raw
+ * key bytes (not hex-decoded). This is Reolink's own scheme and was
+ * confirmed against a live device and cross-checked against the go2rtc
+ * Baichuan implementation.
+ */
+export function deriveAesKey(nonce: string, password: string): Buffer {
+    const digest = crypto.createHash('md5').update(`${nonce}-${password}`).digest('hex').toUpperCase();
+    return Buffer.from(digest.slice(0, 16), 'ascii');
+}
+
+/**
+ * AES-128-CFB (full 128-bit segment feedback, i.e. plain "aes-128-cfb" in
+ * OpenSSL/Node terms) with the fixed Baichuan IV. Each call creates a fresh
+ * cipher/decipher instance: Baichuan does not maintain a running keystream
+ * across messages, every message is encrypted independently with the same
+ * key and IV.
+ */
+export function aesCfbEncrypt(key: Buffer, data: Buffer): Buffer {
+    const cipher = crypto.createCipheriv('aes-128-cfb', key, AES_IV);
+    return Buffer.concat([cipher.update(data), cipher.final()]);
+}
+
+export function aesCfbDecrypt(key: Buffer, data: Buffer): Buffer {
+    const decipher = crypto.createDecipheriv('aes-128-cfb', key, AES_IV);
+    return Buffer.concat([decipher.update(data), decipher.final()]);
+}
+
+/**
+ * Encrypts an XML payload for the wire, per the negotiated encryption mode.
+ * `offset` is the channel id byte from the packet header (used only by the
+ * BC XOR cipher; ignored for AES).
+ */
+export function encryptXml(mode: EncryptionMode, key: Buffer | undefined, offset: number, data: Buffer): Buffer {
+    switch (mode) {
+        case EncryptionMode.None:
+            return Buffer.from(data);
+        case EncryptionMode.BC:
+            return bcXor(data, offset);
+        case EncryptionMode.AES:
+            // Falls back to BC XOR if the AES key has not been established yet,
+            // matching the observed firmware behavior for out-of-order packets.
+            return key ? aesCfbEncrypt(key, data) : bcXor(data, offset);
+    }
+}
+
+export function decryptXml(mode: EncryptionMode, key: Buffer | undefined, offset: number, data: Buffer): Buffer {
+    switch (mode) {
+        case EncryptionMode.None:
+            return Buffer.from(data);
+        case EncryptionMode.BC:
+            return bcXor(data, offset);
+        case EncryptionMode.AES:
+            return key ? aesCfbDecrypt(key, data) : bcXor(data, offset);
+    }
+}

--- a/plugins/reolink/src/baichuan/protocol.ts
+++ b/plugins/reolink/src/baichuan/protocol.ts
@@ -1,0 +1,169 @@
+// Baichuan wire protocol: header layout, message class/id constants, and the
+// Extension+payload body framing used by every request and reply.
+//
+// Reverse engineered from a live Reolink Video Doorbell PoE (2026 firmware)
+// and cross-checked against the AlexxIT/go2rtc Baichuan implementation
+// (pkg/baichuan/types.go), which independently confirms the same constants
+// against a range of other Reolink models.
+
+export const MAGIC_HEADER = 0x0abcdef0;
+
+export const HeaderClass = {
+    /** 20-byte header. Used for the very first, pre-login probe message. */
+    Legacy: 0x6514,
+    /** 20-byte header. Observed on some unsolicited replies from the device. */
+    Modern: 0x6614,
+    /** 24-byte header (adds a binOffset field). The class used for essentially
+     * every authenticated request/reply once logged in. */
+    ModernWithOffset: 0x6414,
+    /** 24-byte header, alternate marker some replies use for the same modern
+     * layout as ModernWithOffset. */
+    ModernAlt: 0x0000,
+} as const;
+
+export function headerLenForClass(msgClass: number): number {
+    return msgClass === HeaderClass.ModernWithOffset || msgClass === HeaderClass.ModernAlt ? 24 : 20;
+}
+
+/** Message ids used by this module. Names and values cross-checked against
+ * go2rtc's pkg/baichuan/types.go; only the ids Phase 1 (two-way audio) needs
+ * are exercised today, the rest are documented for future use (e.g. video). */
+export const MsgId = {
+    Login: 1,
+    Logout: 2,
+    Video: 3,
+    VideoStop: 4,
+    TalkAbility: 10,
+    /** Not TalkConfig - see TalkConfig below. Also doubles as "stop talking". */
+    TalkReset: 11,
+    AbilityInfo: 151,
+    /** NOT 11. Sending TalkConfig as msg id 11 gets silently misinterpreted
+     * as a TalkReset with an unexpected body and rejected. */
+    TalkConfig: 201,
+    Talk: 202,
+} as const;
+
+export interface BcHeader {
+    msgId: number;
+    bodyLen: number;
+    channelId: number;
+    streamType: number;
+    msgNum: number;
+    responseCode: number;
+    msgClass: number;
+    /** Only present for the 24-byte header layout. */
+    binOffset?: number;
+}
+
+export function packHeader(header: BcHeader): Buffer {
+    const headerLen = headerLenForClass(header.msgClass);
+    const buf = Buffer.alloc(headerLen);
+    buf.writeUInt32LE(MAGIC_HEADER, 0);
+    buf.writeUInt32LE(header.msgId, 4);
+    buf.writeUInt32LE(header.bodyLen, 8);
+    buf.writeUInt8(header.channelId, 12);
+    buf.writeUInt8(header.streamType, 13);
+    buf.writeUInt16LE(header.msgNum, 14);
+    buf.writeUInt16LE(header.responseCode, 16);
+    buf.writeUInt16LE(header.msgClass, 18);
+    if (headerLen === 24)
+        buf.writeUInt32LE(header.binOffset || 0, 20);
+    return buf;
+}
+
+/**
+ * Parses a header from `buf`, which must be at least 20 bytes. Callers
+ * should peek the class at bytes [18:20) via `headerLenForClass` first to
+ * know whether they need to read 20 or 24 bytes off the socket.
+ */
+export function parseHeader(buf: Buffer): BcHeader {
+    const magic = buf.readUInt32LE(0);
+    if (magic !== MAGIC_HEADER)
+        throw new Error(`unexpected Baichuan magic ${magic.toString(16)}`);
+
+    const msgClass = buf.readUInt16LE(18);
+    const header: BcHeader = {
+        msgId: buf.readUInt32LE(4),
+        bodyLen: buf.readUInt32LE(8),
+        channelId: buf.readUInt8(12),
+        streamType: buf.readUInt8(13),
+        msgNum: buf.readUInt16LE(14),
+        responseCode: buf.readUInt16LE(16),
+        msgClass,
+    };
+    if (headerLenForClass(msgClass) === 24)
+        header.binOffset = buf.readUInt32LE(20);
+    return header;
+}
+
+/**
+ * Combines an (already encrypted) Extension XML block with an (already
+ * encrypted, or raw binary) payload into a single message body, and works
+ * out the `binOffset` that tells the receiver where the extension ends and
+ * the payload begins. Mirrors the framing implied by go2rtc's `bc_ext` /
+ * `bc_payload` split and confirmed live: when only one of the two parts is
+ * present, `binOffset` is omitted (undefined) unless a raw binary payload
+ * follows the extension, in which case it marks the boundary.
+ */
+export function buildBody(parts: { extension?: Buffer; payload?: Buffer; binary?: Buffer }): { body: Buffer; binOffset?: number } {
+    const chunks: Buffer[] = [];
+    let binOffset: number | undefined;
+
+    if (parts.extension) {
+        chunks.push(parts.extension);
+        binOffset = parts.extension.length;
+    }
+    if (parts.payload) {
+        chunks.push(parts.payload);
+        if (binOffset === undefined && parts.binary)
+            binOffset = chunks.reduce((n, c) => n + c.length, 0);
+    }
+    if (parts.binary) {
+        chunks.push(parts.binary);
+        if (binOffset === undefined)
+            binOffset = 0;
+    }
+
+    return { body: Buffer.concat(chunks), binOffset };
+}
+
+/** Magic header for a Baichuan ADPCM media block ("bw10" as a little-endian u32). */
+const BCMEDIA_ADPCM_MAGIC = 0x62773130;
+/** Magic marking the inner ADPCM sub-header within a bcmedia block. */
+const BCMEDIA_ADPCM_HEADER = 0x0100;
+const BCMEDIA_PAD_SIZE = 8;
+
+/**
+ * Wraps one already-ADPCM-encoded block (predictor header + nibble data, as
+ * produced by `AdpcmEncoder.encodeBlock`) in the bcmedia framing expected
+ * for a `Talk` (msg id 202) binary payload, and pads to an 8-byte boundary
+ * as the device's own media messages do. `seq` is a simple incrementing
+ * per-session counter, echoed back at offset 10-12 of the frame.
+ */
+export function serializeTalkAdpcmBlock(block: Buffer, seq: number): Buffer {
+    const payloadSize = block.length + 4;
+    const pad = (BCMEDIA_PAD_SIZE - (payloadSize % BCMEDIA_PAD_SIZE)) % BCMEDIA_PAD_SIZE;
+    const out = Buffer.alloc(8 + payloadSize + pad);
+    out.writeUInt32LE(BCMEDIA_ADPCM_MAGIC, 0);
+    out.writeUInt16LE(payloadSize, 4);
+    out.writeUInt16LE(payloadSize, 6);
+    out.writeUInt16LE(BCMEDIA_ADPCM_HEADER, 8);
+    out.writeUInt16LE(seq & 0xffff, 10);
+    block.copy(out, 12);
+    return out;
+}
+
+/**
+ * Splits a received body into its extension and payload/binary parts using
+ * the header's `binOffset`, without decrypting either part (that's
+ * crypto.ts's job, since the two parts may use different offsets for the BC
+ * XOR cipher).
+ */
+export function splitBody(header: BcHeader, body: Buffer): { extension?: Buffer; rest?: Buffer } {
+    if (header.binOffset === undefined || header.binOffset === 0)
+        return { rest: body.length ? body : undefined };
+    return {
+        extension: body.subarray(0, header.binOffset),
+        rest: body.subarray(header.binOffset),
+    };
+}

--- a/plugins/reolink/src/baichuan/xml.ts
+++ b/plugins/reolink/src/baichuan/xml.ts
@@ -1,0 +1,102 @@
+import { parseStringPromise } from 'xml2js';
+
+/**
+ * Wraps a top-level payload (LoginUser/LoginNet, TalkConfig, ...) in the
+ * `<?xml?><body>...</body>` envelope Baichuan expects for the main message
+ * payload.
+ *
+ * IMPORTANT: the small `<Extension>` block that precedes the payload in
+ * most requests is NOT wrapped this way - it is sent as a bare fragment.
+ * Wrapping the Extension in `<body>` too was tried live and the device
+ * rejects the request outright (response code 421, "extension xml parse
+ * failed") because its Extension-specific parser expects the fragment to
+ * start directly with `<Extension>`. Use `buildExtensionXml` for that case.
+ */
+export function buildBodyXml(inner: string): string {
+    return `<?xml version="1.0" encoding="UTF-8" ?>\n<body>\n${inner}\n</body>`;
+}
+
+export interface ExtensionOptions {
+    channelId: number;
+    /** Set when the payload that follows the extension is raw binary (e.g.
+     * an ADPCM Talk block) rather than XML. */
+    binaryData?: boolean;
+}
+
+/** Builds the bare `<Extension>` fragment - see the warning on `buildBodyXml`. */
+export function buildExtensionXml(options: ExtensionOptions): string {
+    const binaryDataTag = options.binaryData ? '\n<binaryData>1</binaryData>' : '';
+    return `<Extension version="1.1">\n<channelId>${options.channelId}</channelId>${binaryDataTag}\n</Extension>`;
+}
+
+export function buildLoginXml(username: string, password: string): string {
+    return buildBodyXml(
+        '<LoginUser version="1.1">\n' +
+        `<userName>${username}</userName>\n` +
+        `<password>${password}</password>\n` +
+        '<userVer>1</userVer>\n' +
+        '</LoginUser>\n' +
+        '<LoginNet version="1.1">\n' +
+        '<type>LAN</type>\n' +
+        '<udpPort>0</udpPort>\n' +
+        '</LoginNet>',
+    );
+}
+
+export interface TalkAudioConfig {
+    audioType: string;
+    sampleRate: number;
+    samplePrecision: number;
+    lengthPerEncoder: number;
+    soundTrack: string;
+}
+
+export interface TalkAbility {
+    duplexOptions: string[];
+    audioStreamModeOptions: string[];
+    audioConfigOptions: TalkAudioConfig[];
+}
+
+export function buildTalkConfigXml(channelId: number, duplex: string, audioStreamMode: string, audioConfig: TalkAudioConfig): string {
+    return buildBodyXml(
+        '<TalkConfig version="1.1">\n' +
+        `<channelId>${channelId}</channelId>\n` +
+        `<duplex>${duplex}</duplex>\n` +
+        `<audioStreamMode>${audioStreamMode}</audioStreamMode>\n` +
+        '<audioConfig>\n' +
+        `<audioType>${audioConfig.audioType}</audioType>\n` +
+        `<sampleRate>${audioConfig.sampleRate}</sampleRate>\n` +
+        `<samplePrecision>${audioConfig.samplePrecision}</samplePrecision>\n` +
+        `<lengthPerEncoder>${audioConfig.lengthPerEncoder}</lengthPerEncoder>\n` +
+        `<soundTrack>${audioConfig.soundTrack}</soundTrack>\n` +
+        '</audioConfig>\n' +
+        '</TalkConfig>',
+    );
+}
+
+/** Extracts the login nonce from the `<Encryption><nonce>...</nonce></Encryption>` reply. */
+export function parseNonce(xml: string): string {
+    const match = /<nonce>([^<]+)<\/nonce>/.exec(xml);
+    if (!match)
+        throw new Error(`no <nonce> found in login reply: ${xml}`);
+    return match[1];
+}
+
+export async function parseTalkAbility(xml: string): Promise<TalkAbility> {
+    const parsed = await parseStringPromise(xml);
+    const ability = parsed?.body?.TalkAbility?.[0];
+    if (!ability)
+        throw new Error(`no <TalkAbility> found in reply: ${xml}`);
+
+    const duplexOptions: string[] = (ability.duplexList?.[0]?.duplex ?? []) as string[];
+    const audioStreamModeOptions: string[] = (ability.audioStreamModeList?.[0]?.audioStreamMode ?? []) as string[];
+    const audioConfigOptions: TalkAudioConfig[] = ((ability.audioConfigList?.[0]?.audioConfig ?? []) as any[]).map(cfg => ({
+        audioType: cfg.audioType?.[0],
+        sampleRate: Number(cfg.sampleRate?.[0]),
+        samplePrecision: Number(cfg.samplePrecision?.[0]),
+        lengthPerEncoder: Number(cfg.lengthPerEncoder?.[0]),
+        soundTrack: cfg.soundTrack?.[0],
+    }));
+
+    return { duplexOptions, audioStreamModeOptions, audioConfigOptions };
+}

--- a/plugins/reolink/src/main.ts
+++ b/plugins/reolink/src/main.ts
@@ -6,6 +6,7 @@ import { createRtspMediaStreamOptions, Destroyable, RtspProvider, RtspSmartCamer
 import { OnvifCameraAPI, OnvifEvent, connectCameraAPI } from './onvif-api';
 import { listenEvents } from './onvif-events';
 import { OnvifIntercom } from './onvif-intercom';
+import { BaichuanIntercom } from './baichuan-intercom';
 import { DevInfo } from './probe';
 import { AIState, Enc, isDeviceHomeHub, isDeviceNvr, ReolinkCameraClient } from './reolink-api';
 import { ReolinkNvrDevice } from './nvr/nvr';
@@ -105,6 +106,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
     clientWithToken: ReolinkCameraClient;
     onvifClient: OnvifCameraAPI;
     onvifIntercom = new OnvifIntercom(this);
+    baichuanIntercom = new BaichuanIntercom(this);
     motionTimeout: NodeJS.Timeout;
     siren: ReolinkCameraSiren;
     floodlight: ReolinkCameraFloodlight;
@@ -122,6 +124,12 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
             subgroup: 'Advanced',
             title: 'RTMP Port Override',
             placeholder: '1935',
+            type: 'number',
+        },
+        baichuanPort: {
+            subgroup: 'Advanced',
+            title: 'Baichuan Port Override',
+            placeholder: '9000',
             type: 'number',
         },
         motionTimeout: {
@@ -198,6 +206,15 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
         useOnvifTwoWayAudio: {
             subgroup: 'Advanced',
             title: 'Use ONVIF for Two-Way Audio',
+            type: 'boolean',
+        },
+        useBaichuanTwoWayAudio: {
+            subgroup: 'Advanced',
+            title: 'Use Baichuan for Two-Way Audio',
+            description: 'Uses Reolink\'s native Baichuan protocol for two-way audio instead of ONVIF. '
+                + 'Sends audio directly with no RTP/jitter buffering, which measured significantly '
+                + 'lower latency than the ONVIF backchannel on a real device over LAN. Does not '
+                + 'affect ONVIF-based object detection, which is unrelated and unaffected by this setting.',
             type: 'boolean',
         },
     });
@@ -416,6 +433,9 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
     }
 
     async startIntercom(media: MediaObject): Promise<void> {
+        if (this.storageSettings.values.useBaichuanTwoWayAudio)
+            return this.baichuanIntercom.startIntercom(media);
+
         if (!this.onvifIntercom.url) {
             const client = await this.getOnvifClient();
             const streamUrl = await client.getStreamUrl();
@@ -425,6 +445,8 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
     }
 
     stopIntercom(): Promise<void> {
+        if (this.storageSettings.values.useBaichuanTwoWayAudio)
+            return this.baichuanIntercom.stopIntercom();
         return this.onvifIntercom.stopIntercom();
     }
 
@@ -498,7 +520,7 @@ class ReolinkCamera extends RtspSmartCamera implements Camera, DeviceProvider, R
             type = ScryptedDeviceType.Doorbell;
             name = 'Reolink Doorbell';
         }
-        if (this.storageSettings.values.doorbell || this.storageSettings.values.useOnvifTwoWayAudio) {
+        if (this.storageSettings.values.doorbell || this.storageSettings.values.useOnvifTwoWayAudio || this.storageSettings.values.useBaichuanTwoWayAudio) {
             interfaces.push(
                 ScryptedInterface.Intercom
             );


### PR DESCRIPTION
## Summary

Adds an opt-in, lower-latency alternative to the ONVIF intercom backchannel for Reolink devices, using Reolink's proprietary "Baichuan" binary protocol (TCP port 9000) instead of ONVIF/RTP for two-way audio.

**Motivation**: on a Reolink Video Doorbell PoE, the existing ONVIF backchannel had noticeably high two-way-audio latency even on pure LAN. Baichuan sends audio directly with no RTP/jitter buffering, which measured significantly lower latency on the real device.

**Scope**: audio only. This is purely additive — ONVIF remains the default and is completely untouched, including `onvif-events.ts` object/motion detection, which does not use the intercom path at all and is unaffected. Video over Baichuan was considered but deliberately left out of scope for this PR.

## What's new

- `plugins/reolink/src/baichuan/{crypto,protocol,adpcm,xml,client}.ts` — Baichuan protocol implementation: AES/MD5-based login and message encryption, binary message framing, ADPCM audio encode/decode, minimal XML command builder, and a client handling login + talk-session lifecycle.
- `plugins/reolink/src/baichuan-intercom.ts` — intercom implementation wired to the existing `Intercom` interface, mirroring the shape of `onvif-intercom.ts`.
- `plugins/reolink/src/main.ts` — minimal additive wiring: a new `useBaichuanTwoWayAudio` StorageSettings toggle (**default off**) that, when enabled, routes `startIntercom`/`stopIntercom` through `BaichuanIntercom` instead of `OnvifIntercom`; a `baichuanPort` advanced override (defaults to 9000). No existing ONVIF code paths are modified.

## Validation

- Live-tested end-to-end against a real Reolink Video Doorbell PoE (login, talk-session setup, real-time ADPCM audio streaming).
- Protocol details (message IDs, encryption, framing) cross-checked against AlexxIT/go2rtc PR #2263 for consistency with another independent implementation.
- Iterated through a few robustness fixes found only under live production use: correct Baichuan message IDs (`TalkConfig=201`, not `11`), a time-based (8s) reply-drain instead of a fixed message-count skip, persistent socket error/timeout handlers (a missing handler could previously crash the whole Scrypted process), real-time ADPCM pacing, and not logging the expected caller-hangup race as an error.

## Out of scope / follow-ups

- Video over Baichuan (Phase 2) — not started, left for a future PR if there's interest.
- This is opt-in and defaults off specifically so it has zero behavioral impact on existing ONVIF users unless they explicitly enable it.
