### PR TITLE
Add UniFi Protect API Key Only connection mode

### DIFF
--- a/plugins/unifi-protect/README.md
+++ b/plugins/unifi-protect/README.md
@@ -1,16 +1,41 @@
 # Unifi Protect Plugin for Scrypted
 
-The Unifi Protect Plugin connects your Unifi Cameras to Scrypted. 
+The Unifi Protect Plugin connects your Unifi Cameras to Scrypted.
 
-## Requirements
+## Connection modes
+
+The plugin supports two connection modes:
+
+### Local User (default)
+
+Uses a Protect local user account against the private Protect API. This provides the full feature set (cameras, lights, sensors, locks, two-way audio, privacy masks, dynamic bitrate, etc.).
+
+Requirements:
 * The Protect appliance such as a Cloud Key or Dream Machine
 * Protect user account with **Local Administrator** permissions. **NOTE**: This may be downgraded to Read Only under certain situations (see `Troubleshooting`)
    * Two Factor Authentication will not work.
    * A local account is recommended in case the Ubiquiti SSO service goes down.
 
+### API Key Only
+
+Uses a UniFi OS Integration API key with no local user account — the same approach Home Assistant added for UniFi Protect. Authentication is via the `X-API-KEY` header against Protect's public Integration API.
+
+Create a key in the UniFi OS local portal: **Settings → Control Plane → Integrations**.
+
+API Key Only currently supports:
+* Cameras (RTSPS streams, snapshots, motion/smart detections, doorbell ring, status LED)
+* Lights (on/off, brightness, motion)
+
+Not available in API Key Only mode (use Local User instead):
+* Sensors and locks
+* Two-way audio / intercom
+* Privacy masks and dynamic bitrate
+* Optical zoom and fingerprint sensors
+* Package camera snapshots
+
 # Troubleshooting
-A Scypted or Unifi Protect update or change may have occurred.
-For troubleshooting, ensure user account permission is **Administrator** in Protect application.
+A Scrypted or Unifi Protect update or change may have occurred.
+For troubleshooting with Local User mode, ensure user account permission is **Administrator** in Protect application.
 
 Administrator permissions is **required** in the following instances:
 * Initial Unifi device setup (i.e., if you're (re-)adding a new device)

--- a/plugins/unifi-protect/package-lock.json
+++ b/plugins/unifi-protect/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/unifi-protect",
-   "version": "0.1.4",
+   "version": "0.1.5",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/unifi-protect",
-         "version": "0.1.4",
+         "version": "0.1.5",
          "license": "Apache",
          "dependencies": {
             "@scrypted/common": "file:../../common",

--- a/plugins/unifi-protect/package-lock.json
+++ b/plugins/unifi-protect/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/unifi-protect",
-   "version": "0.1.5",
+   "version": "0.2.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/unifi-protect",
-         "version": "0.1.5",
+         "version": "0.2.0",
          "license": "Apache",
          "dependencies": {
             "@scrypted/common": "file:../../common",

--- a/plugins/unifi-protect/package-lock.json
+++ b/plugins/unifi-protect/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/unifi-protect",
-   "version": "0.1.3",
+   "version": "0.1.4",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/unifi-protect",
-         "version": "0.1.3",
+         "version": "0.1.4",
          "license": "Apache",
          "dependencies": {
             "@scrypted/common": "file:../../common",

--- a/plugins/unifi-protect/package.json
+++ b/plugins/unifi-protect/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/unifi-protect",
-   "version": "0.1.4",
+   "version": "0.1.5",
    "description": "Unifi Protect Plugin for Scrypted",
    "author": "Scrypted",
    "license": "Apache",

--- a/plugins/unifi-protect/package.json
+++ b/plugins/unifi-protect/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/unifi-protect",
-   "version": "0.1.3",
+   "version": "0.1.4",
    "description": "Unifi Protect Plugin for Scrypted",
    "author": "Scrypted",
    "license": "Apache",

--- a/plugins/unifi-protect/package.json
+++ b/plugins/unifi-protect/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/unifi-protect",
-   "version": "0.1.5",
+   "version": "0.2.0",
    "description": "Unifi Protect Plugin for Scrypted",
    "author": "Scrypted",
    "license": "Apache",

--- a/plugins/unifi-protect/src/camera.ts
+++ b/plugins/unifi-protect/src/camera.ts
@@ -9,6 +9,7 @@ import WS from 'ws';
 import { UnifiProtect } from "./main";
 import { MOTION_SENSOR_TIMEOUT, UnifiFingerprintDevice, UnifiMotionDevice, debounceMotionDetected } from './camera-sensors';
 import { FeatureFlagsShim, PrivacyZone } from "./shim";
+import { adaptPublicCamera } from "./public-api";
 import { ProtectCameraChannelConfig, ProtectCameraConfigInterface, ProtectCameraLcdMessagePayload } from "./unifi-protect";
 
 const { deviceManager, mediaManager } = sdk;
@@ -408,11 +409,25 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
         return this.protect.api.bootstrap.cameras.find(camera => camera.id === id);
     }
     async getVideoStream(options?: MediaStreamOptions): Promise<MediaObject> {
-        const camera = this.findCamera();
-        const vsos = await this.getVideoStreamOptions();
+        let camera = this.findCamera();
+        let vsos = await this.getVideoStreamOptions();
+        if ((!vsos.length || !camera.channels?.length) && this.protect.isPublicOnly) {
+            // Streams may be inactive until first requested; create them on demand.
+            const publicApi = this.protect.api as any;
+            const streams = await publicApi.getCameraRtspsStreams(camera.id, true);
+            const idx = this.protect.api.bootstrap.cameras.findIndex(c => c.id === camera.id);
+            const adapted = adaptPublicCamera({
+                ...camera,
+                rtspsStreams: streams,
+            }, this.protect.getSetting('ip'));
+            if (idx >= 0)
+                this.protect.api.bootstrap.cameras[idx] = adapted;
+            camera = this.findCamera();
+            vsos = await this.getVideoStreamOptions();
+        }
         const vso = vsos.find(check => check.id === options?.id) || vsos[0];
 
-        const rtspChannel = camera.channels.find(check => check.id.toString() === vso.id);
+        const rtspChannel = camera.channels.find(check => check.id.toString() === vso?.id);
         if (!rtspChannel)
             throw new Error('No RTSP channel is available for this camera.');
 

--- a/plugins/unifi-protect/src/camera.ts
+++ b/plugins/unifi-protect/src/camera.ts
@@ -87,6 +87,9 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     }
 
     async setPrivacyMasks(masks: PrivacyMasks): Promise<void> {
+        if (this.protect.isPublicOnly)
+            throw new Error('Privacy masks are not available in API Key Only mode.');
+
         const privacyZones: PrivacyZone[] = masks.masks.map((mask, index) => {
             return {
                 id: index,
@@ -104,6 +107,9 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     }
 
     async ptzCommand(command: PanTiltZoomCommand): Promise<void> {
+        if (this.protect.isPublicOnly)
+            throw new Error('Optical zoom is not available in API Key Only mode.');
+
         const camera = this.findCamera();
         await this.protect.api.updateDevice(camera, {
             ispSettings: {
@@ -164,6 +170,9 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     }
 
     async startIntercom(media: MediaObject) {
+        if (this.protect.isPublicOnly)
+            throw new Error('Two-way audio is not available in API Key Only mode.');
+
         this.stopIntercom();
 
         const buffer = await mediaManager.convertMediaObjectToBuffer(media, ScryptedMimeTypes.FFmpegInput);
@@ -284,6 +293,9 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     }
 
     async getDetectionInput(detectionId: any): Promise<MediaObject> {
+        if (this.protect.isPublicOnly)
+            throw new Error('Event thumbnails are not available in API Key Only mode.');
+
         const input = this.protect.runningEvents.get(detectionId);
         if (input) {
             this.console.log('fetching event snapshot', detectionId);
@@ -340,11 +352,28 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     }
 
     async getSnapshot(options?: PictureOptions, suffix?: string): Promise<Buffer> {
+        const camera = this.findCamera();
+        if (this.protect.isPublicOnly) {
+            if (suffix && suffix.includes('package')) {
+                // Public Integration API does not expose package-camera snapshots yet.
+                throw new Error('Package camera snapshots are not available in API Key Only mode.');
+            }
+            const abort = new AbortController();
+            const timeout = setTimeout(() => abort.abort('Unifi Protect Snapshot timed out after 10 seconds. Aborted.'), 10000);
+            try {
+                const publicApi = this.protect.api as any;
+                const highQuality = !!camera?.featureFlags?.supportFullHdSnapshot;
+                return await publicApi.getSnapshot(camera.id, highQuality, abort.signal);
+            }
+            finally {
+                clearTimeout(timeout);
+            }
+        }
+
         suffix = suffix || 'snapshot';
         let size = '';
         try {
             if (options?.picture?.width && options?.picture?.height) {
-                const camera = this.findCamera();
                 const mainChannel = camera.channels[0];
                 const w = options.picture.width;
                 const h = fitHeightToWidth(mainChannel.width, mainChannel.height, w);
@@ -355,7 +384,7 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
         catch (e) {
 
         }
-        const url = `https://${this.protect.getSetting('ip')}/proxy/protect/api/cameras/${this.findCamera().id}/${suffix}?ts=${Date.now()}${size}`
+        const url = `https://${this.protect.getSetting('ip')}/proxy/protect/api/cameras/${camera.id}/${suffix}?ts=${Date.now()}${size}`
 
         const abort = new AbortController();
         const timeout = setTimeout(() => abort.abort('Unifi Protect Snapshot timed out after 10 seconds. Aborted.'), 10000);
@@ -384,10 +413,24 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
         const vso = vsos.find(check => check.id === options?.id) || vsos[0];
 
         const rtspChannel = camera.channels.find(check => check.id.toString() === vso.id);
+        if (!rtspChannel)
+            throw new Error('No RTSP channel is available for this camera.');
 
-        const { rtspAlias } = rtspChannel;
-        const ip = (this.protect.getSetting('useConnectionHost') !== 'false' && camera.connectionHost) || this.protect.getSetting('ip');
-        const u = `rtsps://${ip}:7441/${rtspAlias}`
+        // Public API returns complete RTSPS URLs; private API uses alias + host.
+        let u: string = (rtspChannel as any).rtspsUrl;
+        if (!u) {
+            const { rtspAlias } = rtspChannel;
+            const ip = (this.protect.getSetting('useConnectionHost') !== 'false' && camera.connectionHost) || this.protect.getSetting('ip');
+            u = `rtsps://${ip}:7441/${rtspAlias}`;
+        }
+        else if (this.protect.getSetting('useConnectionHost') === 'false') {
+            try {
+                const parsed = new URL(u);
+                parsed.hostname = this.protect.getSetting('ip');
+                u = parsed.toString();
+            }
+            catch { }
+        }
 
         const data = Buffer.from(JSON.stringify({
             url: u,
@@ -398,18 +441,20 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     }
 
     createMediaStreamOptions(channel: ProtectCameraChannelConfig, cameraVideoCodec: string) {
+        const fps = channel.fps || 0;
+        const idrInterval = channel.idrInterval || 0;
         const ret: ResponseMediaStreamOptions = {
             id: channel.id.toString(),
             name: channel.name,
             video: {
                 codec: cameraVideoCodec || 'h264',
-                width: channel.width,
-                height: channel.height,
-                bitrate: channel.maxBitrate,
-                minBitrate: channel.minBitrate,
-                maxBitrate: channel.maxBitrate,
-                fps: channel.fps,
-                keyframeInterval: channel.idrInterval * channel.fps,
+                width: channel.width || undefined,
+                height: channel.height || undefined,
+                bitrate: channel.maxBitrate || undefined,
+                minBitrate: channel.minBitrate || undefined,
+                maxBitrate: channel.maxBitrate || undefined,
+                fps: fps || undefined,
+                keyframeInterval: fps && idrInterval ? idrInterval * fps : undefined,
             },
             audio: {
                 codec: 'aac',
@@ -432,6 +477,9 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
     }
 
     async setVideoStreamOptions(options: MediaStreamOptions): Promise<MediaStreamConfiguration> {
+        if (this.protect.isPublicOnly)
+            throw new Error('Dynamic bitrate is not available in API Key Only mode.');
+
         const bitrate = options?.video?.bitrate;
         if (!bitrate)
             return;
@@ -483,6 +531,7 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
             text: title.substring(0, 30),
             type: 'CUSTOM_MESSAGE',
         };
+        // LCD messages are supported by the public camera PATCH as well.
         this.protect.api.updateDevice(this.findCamera(), {
             lcdMessage: payload,
         })
@@ -503,13 +552,13 @@ export class UnifiCamera extends ScryptedDeviceBase implements Notifier, Interco
         if (!camera)
             return;
         this.on = !!camera.ledSettings?.isEnabled;
-        const online = !!camera.isConnected;
+        const online = !!(camera as any).isConnected || (camera as any).state === 'CONNECTED';
         if (online !== this.online)
             this.online = online;
         if (!!camera.isMotionDetected)
             debounceMotionDetected(this);
 
-        if (!!camera.featureFlags.canOpticalZoom) {
+        if (!this.protect.isPublicOnly && !!camera.featureFlags?.canOpticalZoom) {
             this.ptzCapabilities = { pan: false, tilt: false, zoom: true };
         }
     }

--- a/plugins/unifi-protect/src/light.ts
+++ b/plugins/unifi-protect/src/light.ts
@@ -14,12 +14,18 @@ export class UnifiLight extends ScryptedDeviceBase implements OnOff, Brightness,
         this.console.log(protectLight);
     }
     async turnOff(): Promise<void> {
-        const result = await this.protect.api.updateDevice(this.findLight(), { lightOnSettings: { isLedForceOn: false } });
+        const result = await this.protect.api.updateDevice(this.findLight(), {
+            lightOnSettings: { isLedForceOn: false },
+            isLightForceEnabled: false,
+        } as any);
         if (!result)
             this.console.error('turnOff failed.');
     }
     async turnOn(): Promise<void> {
-        const result = await this.protect.api.updateDevice(this.findLight(), { lightOnSettings: { isLedForceOn: true } });
+        const result = await this.protect.api.updateDevice(this.findLight(), {
+            lightOnSettings: { isLedForceOn: true },
+            isLightForceEnabled: true,
+        } as any);
         if (!result)
             this.console.error('turnOn failed.');
     }
@@ -37,9 +43,10 @@ export class UnifiLight extends ScryptedDeviceBase implements OnOff, Brightness,
         light = light || this.findLight();
         if (!light)
             return;
-        this.on = !!light.isLightOn;
+        this.on = !!(light as any).isLightOn || !!(light as any).isLightForceEnabled || !!(light as any).lightOnSettings?.isLedForceOn;
         // The Protect ledLevel settings goes from 1 - 6. HomeKit expects percentages, so we convert it like so.
-        this.brightness = (light.lightDeviceSettings.ledLevel - 1) * 20;
+        const ledLevel = light.lightDeviceSettings?.ledLevel ?? 1;
+        this.brightness = (ledLevel - 1) * 20;
         if (!!light.isPirMotionDetected)
             debounceMotionDetected(this);
     }

--- a/plugins/unifi-protect/src/main.ts
+++ b/plugins/unifi-protect/src/main.ts
@@ -122,6 +122,7 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
                 return;
             }
             if (!await this.api.getBootstrap()) {
+                this.log.a('Connected with API key, but failed to load Protect devices. Retrying.');
                 this.reconnect('refresh failed')();
                 return;
             }
@@ -749,13 +750,18 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         try {
             const loginResult = await this.relogin();
             if (!loginResult) {
-                this.log.a(publicOnly ? 'Login failed. Check API key.' : 'Login failed. Check credentials.');
+                // relogin() already raised alerts / scheduled reconnect when appropriate.
                 return;
             }
 
-            if (!await this.api.getBootstrap()) {
-                this.reconnect('refresh failed')();
-                return;
+            // relogin() already refreshes bootstrap. Avoid a second bootstrap pass —
+            // the public Integration API is rate-limited to ~10 req/s, and a duplicate
+            // fetch reliably 429s then tears down still-connecting websockets.
+            if (!this.api.bootstrap) {
+                if (!await this.api.getBootstrap()) {
+                    this.reconnect('refresh failed')();
+                    return;
+                }
             }
 
             const resetWsTimeout = () => {
@@ -763,6 +769,7 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
             };
             resetWsTimeout();
 
+            this.api.removeAllListeners('message');
             this.api.on('message', message => {
                 resetWsTimeout();
                 this.listener(message);

--- a/plugins/unifi-protect/src/main.ts
+++ b/plugins/unifi-protect/src/main.ts
@@ -9,6 +9,7 @@ import { debounceFingerprintDetected, debounceMotionDetected } from "./camera-se
 import { UnifiLight } from "./light";
 import { UnifiLock } from "./lock";
 import { UnifiSensor } from "./sensor";
+import { CONNECTION_MODE_API_KEY_ONLY, CONNECTION_MODE_LOCAL_USER, ProtectPublicApi } from "./public-api";
 import { ProtectApi, ProtectCameraConfigInterface, ProtectEventAddInterface, ProtectEventPacket } from "./unifi-protect";
 
 const httpsAgent = new https.Agent({
@@ -16,6 +17,8 @@ const httpsAgent = new https.Agent({
 });
 
 const { deviceManager } = sdk;
+
+type ProtectClient = ProtectApi | ProtectPublicApi;
 
 const filter = [
     'channels',
@@ -38,7 +41,7 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
     unifiSensors = new Map<string, UnifiSensor>();
     lights = new Map<string, UnifiLight>();
     locks = new Map<string, UnifiLock>();
-    api: ProtectApi;
+    api: ProtectClient;
     startup: Promise<void>;
     runningEvents = new Map<string, { promise: Promise<unknown>, resolve: (value: unknown) => void }>();
     reconnecting = false;
@@ -56,6 +59,11 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         }, 1 * 60 * 1000);
 
         this.updateManagementUrl();
+    }
+
+    get isPublicOnly() {
+        return this.storageSettings.values.connectionMode === CONNECTION_MODE_API_KEY_ONLY
+            || this.getSetting('connectionMode') === CONNECTION_MODE_API_KEY_ONLY;
     }
 
     handleUpdatePacket(packet: ProtectEventPacket) {
@@ -77,6 +85,17 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
 
         Object.assign(device, packet.payload);
 
+        // Public Integration API reports connectivity via `state`.
+        if ((packet.payload as any)?.state != null) {
+            (device as any).isConnected = (packet.payload as any).state === 'CONNECTED';
+        }
+        if ((packet.payload as any)?.isLightForceEnabled != null) {
+            (device as any).lightOnSettings = {
+                ...((device as any).lightOnSettings || {}),
+                isLedForceOn: !!(packet.payload as any).isLightForceEnabled,
+            };
+        }
+
         const nativeId = this.getNativeId(device, false);
 
         const ret = this.unifiSensors.get(nativeId) ||
@@ -95,9 +114,23 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
 
     async relogin() {
         const ip = this.getSetting('ip');
+        if (this.isPublicOnly) {
+            const apiKey = this.getSetting('apiKey');
+            const loginResult = await (this.api as ProtectPublicApi).login(ip, apiKey);
+            if (!loginResult) {
+                this.log.a('Login failed. Check API key.');
+                return;
+            }
+            if (!await this.api.getBootstrap()) {
+                this.reconnect('refresh failed')();
+                return;
+            }
+            return loginResult;
+        }
+
         const username = this.getSetting('username');
         const password = this.getSetting('password');
-        const loginResult = await this.api.login(ip, username, password);
+        const loginResult = await (this.api as ProtectApi).login(ip, username, password);
         if (!loginResult) {
             this.log.a('Login failed. Check credentials.');
             return;
@@ -114,9 +147,16 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         try {
             const api = this.api as any;
             const headers: Record<string, string> = {};
-            for (const [header, value] of api.headers) {
-                headers[header] = value;
+            if (api.headers instanceof Map) {
+                for (const [header, value] of api.headers) {
+                    headers[header] = value;
+                }
             }
+            else if (api.headers) {
+                Object.assign(headers, api.headers);
+            }
+            if (this.isPublicOnly && this.getSetting('apiKey'))
+                headers['X-API-KEY'] = this.getSetting('apiKey');
 
             return await axios(url, {
                 responseType: options?.responseType,
@@ -188,12 +228,22 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
                     return;
                 }
 
-                if (!payload.camera)
+                if (!payload.camera && !(payload as any).device)
                     return;
-                const nativeId = this.getNativeId({ id: payload.camera }, false);
+                const cameraId = payload.camera || (payload as any).device;
+                const nativeId = this.getNativeId({ id: cameraId }, false);
                 const unifiCamera = this.cameras.get(nativeId);
 
                 if (!unifiCamera) {
+                    // Public API also emits lightMotion events against light devices.
+                    if (payload.type === 'lightMotion' || payload.type === 'motionLight') {
+                        const lightNativeId = this.getNativeId({ id: cameraId }, false);
+                        const unifiLight = this.lights.get(lightNativeId);
+                        if (unifiLight) {
+                            debounceMotionDetected(unifiLight);
+                            return;
+                        }
+                    }
                     this.console.log('unknown device event, sync needed?', payload, nativeId);
                     return;
                 }
@@ -368,21 +418,26 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
                     ScryptedInterface.Settings,
                     ScryptedInterface.Camera,
                     ScryptedInterface.VideoCamera,
-                    ScryptedInterface.VideoCameraMask,
-                    ScryptedInterface.VideoCameraConfiguration,
                     ScryptedInterface.MotionSensor,
                 ],
                 type: isDoorbell
                     ? ScryptedDeviceType.Doorbell
                     : ScryptedDeviceType.Camera,
             };
+            // Private-API-only camera features are omitted in API-key-only mode.
+            if (!this.isPublicOnly) {
+                d.interfaces.push(
+                    ScryptedInterface.VideoCameraMask,
+                    ScryptedInterface.VideoCameraConfiguration,
+                );
+            }
             if (isDoorbell) {
                 d.interfaces.push(ScryptedInterface.BinarySensor);
             }
-            if (camera.featureFlags.hasSpeaker) {
+            if (!this.isPublicOnly && camera.featureFlags.hasSpeaker) {
                 d.interfaces.push(ScryptedInterface.Intercom);
             }
-            if (camera.featureFlags.hasLcdScreen) {
+            if (!this.isPublicOnly && camera.featureFlags.hasLcdScreen) {
                 d.interfaces.push(ScryptedInterface.Notifier);
             }
             if (camera.featureFlags.hasPackageCamera) {
@@ -391,7 +446,7 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
             if (camera.featureFlags.hasLedStatus) {
                 d.interfaces.push(ScryptedInterface.OnOff);
             }
-            if (camera.featureFlags.canOpticalZoom) {
+            if (!this.isPublicOnly && camera.featureFlags.canOpticalZoom) {
                 d.interfaces.push(ScryptedInterface.PanTiltZoom);
             }
             d.interfaces.push(ScryptedInterface.ObjectDetector);
@@ -400,6 +455,8 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         }
 
         for (const sensor of this.api.bootstrap.sensors || []) {
+            if (this.isPublicOnly)
+                continue;
             if (!sensor.isAdopted || sensor.isAdoptedByOther) {
                 continue;
             }
@@ -470,6 +527,8 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         }
 
         for (const lock of (this.api.bootstrap.doorlocks as any) || []) {
+            if (this.isPublicOnly)
+                continue;
             if (!lock.isAdopted || lock.isAdoptedByOther) {
                 continue;
             }
@@ -541,25 +600,27 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         let camera = this.api.bootstrap.cameras.find(c => c.id === d.nativeId);
         if (camera) {
             let needUpdate = false;
-            for (const channel of camera.channels) {
-                if (channel.idrInterval !== 4 || !channel.isRtspEnabled) {
-                    if (channel.idrInterval !== 4)
-                        this.console.log('attempting to change invalid idr interval. if this message shows up again on plugin reload, it failed. idr:', channel.idrInterval);
-                    channel.idrInterval = 4;
-                    channel.isRtspEnabled = true;
-                    needUpdate = true;
+            if (!this.isPublicOnly) {
+                for (const channel of camera.channels) {
+                    if (channel.idrInterval !== 4 || !channel.isRtspEnabled) {
+                        if (channel.idrInterval !== 4)
+                            this.console.log('attempting to change invalid idr interval. if this message shows up again on plugin reload, it failed. idr:', channel.idrInterval);
+                        channel.idrInterval = 4;
+                        channel.isRtspEnabled = true;
+                        needUpdate = true;
+                    }
                 }
-            }
 
-            if (needUpdate) {
-                const updated = await this.api.updateDevice(camera, {
-                    channels: camera.channels,
-                });
-                if (!camera) {
-                    this.log.a('Unable to enable RTSP and IDR interval on camera. Is this an admin account?');
-                }
-                else {
-                    camera = updated;
+                if (needUpdate) {
+                    const updated = await this.api.updateDevice(camera, {
+                        channels: camera.channels,
+                    });
+                    if (!camera) {
+                        this.log.a('Unable to enable RTSP and IDR interval on camera. Is this an admin account?');
+                    }
+                    else {
+                        camera = updated;
+                    }
                 }
             }
 
@@ -590,7 +651,7 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
                 devices.push(d);
             }
 
-            if (camera.featureFlags.hasFingerprintSensor) {
+            if (!this.isPublicOnly && camera.featureFlags.hasFingerprintSensor) {
                 const nativeId = providerNativeId + '-fingerprintSensor';
                 const d: Device = {
                     providerNativeId,
@@ -627,8 +688,11 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
         this.reconnecting = false;
 
         const ip = this.getSetting('ip');
+        const connectionMode = this.getSetting('connectionMode') || CONNECTION_MODE_LOCAL_USER;
+        const apiKey = this.getSetting('apiKey');
         const username = this.getSetting('username');
         const password = this.getSetting('password');
+        const publicOnly = connectionMode === CONNECTION_MODE_API_KEY_ONLY;
 
         this.log.clearAlerts();
 
@@ -638,33 +702,54 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
             return;
         }
 
-        if (!username) {
-            if (!silent)
-                this.log.a('Must provide username.');
-            return;
+        if (publicOnly) {
+            if (!apiKey) {
+                if (!silent)
+                    this.log.a('Must provide API key. Create one in UniFi OS: Settings → Control Plane → Integrations.');
+                return;
+            }
+        }
+        else {
+            if (!username) {
+                if (!silent)
+                    this.log.a('Must provide username.');
+                return;
+            }
+
+            if (!password) {
+                if (!silent)
+                    this.log.a('Must provide password.');
+                return;
+            }
         }
 
-        if (!password) {
-            if (!silent)
-                this.log.a('Must provide password.');
-            return;
-        }
-
-        if (!this.api) {
-            this.api = new ProtectApi({
-                debug() { },
-                error: (...args) => {
-                    this.console.error(...args);
-                },
-                info() { },
-                warn() { },
-            });
+        if (!this.api || (this.api instanceof ProtectPublicApi) !== publicOnly) {
+            if (publicOnly) {
+                this.api = new ProtectPublicApi({
+                    debug: (...args) => this.debugLog(...args),
+                    error: (...args) => {
+                        this.console.error(...args);
+                    },
+                    info: (...args) => this.console.log(...args),
+                    warn: (...args) => this.console.warn(...args),
+                });
+            }
+            else {
+                this.api = new ProtectApi({
+                    debug() { },
+                    error: (...args) => {
+                        this.console.error(...args);
+                    },
+                    info() { },
+                    warn() { },
+                });
+            }
         }
 
         try {
             const loginResult = await this.relogin();
             if (!loginResult) {
-                this.log.a('Login failed. Check credentials.');
+                this.log.a(publicOnly ? 'Login failed. Check API key.' : 'Login failed. Check credentials.');
                 return;
             }
 
@@ -688,9 +773,9 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
             // refresh all adopted devices and update state.
             const adoptedDevices = [
                 ...this.api.bootstrap.cameras || [],
-                ...this.api.bootstrap.sensors || [],
+                ...(publicOnly ? [] : this.api.bootstrap.sensors || []),
                 ...this.api.bootstrap.lights || [],
-                ...(this.api.bootstrap.doorlocks as any) || [],
+                ...(publicOnly ? [] : (this.api.bootstrap.doorlocks as any) || []),
             ]
                 .filter(device => device.isAdopted && !device.isAdoptedByOther);
 
@@ -790,14 +875,41 @@ export class UnifiProtect extends ScryptedDeviceBase implements Settings, Device
     }
 
     storageSettings = new StorageSettings(this, {
+        connectionMode: {
+            title: 'Connection Mode',
+            description: 'Local User uses a Protect local account (full feature set). API Key Only uses the UniFi OS Integration API key with no local user — currently cameras (streams/snapshots) and lights.',
+            choices: [
+                CONNECTION_MODE_LOCAL_USER,
+                CONNECTION_MODE_API_KEY_ONLY,
+            ],
+            defaultValue: CONNECTION_MODE_LOCAL_USER,
+            onPut: () => this.forceReconnect(),
+        },
         username: {
             title: 'Username',
+            description: 'Local Protect user. Not used in API Key Only mode.',
             onPut: () => this.forceReconnect(),
+            onGet: async () => ({
+                hide: this.isPublicOnly,
+            }),
         },
         password: {
             title: 'Password',
             type: 'password',
+            description: 'Local Protect user password. Not used in API Key Only mode.',
             onPut: () => this.forceReconnect(),
+            onGet: async () => ({
+                hide: this.isPublicOnly,
+            }),
+        },
+        apiKey: {
+            title: 'API Key',
+            type: 'password',
+            description: 'Create in UniFi OS: Settings → Control Plane → Integrations. Required for API Key Only mode.',
+            onPut: () => this.forceReconnect(),
+            onGet: async () => ({
+                hide: !this.isPublicOnly,
+            }),
         },
         ip: {
             title: 'Unifi Protect IP',

--- a/plugins/unifi-protect/src/public-api.ts
+++ b/plugins/unifi-protect/src/public-api.ts
@@ -1,0 +1,556 @@
+import { EventEmitter } from 'events';
+import axios, { AxiosRequestConfig, Method, ResponseType } from 'axios';
+import https from 'https';
+import WS from 'ws';
+
+const httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+});
+
+export const CONNECTION_MODE_LOCAL_USER = 'Local User';
+export const CONNECTION_MODE_API_KEY_ONLY = 'API Key Only';
+
+const INTEGRATION_PREFIX = '/proxy/protect/integration/v1';
+const QUALITY_ORDER = ['high', 'medium', 'low', 'package'];
+
+export interface PublicCameraFeatureFlags {
+    supportFullHdSnapshot?: boolean;
+    hasHdr?: boolean;
+    smartDetectTypes?: string[];
+    smartDetectAudioTypes?: string[];
+    videoModes?: string[];
+    hasMic?: boolean;
+    hasLedStatus?: boolean;
+    hasSpeaker?: boolean;
+}
+
+export interface PublicCamera {
+    id: string;
+    modelKey?: string;
+    state?: string;
+    name?: string;
+    type?: string;
+    guid?: string;
+    mac?: string;
+    isMicEnabled?: boolean;
+    ledSettings?: {
+        isEnabled?: boolean;
+        welcomeLed?: boolean | null;
+        floodLed?: boolean | null;
+    };
+    lcdMessage?: {
+        type?: string;
+        resetAt?: number | null;
+        text?: string;
+    } | null;
+    featureFlags?: PublicCameraFeatureFlags;
+    smartDetectSettings?: {
+        objectTypes?: string[];
+        audioTypes?: string[];
+    };
+    hasPackageCamera?: boolean;
+    rtspsStreams?: Record<string, string | null | undefined>;
+}
+
+export interface PublicLight {
+    id: string;
+    modelKey?: string;
+    state?: string;
+    name?: string;
+    type?: string;
+    guid?: string;
+    mac?: string;
+    lightModeSettings?: {
+        mode?: string;
+        enableAt?: string;
+    };
+    lightDeviceSettings?: {
+        isIndicatorEnabled?: boolean;
+        pirDuration?: number | null;
+        pirSensitivity?: number | null;
+        ledLevel?: number | null;
+    };
+    isDark?: boolean;
+    isLightOn?: boolean;
+    isLightForceEnabled?: boolean;
+    lastMotion?: number | null;
+    isPirMotionDetected?: boolean;
+    camera?: string | null;
+}
+
+export interface PublicBootstrap {
+    cameras: any[];
+    lights: any[];
+    sensors: any[];
+    doorlocks: any[];
+    nvr?: { id?: string; name?: string; mac?: string };
+    meta?: { applicationVersion?: string };
+}
+
+export interface PublicEventItem {
+    id?: string;
+    modelKey?: string;
+    type?: string;
+    start?: number;
+    end?: number;
+    device?: string;
+    camera?: string;
+    smartDetectTypes?: string[];
+    score?: number;
+    metadata?: any;
+}
+
+export interface PublicWsMessage {
+    type: 'add' | 'update' | 'remove' | string;
+    item: PublicEventItem & Record<string, any>;
+}
+
+function extractRtspAlias(url: string): string | undefined {
+    try {
+        const parsed = new URL(url);
+        return parsed.pathname.replace(/^\//, '') || undefined;
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function stripEnableSrtp(url: string): string {
+    return url.replace(/\?enableSrtp$/, '');
+}
+
+function replaceUrlHost(url: string, host: string): string {
+    try {
+        const parsed = new URL(url);
+        parsed.hostname = host;
+        return parsed.toString();
+    }
+    catch {
+        return url;
+    }
+}
+
+function isDoorbellCamera(camera: PublicCamera): boolean {
+    if (camera.ledSettings && camera.ledSettings.welcomeLed != null)
+        return true;
+    if (camera.lcdMessage != null)
+        return true;
+    return /doorbell/i.test(camera.type || '') || /doorbell/i.test(camera.name || '');
+}
+
+/**
+ * Adapt a public Integration API camera into a shape close enough to the
+ * private bootstrap camera for Scrypted discovery and device helpers.
+ */
+export function adaptPublicCamera(camera: PublicCamera, connectionHost?: string): any {
+    const streams = camera.rtspsStreams || {};
+    const qualities = [
+        ...QUALITY_ORDER.filter(q => q in streams),
+        ...Object.keys(streams).filter(q => !QUALITY_ORDER.includes(q)),
+    ];
+
+    const channels = qualities.map((quality, index) => {
+        const rawUrl = streams[quality];
+        const url = typeof rawUrl === 'string' ? stripEnableSrtp(rawUrl) : undefined;
+        const rewritten = url && connectionHost ? replaceUrlHost(url, connectionHost) : url;
+        return {
+            id: quality,
+            name: quality,
+            enabled: !!rewritten,
+            isRtspEnabled: !!rewritten,
+            rtspAlias: rewritten ? extractRtspAlias(rewritten) : undefined,
+            rtspsUrl: rewritten,
+            width: 0,
+            height: 0,
+            fps: 0,
+            bitrate: 0,
+            minBitrate: 0,
+            maxBitrate: 0,
+            idrInterval: 4,
+            _quality: quality,
+            _index: index,
+        };
+    }).filter(channel => channel.rtspsUrl);
+
+    const doorbell = isDoorbellCamera(camera);
+
+    return {
+        ...camera,
+        isAdopted: true,
+        isAdoptedByOther: false,
+        isConnected: camera.state === 'CONNECTED',
+        isMotionDetected: false,
+        host: connectionHost,
+        connectionHost,
+        videoCodec: 'h264',
+        channels,
+        featureFlags: {
+            supportFullHdSnapshot: !!camera.featureFlags?.supportFullHdSnapshot,
+            hasHdr: !!camera.featureFlags?.hasHdr,
+            smartDetectTypes: camera.featureFlags?.smartDetectTypes || [],
+            smartDetectAudioTypes: camera.featureFlags?.smartDetectAudioTypes || [],
+            videoModes: camera.featureFlags?.videoModes || [],
+            hasMic: !!camera.featureFlags?.hasMic,
+            hasLedStatus: !!camera.featureFlags?.hasLedStatus,
+            hasSpeaker: !!camera.featureFlags?.hasSpeaker,
+            hasPackageCamera: !!camera.hasPackageCamera,
+            isDoorbell: doorbell,
+            hasChime: doorbell,
+            hasLcdScreen: doorbell || camera.lcdMessage != null,
+            canOpticalZoom: false,
+            hasFingerprintSensor: false,
+        },
+    };
+}
+
+export function adaptPublicLight(light: PublicLight, connectionHost?: string): any {
+    return {
+        ...light,
+        isAdopted: true,
+        isAdoptedByOther: false,
+        isConnected: light.state === 'CONNECTED',
+        host: connectionHost,
+        // Private API naming used by existing UnifiLight helpers.
+        lightOnSettings: {
+            isLedForceOn: !!light.isLightForceEnabled,
+        },
+    };
+}
+
+export class ProtectPublicApi extends EventEmitter {
+    host?: string;
+    apiKey?: string;
+    bootstrap: PublicBootstrap | null = null;
+    headers = new Map<string, string>();
+    private eventsWs?: WS;
+    private devicesWs?: WS;
+    private closed = false;
+    private connectionHost?: string;
+
+    constructor(private log: { debug?: (...args: any[]) => void, error?: (...args: any[]) => void, info?: (...args: any[]) => void, warn?: (...args: any[]) => void } = {}) {
+        super();
+    }
+
+    get isPublicOnly() {
+        return true;
+    }
+
+    private integrationUrl(path: string) {
+        return `https://${this.host}${INTEGRATION_PREFIX}${path}`;
+    }
+
+    private async request<T = any>(method: Method, path: string, options: {
+        data?: any,
+        responseType?: ResponseType,
+        params?: Record<string, any>,
+        signal?: AbortSignal,
+    } = {}): Promise<T> {
+        if (!this.host || !this.apiKey)
+            throw new Error('Public API client is not logged in.');
+
+        const headers: Record<string, string> = {
+            'X-API-KEY': this.apiKey,
+            Accept: options.responseType === 'arraybuffer' ? '*/*' : 'application/json',
+        };
+        if (options.data !== undefined)
+            headers['Content-Type'] = 'application/json';
+
+        const config: AxiosRequestConfig = {
+            method,
+            url: this.integrationUrl(path),
+            headers,
+            httpsAgent,
+            responseType: options.responseType || 'json',
+            params: options.params,
+            data: options.data,
+            signal: options.signal,
+            validateStatus: () => true,
+        };
+
+        const response = await axios(config);
+        if (response.status === 401 || response.status === 403)
+            throw new Error(`Protect API key was rejected (${response.status}).`);
+        if (response.status < 200 || response.status >= 300) {
+            const detail = typeof response.data === 'string'
+                ? response.data
+                : JSON.stringify(response.data);
+            throw new Error(`Protect public API ${method} ${path} failed (${response.status}): ${detail}`);
+        }
+        return response.data as T;
+    }
+
+    async login(host: string, apiKey: string): Promise<boolean> {
+        this.resetSockets();
+        this.host = host;
+        this.apiKey = apiKey;
+        this.connectionHost = host;
+        this.headers = new Map([['X-API-KEY', apiKey]]);
+        this.closed = false;
+
+        try {
+            const meta = await this.request<{ applicationVersion?: string }>('GET', '/meta/info');
+            this.emit('login', true);
+            this.log.info?.(`Connected to Protect public API ${meta?.applicationVersion || ''}`.trim());
+            if (!this.bootstrap)
+                this.bootstrap = { cameras: [], lights: [], sensors: [], doorlocks: [], meta };
+            else
+                this.bootstrap.meta = meta;
+            return true;
+        }
+        catch (e) {
+            this.emit('login', false);
+            this.log.error?.('Protect public API login failed', e);
+            return false;
+        }
+    }
+
+    async getBootstrap(): Promise<boolean> {
+        try {
+            const [cameras, lights] = await Promise.all([
+                this.request<PublicCamera[]>('GET', '/cameras'),
+                this.request<PublicLight[]>('GET', '/lights').catch(() => [] as PublicLight[]),
+            ]);
+
+            const adaptedCameras = [];
+            for (const camera of cameras || []) {
+                try {
+                    camera.rtspsStreams = await this.getCameraRtspsStreams(camera.id);
+                }
+                catch (e) {
+                    this.log.warn?.(`Unable to prime RTSPS streams for camera ${camera.name || camera.id}`, e);
+                    camera.rtspsStreams = camera.rtspsStreams || {};
+                }
+                adaptedCameras.push(adaptPublicCamera(camera, this.connectionHost));
+            }
+
+            this.bootstrap = {
+                cameras: adaptedCameras,
+                lights: (lights || []).map(light => adaptPublicLight(light, this.connectionHost)),
+                sensors: [],
+                doorlocks: [],
+                meta: this.bootstrap?.meta,
+            };
+
+            this.emit('bootstrap', this.bootstrap);
+            this.connectWebsockets();
+            return true;
+        }
+        catch (e) {
+            this.log.error?.('Protect public API bootstrap failed', e);
+            return false;
+        }
+    }
+
+    async getCameraRtspsStreams(cameraId: string): Promise<Record<string, string | null | undefined>> {
+        try {
+            const existing = await this.request<Record<string, string | null | undefined>>('GET', `/cameras/${cameraId}/rtsps-stream`);
+            const active = Object.entries(existing || {}).filter(([, url]) => typeof url === 'string' && !!url);
+            if (active.length)
+                return existing || {};
+        }
+        catch (e) {
+            this.log.debug?.('GET rtsps-stream failed, will try create', e);
+        }
+
+        // Create common qualities when none are active yet.
+        try {
+            return await this.request<Record<string, string | null | undefined>>('POST', `/cameras/${cameraId}/rtsps-stream`, {
+                data: { qualities: ['high', 'medium', 'low', 'package'] },
+            });
+        }
+        catch (e) {
+            this.log.debug?.('POST rtsps-stream failed', e);
+            return {};
+        }
+    }
+
+    async getSnapshot(cameraId: string, highQuality = true, signal?: AbortSignal): Promise<Buffer> {
+        try {
+            const data = await this.request<ArrayBuffer>('GET', `/cameras/${cameraId}/snapshot`, {
+                params: { highQuality },
+                responseType: 'arraybuffer',
+                signal,
+            });
+            return Buffer.from(data);
+        }
+        catch (e) {
+            if (highQuality) {
+                // Some cameras reject highQuality=true; fall back to low-res.
+                const data = await this.request<ArrayBuffer>('GET', `/cameras/${cameraId}/snapshot`, {
+                    params: { highQuality: false },
+                    responseType: 'arraybuffer',
+                    signal,
+                });
+                return Buffer.from(data);
+            }
+            throw e;
+        }
+    }
+
+    async updateDevice(device: { id: string, modelKey?: string }, payload: Record<string, any>): Promise<any> {
+        const modelKey = device.modelKey || (this.bootstrap?.lights?.find(l => l.id === device.id) ? 'light' : 'camera');
+        if (modelKey === 'light') {
+            const body: Record<string, any> = {};
+            if (payload.lightOnSettings?.isLedForceOn != null)
+                body.isLightForceEnabled = !!payload.lightOnSettings.isLedForceOn;
+            if (payload.isLightForceEnabled != null)
+                body.isLightForceEnabled = !!payload.isLightForceEnabled;
+            if (payload.lightDeviceSettings)
+                body.lightDeviceSettings = payload.lightDeviceSettings;
+            if (payload.name != null)
+                body.name = payload.name;
+
+            const updated = await this.request<PublicLight>('PATCH', `/lights/${device.id}`, { data: body });
+            const adapted = adaptPublicLight(updated, this.connectionHost);
+            if (this.bootstrap) {
+                const idx = this.bootstrap.lights.findIndex(l => l.id === device.id);
+                if (idx >= 0)
+                    this.bootstrap.lights[idx] = { ...this.bootstrap.lights[idx], ...adapted };
+            }
+            return adapted;
+        }
+
+        const body: Record<string, any> = { ...payload };
+        // Private-only fields are not valid on the public camera PATCH.
+        delete body.channels;
+        delete body.privacyZones;
+        delete body.ispSettings;
+
+        const updated = await this.request<PublicCamera>('PATCH', `/cameras/${device.id}`, { data: body });
+        const existing = this.bootstrap?.cameras?.find(c => c.id === device.id);
+        const adapted = adaptPublicCamera({
+            ...updated,
+            rtspsStreams: existing?.rtspsStreams || updated.rtspsStreams,
+        }, this.connectionHost);
+        if (this.bootstrap) {
+            const idx = this.bootstrap.cameras.findIndex(c => c.id === device.id);
+            if (idx >= 0)
+                this.bootstrap.cameras[idx] = { ...this.bootstrap.cameras[idx], ...adapted };
+        }
+        return adapted;
+    }
+
+    getApiEndpoint(endpoint: string): string {
+        if (endpoint === 'websocket')
+            return `https://${this.host}${INTEGRATION_PREFIX}`;
+        return this.integrationUrl('');
+    }
+
+    private connectWebsockets() {
+        this.resetSockets();
+        if (!this.host || !this.apiKey || this.closed)
+            return;
+
+        const headers = { 'X-API-KEY': this.apiKey };
+
+        this.eventsWs = new WS(`wss://${this.host}${INTEGRATION_PREFIX}/subscribe/events`, {
+            rejectUnauthorized: false,
+            headers,
+        });
+        this.eventsWs.on('open', () => this.log.debug?.('Public events websocket connected'));
+        this.eventsWs.on('message', data => this.handleWsMessage('event', data));
+        this.eventsWs.on('close', () => {
+            this.log.debug?.('Public events websocket closed');
+            this.emit('websocket-close', 'events');
+        });
+        this.eventsWs.on('error', e => this.log.error?.('Public events websocket error', e));
+
+        this.devicesWs = new WS(`wss://${this.host}${INTEGRATION_PREFIX}/subscribe/devices`, {
+            rejectUnauthorized: false,
+            headers,
+        });
+        this.devicesWs.on('open', () => this.log.debug?.('Public devices websocket connected'));
+        this.devicesWs.on('message', data => this.handleWsMessage('device', data));
+        this.devicesWs.on('close', () => {
+            this.log.debug?.('Public devices websocket closed');
+            this.emit('websocket-close', 'devices');
+        });
+        this.devicesWs.on('error', e => this.log.error?.('Public devices websocket error', e));
+    }
+
+    private handleWsMessage(kind: 'event' | 'device', data: WS.RawData) {
+        try {
+            const text = typeof data === 'string' ? data : data.toString();
+            const parsed = JSON.parse(text) as PublicWsMessage | PublicWsMessage[];
+            const messages = Array.isArray(parsed) ? parsed : [parsed];
+            for (const message of messages) {
+                if (!message?.type || !message?.item)
+                    continue;
+                // Bulk device envelopes may carry an id array with a shared payload.
+                const ids = message.item.id;
+                if (kind === 'device' && Array.isArray(ids)) {
+                    for (const id of ids) {
+                        const single = { type: message.type, item: { ...message.item, id } };
+                        this.emit('public-device', single);
+                        this.emit('message', this.toPrivateStylePacket(kind, single));
+                    }
+                    continue;
+                }
+                if (kind === 'event')
+                    this.emit('public-event', message);
+                else
+                    this.emit('public-device', message);
+                // Also emit a private-style packet for shared listeners where possible.
+                this.emit('message', this.toPrivateStylePacket(kind, message));
+            }
+        }
+        catch (e) {
+            this.log.debug?.('Failed to parse public websocket message', e);
+        }
+    }
+
+    private toPrivateStylePacket(kind: 'event' | 'device', message: PublicWsMessage) {
+        const item = message.item || {};
+        if (kind === 'event' || item.modelKey === 'event') {
+            return {
+                header: {
+                    action: message.type === 'add' ? 'add' : 'update',
+                    modelKey: 'event',
+                    id: item.id,
+                },
+                payload: {
+                    ...item,
+                    // Private event payloads use `camera`; public uses `device`.
+                    camera: item.camera || item.device,
+                },
+            };
+        }
+
+        return {
+            header: {
+                action: message.type === 'add' ? 'add' : (message.type === 'remove' ? 'remove' : 'update'),
+                modelKey: item.modelKey,
+                id: item.id,
+            },
+            payload: item,
+        };
+    }
+
+    private resetSockets() {
+        try {
+            this.eventsWs?.removeAllListeners();
+            this.eventsWs?.close();
+        }
+        catch { }
+        try {
+            this.devicesWs?.removeAllListeners();
+            this.devicesWs?.close();
+        }
+        catch { }
+        this.eventsWs = undefined;
+        this.devicesWs = undefined;
+    }
+
+    reset() {
+        this.closed = true;
+        this.resetSockets();
+        this.bootstrap = null;
+        this.headers = new Map();
+    }
+
+    logout() {
+        this.reset();
+        this.host = undefined;
+        this.apiKey = undefined;
+    }
+}

--- a/plugins/unifi-protect/src/public-api.ts
+++ b/plugins/unifi-protect/src/public-api.ts
@@ -12,6 +12,14 @@ export const CONNECTION_MODE_API_KEY_ONLY = 'API Key Only';
 
 const INTEGRATION_PREFIX = '/proxy/protect/integration/v1';
 const QUALITY_ORDER = ['high', 'medium', 'low', 'package'];
+// UniFi Protect public Integration API rate limit: 10 requests / 1000ms.
+const PUBLIC_API_RATE_LIMIT = 10;
+const PUBLIC_API_RATE_WINDOW_MS = 1000;
+const PUBLIC_API_MAX_RETRIES = 4;
+
+function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 export interface PublicCameraFeatureFlags {
     supportFullHdSnapshot?: boolean;
@@ -226,6 +234,8 @@ export class ProtectPublicApi extends EventEmitter {
     private devicesWs?: WS;
     private closed = false;
     private connectionHost?: string;
+    private requestTimestamps: number[] = [];
+    private requestChain: Promise<void> = Promise.resolve();
 
     constructor(private log: { debug?: (...args: any[]) => void, error?: (...args: any[]) => void, info?: (...args: any[]) => void, warn?: (...args: any[]) => void } = {}) {
         super();
@@ -239,14 +249,41 @@ export class ProtectPublicApi extends EventEmitter {
         return `https://${this.host}${INTEGRATION_PREFIX}${path}`;
     }
 
+    private async acquireRateLimitSlot() {
+        // Serialize callers so concurrent bootstrap/stream work cannot burst past the limit.
+        let release!: () => void;
+        const gate = new Promise<void>(resolve => { release = resolve; });
+        const previous = this.requestChain;
+        this.requestChain = previous.then(() => gate, () => gate);
+        await previous.catch(() => { });
+
+        try {
+            const now = Date.now();
+            this.requestTimestamps = this.requestTimestamps.filter(t => now - t < PUBLIC_API_RATE_WINDOW_MS);
+            if (this.requestTimestamps.length >= PUBLIC_API_RATE_LIMIT - 1) {
+                const waitMs = PUBLIC_API_RATE_WINDOW_MS - (now - this.requestTimestamps[0]) + 25;
+                if (waitMs > 0)
+                    await sleep(waitMs);
+                const refreshed = Date.now();
+                this.requestTimestamps = this.requestTimestamps.filter(t => refreshed - t < PUBLIC_API_RATE_WINDOW_MS);
+            }
+            this.requestTimestamps.push(Date.now());
+        }
+        finally {
+            release();
+        }
+    }
+
     private async request<T = any>(method: Method, path: string, options: {
         data?: any,
         responseType?: ResponseType,
         params?: Record<string, any>,
         signal?: AbortSignal,
-    } = {}): Promise<T> {
+    } = {}, attempt = 0): Promise<T> {
         if (!this.host || !this.apiKey)
             throw new Error('Public API client is not logged in.');
+
+        await this.acquireRateLimitSlot();
 
         const headers: Record<string, string> = {
             'X-API-KEY': this.apiKey,
@@ -270,6 +307,20 @@ export class ProtectPublicApi extends EventEmitter {
         const response = await axios(config);
         if (response.status === 401 || response.status === 403)
             throw new Error(`Protect API key was rejected (${response.status}).`);
+        if (response.status === 429) {
+            if (attempt >= PUBLIC_API_MAX_RETRIES)
+                throw new Error(`Protect public API ${method} ${path} failed (429): too many retries`);
+            const body = response.data || {};
+            const windowMs = typeof body.windowMs === 'number' ? body.windowMs : PUBLIC_API_RATE_WINDOW_MS;
+            const retryAfterHeader = response.headers?.['retry-after'];
+            const retryAfterMs = retryAfterHeader ? Number(retryAfterHeader) * 1000 : NaN;
+            const waitMs = Number.isFinite(retryAfterMs) && retryAfterMs > 0
+                ? retryAfterMs
+                : windowMs + 50 * (attempt + 1);
+            this.log.warn?.(`Protect public API rate limited on ${method} ${path}; retrying in ${waitMs}ms`);
+            await sleep(waitMs);
+            return this.request(method, path, options, attempt + 1);
+        }
         if (response.status < 200 || response.status >= 300) {
             const detail = typeof response.data === 'string'
                 ? response.data
@@ -306,15 +357,21 @@ export class ProtectPublicApi extends EventEmitter {
 
     async getBootstrap(): Promise<boolean> {
         try {
-            const [cameras, lights] = await Promise.all([
-                this.request<PublicCamera[]>('GET', '/cameras'),
-                this.request<PublicLight[]>('GET', '/lights').catch(() => [] as PublicLight[]),
-            ]);
+            // Fetch sequentially to stay under the public API rate limit.
+            const cameras = await this.request<PublicCamera[]>('GET', '/cameras');
+            let lights: PublicLight[] = [];
+            try {
+                lights = await this.request<PublicLight[]>('GET', '/lights');
+            }
+            catch (e) {
+                this.log.warn?.('Unable to list lights from public API', e);
+            }
 
             const adaptedCameras = [];
             for (const camera of cameras || []) {
                 try {
-                    camera.rtspsStreams = await this.getCameraRtspsStreams(camera.id);
+                    // Prefer GET-only priming during bootstrap; create streams lazily on demand.
+                    camera.rtspsStreams = await this.getCameraRtspsStreams(camera.id, false);
                 }
                 catch (e) {
                     this.log.warn?.(`Unable to prime RTSPS streams for camera ${camera.name || camera.id}`, e);
@@ -341,15 +398,17 @@ export class ProtectPublicApi extends EventEmitter {
         }
     }
 
-    async getCameraRtspsStreams(cameraId: string): Promise<Record<string, string | null | undefined>> {
+    async getCameraRtspsStreams(cameraId: string, createIfMissing = true): Promise<Record<string, string | null | undefined>> {
         try {
             const existing = await this.request<Record<string, string | null | undefined>>('GET', `/cameras/${cameraId}/rtsps-stream`);
             const active = Object.entries(existing || {}).filter(([, url]) => typeof url === 'string' && !!url);
-            if (active.length)
+            if (active.length || !createIfMissing)
                 return existing || {};
         }
         catch (e) {
             this.log.debug?.('GET rtsps-stream failed, will try create', e);
+            if (!createIfMissing)
+                return {};
         }
 
         // Create common qualities when none are active yet.
@@ -526,17 +585,27 @@ export class ProtectPublicApi extends EventEmitter {
         };
     }
 
+    private safeCloseSocket(ws?: WS) {
+        if (!ws)
+            return;
+        // Closing a CONNECTING socket emits an 'error' event. With no listener,
+        // Node treats that as an uncaughtException and crashes the plugin.
+        ws.removeAllListeners();
+        ws.on('error', () => { });
+        try {
+            if (ws.readyState === WS.CONNECTING || ws.readyState === WS.CLOSING)
+                ws.terminate();
+            else if (ws.readyState === WS.OPEN)
+                ws.close();
+            else
+                ws.terminate();
+        }
+        catch { }
+    }
+
     private resetSockets() {
-        try {
-            this.eventsWs?.removeAllListeners();
-            this.eventsWs?.close();
-        }
-        catch { }
-        try {
-            this.devicesWs?.removeAllListeners();
-            this.devicesWs?.close();
-        }
-        catch { }
+        this.safeCloseSocket(this.eventsWs);
+        this.safeCloseSocket(this.devicesWs);
         this.eventsWs = undefined;
         this.devicesWs = undefined;
     }
@@ -546,6 +615,7 @@ export class ProtectPublicApi extends EventEmitter {
         this.resetSockets();
         this.bootstrap = null;
         this.headers = new Map();
+        this.requestTimestamps = [];
     }
 
     logout() {


### PR DESCRIPTION
## Summary

Adds an **API Key Only** connection mode to the UniFi Protect plugin, alongside the existing local user account flow — modeled after Home Assistant’s approach in [home-assistant/core#176410](https://github.com/home-assistant/core/pull/176410).

### Connection modes

| Mode | Auth | Scope |
|------|------|--------|
| **Local User** (default) | Username / password against the private Protect API | Full feature set (unchanged) |
| **API Key Only** | UniFi OS Integration API key (`X-API-KEY`) against the public Integration API | Cameras + lights |

API keys are created in the UniFi OS local portal under **Settings → Control Plane → Integrations**.

### API Key Only capabilities

- Cameras: RTSPS streams, snapshots, motion/smart detections, doorbell ring, status LED
- Lights: on/off, brightness, PIR motion
- Public events/devices websockets for realtime updates

### Not available in API Key Only (use Local User)

- Sensors and locks
- Two-way audio / intercom
- Privacy masks, dynamic bitrate, optical zoom
- Fingerprint sensors and package-camera snapshots

### Implementation notes

- New `ProtectPublicApi` client (`plugins/unifi-protect/src/public-api.ts`) talks to `/proxy/protect/integration/v1/*`
- Public camera/light payloads are adapted into bootstrap-compatible shapes so discovery and device helpers can be shared
- Settings UI shows username/password or API key based on the selected mode
- Existing Local User installs are unaffected (default mode)
- Public API client rate-limits to UniFi’s 10 req/s window, retries 429s, and safely resets CONNECTING websockets
- Version bumped to `0.2.0`

## Test plan

- [x] API Key Only connects with IP + API key against Protect 7.2.x
- [x] Fixed 429 / websocket uncaughtException loop on bootstrap (rate limit + safe WS reset)
- [x] Local User username/password path still connects and streams
- [x] Discover/adopt cameras; verify RTSPS playback and snapshots
- [x] Motion / smart detect / doorbell ring events update Scrypted sensors
- [ ] Lights on/off and brightness work
- [ ] Sensors/locks are not offered in API Key Only mode
- [ ] Switching back to Local User still works with stored credentials