### PR TITLE
python-codecs: arm zygote fork self-destruct at call time, not first frame

### DIFF
--- a/plugins/python-codecs/src/main.py
+++ b/plugins/python-codecs/src/main.py
@@ -26,6 +26,16 @@ except:
     pass
 
 
+def terminate_zygote(fork: scrypted_sdk.PluginFork) -> None:
+    # a fork popped from the zygote pool is only reachable through this handle.
+    # kill it if the decode session could not be handed to the caller, otherwise
+    # the worker idles forever with no one able to stop it.
+    try:
+        fork.terminate()
+    except:
+        pass
+
+
 class LibavGenerator(scrypted_sdk.ScryptedDeviceBase, scrypted_sdk.VideoFrameGenerator):
     def __init__(self, nativeId: Union[str, None], z):
         super().__init__(nativeId)
@@ -38,8 +48,13 @@ class LibavGenerator(scrypted_sdk.ScryptedDeviceBase, scrypted_sdk.VideoFrameGen
         # todo remove
         filter: Any = None,
     ) -> scrypted_sdk.VideoFrame:
-        forked: CodecFork = await self.zygote().result
-        return await forked.generateVideoFramesLibav(mediaObject, options)
+        fork = self.zygote()
+        try:
+            forked: CodecFork = await fork.result
+            return await forked.generateVideoFramesLibav(mediaObject, options)
+        except:
+            terminate_zygote(fork)
+            raise
 
 
 class GstreamerGenerator(
@@ -59,15 +74,20 @@ class GstreamerGenerator(
         filter: Any = None,
     ) -> scrypted_sdk.VideoFrame:
         start = time.time()
-        forked: CodecFork = await self.zygote().result
-        print("fork", time.time() - start)
-        return await forked.generateVideoFramesGstreamer(
-            mediaObject,
-            options,
-            self.storage.getItem("h264Decoder"),
-            self.storage.getItem("h265Decoder"),
-            self.storage.getItem("postProcessPipeline"),
-        )
+        fork = self.zygote()
+        try:
+            forked: CodecFork = await fork.result
+            print("fork", time.time() - start)
+            return await forked.generateVideoFramesGstreamer(
+                mediaObject,
+                options,
+                self.storage.getItem("h264Decoder"),
+                self.storage.getItem("h265Decoder"),
+                self.storage.getItem("postProcessPipeline"),
+            )
+        except:
+            terminate_zygote(fork)
+            raise
 
     async def getSettings(self) -> List[Setting]:
         return [
@@ -237,32 +257,36 @@ class CodecFork:
         h265Decoder: str,
         postProcessPipeline: str,
     ) -> AsyncGenerator[scrypted_sdk.VideoFrame, Any]:
+        # armed here rather than inside the generator body: the body does not run
+        # until the caller requests a frame, so a session that is never iterated
+        # would otherwise have no watchdog at all.
         loop = asyncio.get_event_loop()
         self.timeout = loop.call_later(10, self.timeoutExit)
 
-        async for data in self.generateVideoFrames(
+        return self.generateVideoFrames(
             gstreamer.generateVideoFramesGstreamer(
                 mediaObject, options, h264Decoder, h265Decoder, postProcessPipeline
             ),
             "gstreamer",
             options and options.get("firstFrameOnly"),
-        ):
-            yield data
+        )
 
     async def generateVideoFramesLibav(
         self,
         mediaObject: scrypted_sdk.MediaObject,
         options: scrypted_sdk.VideoFrameGeneratorOptions = None,
     ) -> AsyncGenerator[scrypted_sdk.VideoFrame, Any]:
+        # armed here rather than inside the generator body: the body does not run
+        # until the caller requests a frame, so a session that is never iterated
+        # would otherwise have no watchdog at all.
         loop = asyncio.get_event_loop()
         self.timeout = loop.call_later(10, self.timeoutExit)
 
-        async for data in self.generateVideoFrames(
+        return self.generateVideoFrames(
             libav.generateVideoFramesLibav(mediaObject, options),
             "libav",
             options and options.get("firstFrameOnly"),
-        ):
-            yield data
+        )
 
 
 async def fork():


### PR DESCRIPTION
Fixes #2138.

## Problem

`@scrypted/python-codecs` hands a pre-forked zygote worker to each decode session and relies entirely on the worker killing *itself*, via the 10 s `timeoutExit` watchdog and the `finally: call_later(1, multiprocess_exit)` in `CodecFork.generateVideoFrames`.

Both live inside an async generator body. `generateVideoFramesLibav` and `generateVideoFramesGstreamer` are `async def` functions containing `yield`, so calling them over RPC only *constructs* the generator — `rpc.py` serializes it as an async-iterator proxy without executing a line. `self.timeout` is never assigned, and the `finally` never registers.

Meanwhile the call sites in `LibavGenerator` / `GstreamerGenerator` discard the `PluginFork` handle:

```python
forked: CodecFork = await self.zygote().result
return await forked.generateVideoFramesLibav(mediaObject, options)
```

`PluginFork.terminate()` is the only external way to kill the child, and after this statement nothing holds a reference to it.

So a worker that is handed a session but never iterated has no watchdog *and* no reachable `terminate()`. It idles at ~30 MB PSS for the life of the plugin host. A consumer that politely closes the proxy does not help either: RPC maps `return()` to `aclose()`, and `aclose()` on a never-started async generator returns without running the body.

That window is entered whenever the consumer disappears between the handout and the first frame request — which is exactly the state `@scrypted/objectdetector` labels `waiting first result` before its 30 s watchdog kills the analysis. Measured on a 3-camera Pi 4: 44 forked children after 17.9 h, 39 of them idle at 0% CPU, 1082 MB combined PSS on a 3.8 GB machine, the oldest fork as old as the plugin host itself. Full evidence in #2138.

This is the other half of fa5b9f66 (*python-codecs: Fix process exit leak*), which made `timeoutExit` callable again but left it armed too late to cover this case.

## Fix

Make the two public `CodecFork` methods coroutines that **return** the inner generator rather than being generators themselves, so the existing 10 s watchdog is armed the moment the fork is committed to a session:

```python
async def generateVideoFramesLibav(self, mediaObject, options=None):
    loop = asyncio.get_event_loop()
    self.timeout = loop.call_later(10, self.timeoutExit)
    return self.generateVideoFrames(
        libav.generateVideoFramesLibav(mediaObject, options),
        "libav",
        options and options.get("firstFrameOnly"),
    )
```

The wire contract is unchanged. `rpc.py` does `value = await maybe_await(invoke(*args))` and then serializes, so a coroutine returning an async generator yields the identical async-iterator proxy; one proxy layer is removed rather than added. No new constants — it reuses the same 10 s budget the code already applies to every frame, and the fork already has to produce its first frame within that budget once decoding starts.

Secondarily, the call sites keep the `PluginFork` handle and terminate it if the session cannot be handed to the caller, since a popped fork is otherwise unreachable.

## Verification

Not deployed to a live server — I have no way to run a modified plugin bundle on the affected host. Verified against Scrypted's own `server/python/rpc.py` with two in-memory peers, running the upstream and patched `CodecFork` shapes side by side (10 s timers shortened for the test; `multiprocess_exit` stubbed):

```
UPSTREAM  iterated normally             frames=[0, 1, 2]  exit_called=True   err=RPCResultError: async generator raised StopAsyncIteration
UPSTREAM  handed out, never iterated    frames=[]         exit_called=False  err=None
PATCHED   iterated normally             frames=[0, 1, 2]  exit_called=True   err=RPCResultError: async generator raised StopAsyncIteration
PATCHED   handed out, never iterated    frames=[]         exit_called=True   err=None
```

Same frames, same end-of-stream behaviour (the `StopAsyncIteration` wrapping is pre-existing in the untouched inner `generateVideoFrames` and is identical on both sides). The only difference is the leaking case, which now self-exits.

Also confirmed separately that `aclose()` on a never-started async generator does not run the body, which is why the teardown has to move out of it rather than be triggered from the consumer side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kjDzffi8VZKA1mn6nrGfo
