### PR TITLE
rtsp: fold continuation lines and dump raw bytes on bad frame magic

### DIFF
--- a/common/src/read-stream.ts
+++ b/common/src/read-stream.ts
@@ -110,7 +110,11 @@ export async function readLength(readable: Readable, length: number): Promise<Bu
 
 const CHARCODE_NEWLINE = '\n'.charCodeAt(0);
 
-export async function readUntil(readable: Readable, charCode: number) {
+/**
+ * Read up to (not including) the next occurrence of charCode, returning the raw bytes.
+ * The delimiter itself is consumed and discarded.
+ */
+export async function readUntilBuffer(readable: Readable, charCode: number): Promise<Buffer> {
   const queued: Buffer[] = [];
   while (true) {
     const available: Buffer = readable.read();
@@ -129,12 +133,55 @@ export async function readUntil(readable: Readable, charCode: number) {
 
     const after = available.subarray(index + 1);
     readable.unshift(after);
-    return Buffer.concat(queued).toString();
+    return Buffer.concat(queued);
   }
+}
+
+export async function readUntil(readable: Readable, charCode: number) {
+  return (await readUntilBuffer(readable, charCode)).toString();
+}
+
+/**
+ * Read one line as raw bytes. The terminating LF is consumed and not returned;
+ * a preceding CR, if any, is returned.
+ */
+export async function readLineBuffer(readable: Readable) {
+  return readUntilBuffer(readable, CHARCODE_NEWLINE);
 }
 
 export async function readLine(readable: Readable) {
   return readUntil(readable, CHARCODE_NEWLINE);
+}
+
+/**
+ * Format bytes for diagnostics. Printable ASCII is kept, CR, LF and TAB are shown as
+ * escapes so line structure is unambiguous, everything else is shown as \xNN.
+ * A hex dump follows. Intended for error messages and opt-in debug logging.
+ */
+export function formatRawBytes(buffer: Buffer, maxLength = 512): string {
+  const shown = buffer.subarray(0, maxLength);
+  let escaped = '';
+  for (const c of shown) {
+    if (c === 13)
+      escaped += '\\r';
+    else if (c === 10)
+      escaped += '\\n\n';
+    else if (c === 9)
+      escaped += '\\t';
+    else if (c >= 32 && c < 127)
+      escaped += String.fromCharCode(c);
+    else
+      escaped += '\\x' + c.toString(16).padStart(2, '0');
+  }
+  const hexLines: string[] = [];
+  for (let i = 0; i < shown.length; i += 16) {
+    const chunk = shown.subarray(i, i + 16);
+    const hex = [...chunk].map(c => c.toString(16).padStart(2, '0')).join(' ');
+    const ascii = [...chunk].map(c => c >= 32 && c < 127 ? String.fromCharCode(c) : '.').join('');
+    hexLines.push(`${i.toString(16).padStart(8, '0')}  ${hex.padEnd(47)}  |${ascii}|`);
+  }
+  const truncated = buffer.length > shown.length ? `\n... ${buffer.length - shown.length} more bytes not shown` : '';
+  return `${escaped}\n${hexLines.join('\n')}${truncated}`;
 }
 
 export async function readString(readable: Readable | Promise<Readable>) {

--- a/common/src/rtsp-server.ts
+++ b/common/src/rtsp-server.ts
@@ -8,7 +8,7 @@ import { URL } from 'url';
 import { Deferred } from './deferred';
 import { closeQuiet, createBindZero, createSquentialBindZero, listenZeroSingleClient } from './listen-cluster';
 import { timeoutPromise } from './promise-utils';
-import { readLength, readLine } from './read-stream';
+import { formatRawBytes, readLength, readLine, readLineBuffer } from './read-stream';
 import { MSection, parseSdp } from './sdp-utils';
 import { sleep } from './sleep';
 import { StreamChunk, StreamParser, StreamParserOptions } from './stream-parser';
@@ -36,14 +36,46 @@ export interface RtspStreamParser extends StreamParser {
     sdp: Promise<string>;
 }
 
-export async function readMessage(client: Readable): Promise<string[]> {
-    let currentHeaders: string[] = [];
+/**
+ * Read an RTSP message header block (status or request line followed by headers),
+ * returning one string per header. The block ends at an empty line.
+ *
+ * RTSP header syntax is inherited from HTTP/1.1 (RFC 2326 section 4.2 refers to
+ * RFC 2068 section 4.2): "Header fields can be extended over multiple lines by
+ * preceding each extra line with at least one SP or HT." Such continuation lines
+ * are folded into the preceding header here.
+ *
+ * The end-of-headers test is made before trimming. A line containing only
+ * whitespace is a (content-free) continuation line, not the end of the message.
+ * Luma x20 cameras ("Customer RTSP Server/1.0.0") send exactly that, a lone
+ * SP CRLF, between the Session and RTP-Info headers of the PLAY response.
+ * Trimming first turned that into an early end of message and left RTP-Info in
+ * the socket buffer, where the interleaved frame reader rejected it as bad magic.
+ *
+ * @param console optional. When provided, every line is logged as read, raw and
+ * trimmed, with its bytes, so whitespace and line endings are visible.
+ */
+export async function readMessage(client: Readable, console?: Console): Promise<string[]> {
+    const currentHeaders: string[] = [];
     while (true) {
-        let line = await readLine(client);
-        line = line.trim();
-        if (!line)
+        const raw = await readLineBuffer(client);
+        const line = raw.toString();
+        // readLine consumes the LF. Drop the CR (or any stray CR/LF) that precedes it.
+        const content = line.replace(/[\r\n]+$/, '');
+        const trimmed = content.trim();
+        console?.log(`rtsp raw line ${JSON.stringify(line)} -> ${JSON.stringify(trimmed)} [${raw.toString('hex')}]`);
+
+        if (!content)
             return currentHeaders;
-        currentHeaders.push(line);
+
+        if ((content[0] === ' ' || content[0] === '\t') && currentHeaders.length) {
+            // continuation (folded) line: append to the previous header.
+            if (trimmed)
+                currentHeaders[currentHeaders.length - 1] += ' ' + trimmed;
+            continue;
+        }
+
+        currentHeaders.push(trimmed);
     }
 }
 
@@ -395,6 +427,13 @@ export class RtspStatusError extends Error {
 export class RtspBase {
     client: net.Socket;
     console?: Console;
+    /**
+     * Opt-in raw logging of the control channel: every line read by readMessage is
+     * logged with its bytes. Only emitted when a console is attached, so it costs
+     * nothing otherwise. Enable with the SCRYPTED_RTSP_NOISY environment variable
+     * or by setting it on an instance.
+     */
+    noisy = !!process.env.SCRYPTED_RTSP_NOISY;
 
     constructor() {
     }
@@ -404,7 +443,7 @@ export class RtspBase {
     }
 
     async readMessage(): Promise<string[]> {
-        const message = await readMessage(this.client);
+        const message = await readMessage(this.client, this.noisy ? this.console : undefined);
         this.console?.log('rtsp incoming message\n', message.join('\n'));
         this.console?.log();
         return message;
@@ -520,7 +559,7 @@ export class RtspClient extends RtspBase {
     async handleDataPayload(header: Buffer) {
         // todo: fix this, because calling teardown outside of the read loop causes this.
         if (header[0] !== RTSP_FRAME_MAGIC)
-            throw new Error('RTSP Client received invalid frame magic. This may be a bug in your camera firmware. If this error persists, switch your RTSP Parser to FFmpeg or Scrypted (UDP): ' + header.toString());
+            throw this.createBadHeader(header);
 
         const channel = header.readUInt8(1);
         const length = header.readUInt16BE(2);
@@ -536,7 +575,19 @@ export class RtspClient extends RtspBase {
     }
 
     createBadHeader(header: Buffer) {
-        return new Error('RTSP Client received invalid frame magic. This may be a bug in your camera firmware. If this error persists, switch your RTSP Parser to FFmpeg or Scrypted (UDP): ' + header.toString());
+        // Include whatever else is already buffered so the error shows the bytes in
+        // context rather than only the 4 that failed validation. The socket is about
+        // to be destroyed by every caller, so consuming the buffer here is harmless.
+        let buffered: Buffer;
+        try {
+            buffered = this.client.read() || Buffer.alloc(0);
+        }
+        catch (e) {
+            buffered = Buffer.alloc(0);
+        }
+        const context = Buffer.concat([header, buffered]);
+        return new Error('RTSP Client received invalid frame magic. This may be a bug in your camera firmware. If this error persists, switch your RTSP Parser to FFmpeg or Scrypted (UDP): ' + header.toString()
+            + `\nRaw bytes at the failure (${header.length} header + ${buffered.length} buffered):\n${formatRawBytes(context)}`);
     }
 
     async readLoopLegacy() {

--- a/common/test/rtsp-read-message.ts
+++ b/common/test/rtsp-read-message.ts
@@ -1,0 +1,214 @@
+import assert from 'assert';
+import { once } from 'events';
+import net, { AddressInfo } from 'net';
+import { PassThrough, Readable } from 'stream';
+import { readLength, readLine } from '../src/read-stream';
+import { RtspClient, parseHeaders, readMessage } from '../src/rtsp-server';
+import { sleep } from '../src/sleep';
+
+// Run with: npx ts-node test/rtsp-read-message.ts
+
+// Captured 2026-09-04 from a Luma x20 (LUM-820-IP-TMHW, firmware 5.1.1.0,
+// "Server: Customer RTSP Server/1.0.0") on the RTSP control socket immediately
+// after PLAY over RTP/AVP/TCP. It is the complete PLAY response followed by the
+// first interleaved frame: channel 3, 56 bytes (an RTCP sender report).
+//
+// The line between "Session:" and "RTP-Info:" is a single SP then CRLF (20 0d 0a).
+// Under RFC 2068 4.2 (which RFC 2326 4.2 defers to) a line starting with SP or HT
+// continues the previous header, so this is a content-free fold, not the end of
+// the header block. The same bytes were seen on three cameras (two 4K models and
+// the 1080p LUM-220) over both TCP and UDP transports.
+const LUMA_PLAY_RESPONSE = Buffer.from(
+    '525453502f312e3020323030204f4b0d0a5365727665723a20437573746f6d65722052545350205365727665722f312e' +
+    '302e300d0a435365713a20360d0a53657373696f6e3a203832313732343435333735393738390d0a200d0a5254502d49' +
+    '6e666f3a2075726c3d727473703a2f2f3139322e3136382e322e3233363a3535342f70726f66696c65312f747261636b' +
+    '313b7365713d35363335303b72747074696d653d313137333738363434362c75726c3d727473703a2f2f3139322e3136' +
+    '382e322e3233363a3535342f70726f66696c65312f747261636b323b7365713d32363336373b72747074696d653d3533' +
+    '303538333436310d0a0d0a2403003880c800060cc6c9ed83ad7eeb000014771fa00fa5000000000000000081ca00060c' +
+    'c6c9ed011164342d36612d39312d31642d37392d623800',
+    'hex');
+
+const EXPECTED_RTP_INFO = 'url=rtsp://192.168.2.236:554/profile1/track1;seq=56350;rtptime=1173786446,url=rtsp://192.168.2.236:554/profile1/track2;seq=26367;rtptime=530583461';
+
+function stream(buffer: Buffer): Readable {
+    const pt = new PassThrough();
+    pt.end(buffer);
+    return pt;
+}
+
+// The reader as it was before this change, kept here to demonstrate the failure.
+async function readMessageLegacy(client: Readable): Promise<string[]> {
+    let currentHeaders: string[] = [];
+    while (true) {
+        let line = await readLine(client);
+        line = line.trim();
+        if (!line)
+            return currentHeaders;
+        currentHeaders.push(line);
+    }
+}
+
+async function testLegacyReaderStopsEarly() {
+    const s = stream(LUMA_PLAY_RESPONSE);
+    const message = await readMessageLegacy(s);
+    assert.strictEqual(message.length, 4, 'legacy reader stops at the whitespace line');
+    assert.strictEqual(parseHeaders(message)['rtp-info'], undefined);
+    const next = await readLength(s, 4);
+    assert.strictEqual(next.toString(), 'RTP-', 'legacy reader leaves RTP-Info in the buffer, which is what the frame reader then rejects');
+}
+
+async function testLumaPlayResponse() {
+    const s = stream(LUMA_PLAY_RESPONSE);
+    const message = await readMessage(s);
+    assert.deepStrictEqual(message, [
+        'RTSP/1.0 200 OK',
+        'Server: Customer RTSP Server/1.0.0',
+        'CSeq: 6',
+        'Session: 821724453759789',
+        `RTP-Info: ${EXPECTED_RTP_INFO}`,
+    ]);
+    const headers = parseHeaders(message);
+    assert.strictEqual(headers['session'], '821724453759789');
+    assert.strictEqual(headers['rtp-info'], EXPECTED_RTP_INFO);
+
+    // the next bytes in the stream must be the interleaved frame header.
+    const frameHeader = await readLength(s, 4);
+    assert.strictEqual(frameHeader[0], 0x24);
+    assert.strictEqual(frameHeader.readUInt8(1), 3);
+    assert.strictEqual(frameHeader.readUInt16BE(2), 56);
+    const frame = await readLength(s, 56);
+    assert.strictEqual(frame.length, 56);
+}
+
+async function testPlainMessageUnchanged() {
+    const s = stream(Buffer.from('RTSP/1.0 200 OK\r\nCSeq: 2  \r\nContent-Length: 5\r\n\r\nhello'));
+    const message = await readMessage(s);
+    assert.deepStrictEqual(message, ['RTSP/1.0 200 OK', 'CSeq: 2', 'Content-Length: 5']);
+    const body = await readLength(s, 5);
+    assert.strictEqual(body.toString(), 'hello');
+}
+
+async function testBareLfUnchanged() {
+    const s = stream(Buffer.from('RTSP/1.0 200 OK\nCSeq: 3\n\n$'));
+    const message = await readMessage(s);
+    assert.deepStrictEqual(message, ['RTSP/1.0 200 OK', 'CSeq: 3']);
+    assert.strictEqual((await readLength(s, 1)).toString(), '$');
+}
+
+async function testFoldedHeader() {
+    const s = stream(Buffer.from('RTSP/1.0 200 OK\r\nRTP-Info: url=a;seq=1;rtptime=2,\r\n url=b;seq=3;rtptime=4\r\n\t url=c;seq=5\r\nCSeq: 4\r\n\r\n'));
+    const message = await readMessage(s);
+    assert.deepStrictEqual(message, [
+        'RTSP/1.0 200 OK',
+        'RTP-Info: url=a;seq=1;rtptime=2, url=b;seq=3;rtptime=4 url=c;seq=5',
+        'CSeq: 4',
+    ]);
+}
+
+async function testWhitespaceOnlyLinesDoNotTerminate() {
+    const s = stream(Buffer.from('RTSP/1.0 200 OK\r\nCSeq: 5\r\n \r\n\t\r\n   \t \r\nSession: 1\r\n\r\n'));
+    const message = await readMessage(s);
+    assert.deepStrictEqual(message, ['RTSP/1.0 200 OK', 'CSeq: 5', 'Session: 1']);
+}
+
+async function testFirstLineNotFolded() {
+    // a leading space on the very first line has nothing to fold into: keep the old behavior of trimming it.
+    const s = stream(Buffer.from(' RTSP/1.0 200 OK\r\nCSeq: 6\r\n\r\n'));
+    const message = await readMessage(s);
+    assert.deepStrictEqual(message, ['RTSP/1.0 200 OK', 'CSeq: 6']);
+}
+
+async function testRawLineLogging() {
+    const logged: string[] = [];
+    const console = { log: (...args: any[]) => logged.push(args.join(' ')) } as unknown as Console;
+    const s = stream(Buffer.from('RTSP/1.0 200 OK\r\n \r\n\r\n'));
+    await readMessage(s, console);
+    assert.strictEqual(logged.length, 3);
+    assert.strictEqual(logged[1], 'rtsp raw line " \\r" -> "" [200d]');
+}
+
+async function withServer(payload: Buffer, test: (client: RtspClient) => Promise<void>) {
+    const server = net.createServer(socket => {
+        socket.write(payload);
+        socket.end();
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const { port } = server.address() as AddressInfo;
+    const client = new RtspClient(`rtsp://127.0.0.1:${port}/profile1`);
+    try {
+        await once(client.client, 'connect');
+        // let the whole payload land in the socket buffer before reading, so the
+        // bad header dump below is deterministic.
+        await sleep(50);
+        await test(client);
+    }
+    finally {
+        client.client.destroy();
+        server.close();
+    }
+}
+
+async function testRtspClientReadLoop() {
+    await withServer(LUMA_PLAY_RESPONSE, async client => {
+        // this is what RtspClient.play() does: the RTSP-aware message read.
+        const message = await client.readMessage();
+        assert.strictEqual(parseHeaders(message)['rtp-info'], EXPECTED_RTP_INFO);
+
+        // then rtsp-session.ts hands the socket to readLoop, which failed here before.
+        const received: { channel: number, length: number }[] = [];
+        client.setupOptions.set(3, {
+            type: 'tcp',
+            port: 3,
+            onRtp: (header, data) => received.push({ channel: header.readUInt8(1), length: data.length }),
+        });
+        await client.readLoop();
+        assert.deepStrictEqual(received, [{ channel: 3, length: 56 }]);
+    });
+}
+
+async function testBadHeaderErrorIncludesContext() {
+    // the bytes the old reader left behind: everything from RTP-Info onwards.
+    const leftover = LUMA_PLAY_RESPONSE.subarray(LUMA_PLAY_RESPONSE.indexOf('RTP-Info'));
+    await withServer(leftover, async client => {
+        await assert.rejects(client.readMessage(), (e: Error) => {
+            assert.match(e.message, /invalid frame magic/);
+            assert.match(e.message, /: RTP-\n/);
+            assert.match(e.message, /RTP-Info: url=rtsp:\/\/192\.168\.2\.236:554\/profile1\/track1;seq=56350/);
+            assert.match(e.message, /\\r\\n/);
+            assert.match(e.message, /52 54 50 2d 49 6e 66 6f/);
+            return true;
+        });
+    });
+}
+
+async function main() {
+    const tests = [
+        testLegacyReaderStopsEarly,
+        testLumaPlayResponse,
+        testPlainMessageUnchanged,
+        testBareLfUnchanged,
+        testFoldedHeader,
+        testWhitespaceOnlyLinesDoNotTerminate,
+        testFirstLineNotFolded,
+        testRawLineLogging,
+        testRtspClientReadLoop,
+        testBadHeaderErrorIncludesContext,
+    ];
+    let failed = 0;
+    for (const test of tests) {
+        try {
+            await test();
+            console.log('ok  ', test.name);
+        }
+        catch (e) {
+            failed++;
+            console.log('FAIL', test.name);
+            console.log(e);
+        }
+    }
+    console.log(failed ? `${failed} test(s) failed` : `all ${tests.length} tests passed`);
+    process.exit(failed ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
Branch: `rtsp-client-header-folding` (one commit on top of `10c8dea ha: verup`).

Fixes the "RTSP Client received invalid frame magic ... : RTP-" failure on Luma x20 cameras (`Server: Customer RTSP Server/1.0.0`, firmware 5.1.1.0), which broke both the `Scrypted (TCP)` and `Scrypted (UDP)` parsers while `FFmpeg (TCP)` and VLC worked.

## What was observed

Raw bytes were captured on the RTSP control socket, with a standalone script that sends the same OPTIONS/DESCRIBE/SETUP/PLAY sequence and headers as `RtspClient`, on three cameras (two 4K LUM-820 models and the 1080p LUM-220) over both TCP-interleaved and UDP transport. All four captures have the same PLAY response shape. This is the TCP capture from the 4K camera, verbatim, up to the first interleaved frame:

```
RTSP/1.0 200 OK\r\n
Server: Customer RTSP Server/1.0.0\r\n
CSeq: 6\r\n
Session: 821724453759789\r\n
 \r\n
RTP-Info: url=rtsp://192.168.2.236:554/profile1/track1;seq=56350;rtptime=1173786446,url=rtsp://192.168.2.236:554/profile1/track2;seq=26367;rtptime=530583461\r\n
\r\n
$\x03\x00\x38\x80\xc8\x00\x06...
```

```
00000040  73 73 69 6f 6e 3a 20 38 32 31 37 32 34 34 35 33  |ssion: 821724453|
00000050  37 35 39 37 38 39 0d 0a 20 0d 0a 52 54 50 2d 49  |759789.. ..RTP-I|
00000060  6e 66 6f 3a 20 75 72 6c 3d 72 74 73 70 3a 2f 2f  |nfo: url=rtsp://|
...
000000f0  30 35 38 33 34 36 31 0d 0a 0d 0a 24 03 00 38 80  |0583461....$..8.|
```

The line between `Session:` and `RTP-Info:` is exactly one space followed by CRLF (`20 0d 0a`). Every other line ends in CRLF. The interleaved data that follows the header block is correctly framed (`$`, channel 3, length 56, an RTCP sender report).

## What was inferred

`readMessage` in `common/src/rtsp-server.ts` trimmed each line before testing for the empty line that terminates the header block. `" \r"` trims to `""`, so the reader returned after `Session:` with four headers, which matches the PLAY response Scrypted logged in the bug report (no `RTP-Info`). `RTP-Info: ...` stayed in the socket buffer. `rtsp-session.ts` then calls `readLoop()` regardless of transport, `readLoop` read four bytes, got `RTP-`, and threw. The regression test replays the captured bytes through a copy of the old reader and reproduces exactly this: four headers, then `RTP-` as the next four bytes.

Of the four candidate mechanisms:

1. **Whitespace-only line inside the header block: confirmed.** This is what is on the wire.
2. **Header line folding: confirmed as the spec reading of (1), not as a separate mechanism.** RFC 2326 section 4.2 defers to RFC 2068 section 4.2: "Header fields can be extended over multiple lines by preceding each extra line with at least one SP or HT." A line consisting of SP CRLF is therefore a content-free continuation of the `Session` header, and the message is legal. The camera is not folding `RTP-Info` itself; that header arrives on one line.
3. **Spurious CRLF before `RTP-Info`: disproven.** The line is not empty.
4. **Bare CR or LF line endings: disproven.** All terminators are CRLF.

Why ffmpeg copes: from reading `libavformat/rtsp.c` (not executed), `ff_rtsp_read_reply` strips CR, ends the header block only on a zero-length line, and hands every other line to `ff_rtsp_parse_line`, which ignores unrecognised ones. A lone space is an unrecognised header line to ffmpeg. It does not implement folding either.

## The change

`common/src/rtsp-server.ts`

- `readMessage` ends the header block only on a genuinely empty line (after removing the CR that `readLine` leaves behind). A line starting with SP or HT is appended to the previous header, per RFC 2068 4.2; an all-whitespace continuation adds nothing. For messages without continuation lines the output is byte-for-byte what it was.
- `createBadHeader` now drains whatever is already buffered on the socket (the socket is destroyed by every caller anyway) and appends it, up to 512 bytes, as escaped ASCII with CR/LF/TAB visible, plus a hex dump. The old error showed only the four bytes that failed validation, which is why the bug report had `RTP-` and nothing else. `handleDataPayload` now uses the same helper instead of its own copy of the message.
- Opt-in raw line logging. `readMessage` takes an optional console and logs every line before and after trimming with its bytes. `RtspBase.readMessage` passes its console through only when `noisy` is true, which defaults to `!!process.env.SCRYPTED_RTSP_NOISY` (same shape as `SCRYPTED_FFMPEG_NOISY` in `server/src/media-helpers.ts`) and can be set per instance. With `noisy` false the optional chain short-circuits and no arguments are evaluated.

`common/src/read-stream.ts`

- `readUntilBuffer` and `readLineBuffer` return the raw bytes of a line; `readUntil` and `readLine` are now one-line wrappers over them with identical results.
- `formatRawBytes` produces the escaped ASCII plus hex dump used above.

`common/test/rtsp-read-message.ts` (new)

Replays the captured PLAY response and first interleaved frame. Ten cases: the old reader stops early and leaves `RTP-`; the new reader returns five headers with `RTP-Info` intact and the next four bytes are the `$` frame header; plain CRLF and bare-LF messages are unchanged; a folded `RTP-Info` merges; whitespace-only lines do not terminate; a leading space on the first line is still trimmed; the raw log line format; a real `RtspClient` over a loopback socket runs `readMessage` then `readLoop` and delivers the channel-3 frame to `onRtp`; and the bad-header error carries the buffered `RTP-Info` text and its hex.

```
cd common && npx ts-node --transpile-only test/rtsp-read-message.ts
```

`--transpile-only` is needed because `external/werift` lacks `@types/debug` under this tsconfig; that is pre-existing and unrelated. The repo has no test runner, so this follows the `common/test/rtsp-proxy.ts` pattern of a standalone script.

## Blast radius

- `readMessage` is also used by `plugins/tapo` and `plugins/hikvision` to parse HTTP-style responses. They call it with one argument, so the signature change is transparent; the behavioural change only affects responses containing whitespace-only or SP/HT-prefixed lines, where folding is the correct HTTP reading as well.
- `RtspServer.handleSetup` (the server side, used by the rebroadcaster and HomeKit) has its own trim-then-test loop and is deliberately left alone. Clients like ffmpeg do not send whitespace-only lines, and this PR is about the client.
- `rtsp-session.ts` still sets `rtspClient.console = undefined` before `readLoop`. That was left as is: the failing path now self-describes through the error text, and keeping the console would log every keepalive exchange.

## Testing done

- The ten-case replay test above passes.
- `npm run build` in `plugins/prebuffer-mixin` bundles the patched `common` sources cleanly.
- Live run: the patched Rebroadcast plugin was deployed into the reporter's macOS Desktop App (server 0.143.0) with `npx scrypted login 127.0.0.1` and `npm run scrypted-deploy 127.0.0.1`, and the plugin-wide parser set to `Scrypted (TCP)`. All six Luma x20 cameras negotiated, every PLAY response was parsed with `RTP-Info` present, no `invalid frame magic` was logged, and every camera wrote growing NVR segments on both its main and sub streams within two minutes.

## Related, out of scope

`RTP-Info` is now preserved and parsed (`seq` and `rtptime` per track). Nothing consumes it yet. The separate "Timestamps are unset in a packet" noise seen on the FFmpeg parser path was not investigated and the evidence here does not connect the two.